### PR TITLE
[DD-94]: feature/faster-backups-with-small-files

### DIFF
--- a/src/workers/backups/test/backups.test.ts
+++ b/src/workers/backups/test/backups.test.ts
@@ -77,9 +77,9 @@ describe('backups tests', () => {
       async getCurrentListing() {
         return {
           listing: {
-            notExistInLocal: 40,
-            existInBothButIsTheSame: 30,
-            'folder/nested/existInBoth.txt': 44,
+            notExistInLocal: { modtime: 40, size: 1 },
+            existInBothButIsTheSame: { modtime: 30, size: 1 },
+            'folder/nested/existInBoth.txt': { modtime: 44, size: 1 },
           },
           readingMetaErrors: [],
         };
@@ -91,9 +91,9 @@ describe('backups tests', () => {
       async getCurrentListing() {
         return {
           listing: {
-            notExistInRemote: 40,
-            existInBothButIsTheSame: 30,
-            'folder/nested/existInBoth.txt': 55,
+            notExistInRemote: { modtime: 40, size: 1 },
+            existInBothButIsTheSame: { modtime: 30, size: 1 },
+            'folder/nested/existInBoth.txt': { modtime: 55, size: 1 },
           },
           readingMetaErrors: [],
         };

--- a/src/workers/filesystems/local-filesystem.ts
+++ b/src/workers/filesystems/local-filesystem.ts
@@ -93,7 +93,7 @@ export function getLocalFilesystem(
         try {
           const { modTimeInSeconds, size } = await getLocalMeta(fileName);
 
-          if (size) listing[relativeName] = modTimeInSeconds;
+          if (size) listing[relativeName] = { modtime: modTimeInSeconds, size };
           else {
             const emptyFileError = {
               message: 'Internxt does not support empty files',

--- a/src/workers/filesystems/remote-filesystem.ts
+++ b/src/workers/filesystems/remote-filesystem.ts
@@ -160,7 +160,7 @@ export function getRemoteFilesystem({
           const modificationTime = getSecondsFromDateString(
             file.modificationTime
           );
-          listing[name] = modificationTime;
+          listing[name] = { modtime: modificationTime, size: file.size };
           cache[name] = {
             id: file.id,
             parentId: file.folderId,

--- a/src/workers/process.ts
+++ b/src/workers/process.ts
@@ -171,12 +171,14 @@ abstract class Process extends EventEmitter {
     const filesNotInRemote = [];
     const filesWithDifferentModtime = [];
 
-    for (const [localName, localModtime] of Object.entries(local)) {
-      const remoteModTime = remote[localName];
+    for (const [localName, { modtime: localModtime }] of Object.entries(
+      local
+    )) {
+      const entryInRemote = remote[localName];
 
-      if (!remoteModTime) {
+      if (!entryInRemote) {
         filesNotInRemote.push(localName);
-      } else if (localModtime !== remoteModTime) {
+      } else if (localModtime !== entryInRemote.modtime) {
         filesWithDifferentModtime.push(localName);
       }
     }

--- a/src/workers/sync/listing-store.ts
+++ b/src/workers/sync/listing-store.ts
@@ -3,10 +3,29 @@ import { Listing } from '../types';
 import { ListingStore } from './sync';
 
 export default function getListingStore(): ListingStore {
+  function isOldListingFormat(listing: Record<string, any>): boolean {
+    const entries = Object.entries(listing);
+    return entries.some((entry) => typeof entry[1] !== 'object');
+  }
+
+  function convertOldListingFormat(listing: Record<string, number>): Listing {
+    const listingConverted: Listing = {};
+    for (const [name, modtime] of Object.entries(listing)) {
+      listingConverted[name] = { modtime, size: 0 };
+    }
+
+    return listingConverted;
+  }
   return {
     async getLastSavedListing(): Promise<Listing | null> {
       const lastSavedListing = ConfigStore.get('lastSavedListing') as string;
-      return lastSavedListing !== '' ? JSON.parse(lastSavedListing) : null;
+      if (lastSavedListing === '') return null;
+
+      const listingParsed = JSON.parse(lastSavedListing);
+
+      if (isOldListingFormat(listingParsed))
+        return convertOldListingFormat(listingParsed);
+      else return listingParsed;
     },
 
     async saveListing(listing: Listing): Promise<void> {

--- a/src/workers/sync/sync.ts
+++ b/src/workers/sync/sync.ts
@@ -108,8 +108,8 @@ class Sync extends Process {
     } = this.getListingsDiff(currentLocal, currentRemote);
 
     for (const name of filesWithDifferentModtime) {
-      const modtimeInLocal = currentLocal[name];
-      const modtimeInRemote = currentRemote[name];
+      const { modtime: modtimeInLocal } = currentLocal[name];
+      const { modtime: modtimeInRemote } = currentRemote[name];
 
       if (modtimeInLocal < modtimeInRemote) pullFromLocal.push(name);
       else pullFromRemote.push(name);
@@ -147,8 +147,8 @@ class Sync extends Process {
     const deleteInRemote: string[] = [];
 
     const keepMostRecent = (name: string) => {
-      const modtimeInLocal = currentLocalListing[name];
-      const modtimeInRemote = currentRemoteListing[name];
+      const { modtime: modtimeInLocal } = currentLocalListing[name];
+      const { modtime: modtimeInRemote } = currentRemoteListing[name];
 
       if (modtimeInLocal < modtimeInRemote) pullFromLocal.push(name);
       else pullFromRemote.push(name);
@@ -158,7 +158,8 @@ class Sync extends Process {
       const deltaRemote = deltasRemote[name];
       const doesntExistInRemote = deltaRemote === undefined;
       const sameModTime =
-        currentLocalListing[name] === currentRemoteListing[name];
+        currentLocalListing[name]?.modtime ===
+        currentRemoteListing[name]?.modtime;
 
       if (deltaLocal === 'NEW' && deltaRemote === 'NEW' && !sameModTime) {
         keepMostRecent(name);
@@ -240,14 +241,14 @@ class Sync extends Process {
   private generateDeltas(saved: Listing, current: Listing): Deltas {
     const deltas: Deltas = {};
 
-    for (const [name, currentModTime] of Object.entries(current)) {
-      const savedModTime = saved[name];
+    for (const [name, { modtime: currentModTime }] of Object.entries(current)) {
+      const savedEntry = saved[name];
 
-      if (!savedModTime) {
+      if (!savedEntry) {
         deltas[name] = 'NEW';
-      } else if (savedModTime === currentModTime) {
+      } else if (savedEntry.modtime === currentModTime) {
         deltas[name] = 'UNCHANGED';
-      } else if (savedModTime < currentModTime) {
+      } else if (savedEntry.modtime < currentModTime) {
         deltas[name] = 'NEWER';
       } else {
         deltas[name] = 'OLDER';

--- a/src/workers/sync/test/sync.test.ts
+++ b/src/workers/sync/test/sync.test.ts
@@ -101,9 +101,9 @@ describe('sync tests', () => {
       async getCurrentListing() {
         return {
           listing: {
-            notExistInRemote: 40,
-            existInBothButIsTheSame: 30,
-            'folder/nested/existInBoth.txt': 44,
+            notExistInRemote: { modtime: 40, size: 1 },
+            existInBothButIsTheSame: { modtime: 30, size: 2 },
+            'folder/nested/existInBoth.txt': { modtime: 44, size: 3 },
           },
           readingMetaErrors: [],
         };
@@ -115,9 +115,9 @@ describe('sync tests', () => {
       async getCurrentListing() {
         return {
           listing: {
-            notExistInLocal: 40,
-            existInBothButIsTheSame: 30,
-            'folder/nested/existInBoth.txt': 55,
+            notExistInLocal: { modtime: 40, size: 1 },
+            existInBothButIsTheSame: { modtime: 30, size: 2 },
+            'folder/nested/existInBoth.txt': { modtime: 55, size: 3 },
           },
           readingMetaErrors: [],
         };
@@ -181,24 +181,24 @@ describe('sync tests', () => {
       ...listingStore(),
       async getLastSavedListing() {
         return {
-          'newer/newer/different': 4,
-          'newer/newer/same': 4,
-          'newer/deleted': 5,
-          'newer/older': 5,
-          'newer/unchanged': 4,
-          'deleted/newer': 4,
-          'deleted/deleted': 4,
-          'deleted/older': 4,
-          'deleted/unchanged': 4,
-          'older/newer': 4,
-          'older/deleted': 4,
-          'older/older/same': 4,
-          'older/older/different': 4,
-          'older/unchanged': 4,
-          'unchanged/newer': 4,
-          'unchanged/deleted': 4,
-          'unchanged/older': 4,
-          'unchanged/unchanged': 4,
+          'newer/newer/different': { modtime: 4, size: 4 },
+          'newer/newer/same': { modtime: 4, size: 4 },
+          'newer/deleted': { modtime: 5, size: 4 },
+          'newer/older': { modtime: 5, size: 4 },
+          'newer/unchanged': { modtime: 4, size: 4 },
+          'deleted/newer': { modtime: 4, size: 4 },
+          'deleted/deleted': { modtime: 4, size: 4 },
+          'deleted/older': { modtime: 4, size: 4 },
+          'deleted/unchanged': { modtime: 4, size: 4 },
+          'older/newer': { modtime: 4, size: 4 },
+          'older/deleted': { modtime: 4, size: 4 },
+          'older/older/same': { modtime: 4, size: 4 },
+          'older/older/different': { modtime: 4, size: 4 },
+          'older/unchanged': { modtime: 4, size: 4 },
+          'unchanged/newer': { modtime: 4, size: 4 },
+          'unchanged/deleted': { modtime: 4, size: 4 },
+          'unchanged/older': { modtime: 4, size: 4 },
+          'unchanged/unchanged': { modtime: 4, size: 4 },
         };
       },
     };
@@ -207,23 +207,23 @@ describe('sync tests', () => {
       async getCurrentListing() {
         return {
           listing: {
-            'new/new/different': 4,
-            'new/new/same': 4,
-            'new/noexist': 43,
-            'newer/newer/different': 6,
-            'newer/newer/same': 5,
-            'newer/deleted': 6,
-            'newer/older': 6,
-            'newer/unchanged': 5,
-            'older/newer': 3,
-            'older/deleted': 3,
-            'older/older/same': 3,
-            'older/older/different': 3,
-            'older/unchanged': 3,
-            'unchanged/newer': 4,
-            'unchanged/deleted': 4,
-            'unchanged/older': 4,
-            'unchanged/unchanged': 4,
+            'new/new/different': { modtime: 4, size: 3 },
+            'new/new/same': { modtime: 4, size: 3 },
+            'new/noexist': { modtime: 43, size: 3 },
+            'newer/newer/different': { modtime: 6, size: 3 },
+            'newer/newer/same': { modtime: 5, size: 3 },
+            'newer/deleted': { modtime: 6, size: 3 },
+            'newer/older': { modtime: 6, size: 3 },
+            'newer/unchanged': { modtime: 5, size: 3 },
+            'older/newer': { modtime: 3, size: 3 },
+            'older/deleted': { modtime: 3, size: 3 },
+            'older/older/same': { modtime: 3, size: 3 },
+            'older/older/different': { modtime: 3, size: 3 },
+            'older/unchanged': { modtime: 3, size: 3 },
+            'unchanged/newer': { modtime: 4, size: 3 },
+            'unchanged/deleted': { modtime: 4, size: 3 },
+            'unchanged/older': { modtime: 4, size: 3 },
+            'unchanged/unchanged': { modtime: 4, size: 3 },
           },
           readingMetaErrors: [],
         };
@@ -235,23 +235,23 @@ describe('sync tests', () => {
       async getCurrentListing() {
         return {
           listing: {
-            'new/new/different': 5,
-            'new/new/same': 4,
-            'newer/newer/different': 5,
-            'newer/newer/same': 5,
-            'newer/older': 4,
-            'newer/unchanged': 4,
-            'deleted/newer': 5,
-            'deleted/older': 3,
-            'deleted/unchanged': 4,
-            'older/newer': 5,
-            'older/older/same': 3,
-            'older/older/different': 2,
-            'older/unchanged': 4,
-            'unchanged/newer': 5,
-            'unchanged/older': 3,
-            'unchanged/unchanged': 4,
-            'noexist/new': 4,
+            'new/new/different': { modtime: 5, size: 1 },
+            'new/new/same': { modtime: 4, size: 1 },
+            'newer/newer/different': { modtime: 5, size: 1 },
+            'newer/newer/same': { modtime: 5, size: 1 },
+            'newer/older': { modtime: 4, size: 1 },
+            'newer/unchanged': { modtime: 4, size: 1 },
+            'deleted/newer': { modtime: 5, size: 1 },
+            'deleted/older': { modtime: 3, size: 1 },
+            'deleted/unchanged': { modtime: 4, size: 1 },
+            'older/newer': { modtime: 5, size: 1 },
+            'older/older/same': { modtime: 3, size: 1 },
+            'older/older/different': { modtime: 2, size: 1 },
+            'older/unchanged': { modtime: 4, size: 1 },
+            'unchanged/newer': { modtime: 5, size: 1 },
+            'unchanged/older': { modtime: 3, size: 1 },
+            'unchanged/unchanged': { modtime: 4, size: 1 },
+            'noexist/new': { modtime: 4, size: 1 },
           },
           readingMetaErrors: [],
         };
@@ -407,17 +407,17 @@ describe('sync tests', () => {
     const sync = dummySync();
 
     const savedListing = {
-      unchanged: 44,
-      newer: 44,
-      older: 44,
-      deleted: 44,
+      unchanged: { modtime: 44, size: 1 },
+      newer: { modtime: 44, size: 1 },
+      older: { modtime: 44, size: 1 },
+      deleted: { modtime: 44, size: 1 },
     };
 
     const currentListing = {
-      unchanged: 44,
-      newer: 45,
-      older: 43,
-      new: 44,
+      unchanged: { modtime: 44, size: 1 },
+      newer: { modtime: 45, size: 1 },
+      older: { modtime: 43, size: 1 },
+      new: { modtime: 44, size: 1 },
     };
 
     const deltas = sync.generateDeltas(savedListing, currentListing);
@@ -433,51 +433,51 @@ describe('sync tests', () => {
     const sync = dummySync();
 
     const localListing: Listing = {
-      a: 2,
-      aa: 2,
-      b: 2,
+      a: { modtime: 2, size: 1 },
+      aa: { modtime: 2, size: 1 },
+      b: { modtime: 2, size: 1 },
 
-      c: 1,
-      cc: 2,
-      d: 2,
-      e: 2,
-      f: 2,
+      c: { modtime: 1, size: 1 },
+      cc: { modtime: 2, size: 1 },
+      d: { modtime: 2, size: 1 },
+      e: { modtime: 2, size: 1 },
+      f: { modtime: 2, size: 1 },
 
-      k: 2,
-      m: 2,
-      n: 1,
-      nn: 2,
-      l: 2,
+      k: { modtime: 2, size: 1 },
+      m: { modtime: 2, size: 1 },
+      n: { modtime: 1, size: 1 },
+      nn: { modtime: 2, size: 1 },
+      l: { modtime: 2, size: 1 },
 
-      o: 2,
-      p: 2,
-      q: 2,
-      r: 2,
+      o: { modtime: 2, size: 1 },
+      p: { modtime: 2, size: 1 },
+      q: { modtime: 2, size: 1 },
+      r: { modtime: 2, size: 1 },
     };
 
     const remoteListing: Listing = {
-      a: 1,
-      aa: 2,
-      b: 2,
+      a: { modtime: 1, size: 1 },
+      aa: { modtime: 2, size: 1 },
+      b: { modtime: 2, size: 1 },
 
-      c: 2,
-      cc: 2,
-      e: 1,
-      f: 2,
+      c: { modtime: 2, size: 1 },
+      cc: { modtime: 2, size: 1 },
+      e: { modtime: 1, size: 1 },
+      f: { modtime: 2, size: 1 },
 
-      g: 2,
-      h: 2,
-      i: 2,
-      j: 2,
+      g: { modtime: 2, size: 1 },
+      h: { modtime: 2, size: 1 },
+      i: { modtime: 2, size: 1 },
+      j: { modtime: 2, size: 1 },
 
-      k: 3,
-      n: 2,
-      nn: 2,
-      l: 2,
+      k: { modtime: 3, size: 1 },
+      n: { modtime: 2, size: 1 },
+      nn: { modtime: 2, size: 1 },
+      l: { modtime: 2, size: 1 },
 
-      o: 2,
-      q: 2,
-      r: 2,
+      o: { modtime: 2, size: 1 },
+      q: { modtime: 2, size: 1 },
+      r: { modtime: 2, size: 1 },
     };
 
     const deltasLocal: Deltas = {
@@ -559,29 +559,29 @@ describe('sync tests', () => {
     const sync = dummySync();
 
     const savedListing: Listing = {
-      a: 4,
-      b: 4,
-      'c/d': 5,
-      'c/e': 6,
-      'c/f': 7,
-      'd/a': 2,
-      'd/b': 2,
-      'e/a': 1,
-      'e/b': 2,
-      'nested/quite/a': 1,
-      'nested/quite/b': 1,
-      'nested/dontDisapear/a': 1,
-      'nested/dontDisapear/b': 1,
-      'disapear/but/returnfalse': 2,
+      a: { modtime: 4, size: 1 },
+      b: { modtime: 4, size: 1 },
+      'c/d': { modtime: 5, size: 1 },
+      'c/e': { modtime: 6, size: 1 },
+      'c/f': { modtime: 7, size: 1 },
+      'd/a': { modtime: 2, size: 1 },
+      'd/b': { modtime: 2, size: 1 },
+      'e/a': { modtime: 1, size: 1 },
+      'e/b': { modtime: 2, size: 1 },
+      'nested/quite/a': { modtime: 1, size: 1 },
+      'nested/quite/b': { modtime: 1, size: 1 },
+      'nested/dontDisapear/a': { modtime: 1, size: 1 },
+      'nested/dontDisapear/b': { modtime: 1, size: 1 },
+      'disapear/but/returnfalse': { modtime: 2, size: 1 },
     };
 
     const currentListing: Listing = {
-      a: 4,
-      'c/d': 5,
-      'c/e': 6,
-      'c/f': 7,
-      'd/a': 2,
-      'nested/dontDisapear/a': 1,
+      a: { modtime: 4, size: 1 },
+      'c/d': { modtime: 5, size: 1 },
+      'c/e': { modtime: 6, size: 1 },
+      'c/f': { modtime: 7, size: 1 },
+      'd/a': { modtime: 2, size: 1 },
+      'nested/dontDisapear/a': { modtime: 1, size: 1 },
     };
 
     const fileSystem = {

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -95,12 +95,13 @@ export type Source = {
 /**
  * Represents a list of files, each with
  * its modTime that is set as seconds since epoch
+ * and size in bytes
  *
  * The name of each file can be namespaced by
  * his ancestors such as: folderA/folderB/fileName
  * It cannot start or end with "/"
  */
-export type Listing = Record<string, number>;
+export type Listing = Record<string, { modtime: number; size: number }>;
 
 export type ProcessFatalErrorName =
   | 'NO_INTERNET'


### PR DESCRIPTION
- Start including size alongside modtime in process listings 
- Use that size to filter small files and parallelise its upload with parameters SMALL_FILE_THRESHOLD and PARALLEL_QUEUES 