### PR TITLE
[WT-45] fix: ignore root folder events

### DIFF
--- a/src/main/realtime.ts
+++ b/src/main/realtime.ts
@@ -56,9 +56,23 @@ async function cleanAndStartLocalWatcher() {
 
       const ig = ignore().add(ignoredFiles);
 
-      const shouldBeIgnored = events.every((event) =>
-        ig.ignores(path.relative(configStore.get('syncRoot'), event.path))
-      );
+      const shouldBeIgnored = events.every((event) => {
+        const relativePath = path.relative(
+          configStore.get('syncRoot'),
+          event.path
+        );
+
+        if (relativePath.length === 0) {
+          if (event.type === 'delete') {
+            logger.warn(
+              `The root folder was deleted, the synchronization will not work until a new one is selected`
+            );
+          }
+          return true;
+        }
+
+        return ig.ignores(relativePath);
+      });
 
       if (shouldBeIgnored)
         logger.log(


### PR DESCRIPTION
Ignore events on the root sync folder. Additionally if the root sync folder is deleted add a warn on the app logs