### PR TITLE
[WT-147] fix: menu order and onboaring text

### DIFF
--- a/src/renderer/pages/Widget/Header.tsx
+++ b/src/renderer/pages/Widget/Header.tsx
@@ -101,10 +101,10 @@ export default function Header() {
               role="button"
               tabIndex={0}
               aria-hidden="true"
-              onClick={() => window.electron.openOnboardingWindow()}
+              onClick={window.electron.logout}
             >
               <DropdownItem active={active}>
-                <span>Onboarding</span>
+                <span>Log out</span>
               </DropdownItem>
             </div>
           )}
@@ -115,10 +115,10 @@ export default function Header() {
               role="button"
               tabIndex={0}
               aria-hidden="true"
-              onClick={window.electron.logout}
+              onClick={() => window.electron.openOnboardingWindow()}
             >
               <DropdownItem active={active}>
-                <span>Log out</span>
+                <span>Show Onboarding</span>
               </DropdownItem>
             </div>
           )}


### PR DESCRIPTION
Maintain the order on menu items as it was before (on v1.5.0)