### PR TITLE
Fix access to process

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -15,7 +15,7 @@
 <body>
   <div id="app"></div>
   <!-- Set `__static` path to static files in production -->
-  <% if (!process.browser) { %>
+  <% if (!require('process').browser) { %>
   <script>
     if (process.env.NODE_ENV !== 'development') window.__static = require('path').join(__dirname, '/static').replace(/\\/g, '\\\\')
   </script>


### PR DESCRIPTION
`electron-vue` has this open issue: https://github.com/SimulatedGREG/electron-vue/issues/871

Trying to build the app in a node version higher than 10.21.0 will result in the following error:

```
Html Webpack Plugin:
  ReferenceError: process is not defined
  
  - index.ejs:11 eval
    [.]/[html-webpack-plugin]/lib/loader.js!./src/index.ejs:11:2
  
  - index.ejs:16 module.exports
    [.]/[html-webpack-plugin]/lib/loader.js!./src/index.ejs:16:3
  
  - index.js:284 
    [drive-desktop]/[html-webpack-plugin]/index.js:284:18
  
  - task_queues.js:97 processTicksAndRejections
    internal/process/task_queues.js:97:5
```

This PR changes the way the process variable is accessed, allowing the app to build correctly on the old and new node versions.