### PR TITLE
Fix forgot password track

### DIFF
--- a/src/renderer/logic/utils/analytics.js
+++ b/src/renderer/logic/utils/analytics.js
@@ -292,6 +292,7 @@ function trackForgotPassword() {
   const { uuid } = ConfigStore.get('userData')
   analyticsLibrary.track({
     userId: uuid,
+    anonymousId,
     event: 'Password Forgotten',
     context
   })


### PR DESCRIPTION
Adds anonymousId to forgot password track.

Tested on dev environment and on a build version.

Solves: exception risen by Segment analytics-node library when a userId not present.