### PR TITLE
[TICK-367] fix: define transports connection option on socket connection

### DIFF
--- a/src/main/realtime.ts
+++ b/src/main/realtime.ts
@@ -108,6 +108,7 @@ function cleanAndStartRemoteNotifications() {
       token: getToken(),
     },
     withCredentials: true,
+    transports: ['polling'],
   });
 
   socket.io.on('open', () => {


### PR DESCRIPTION
Seems like the transports option needs to be defined to be able to connect reliably. https://github.com/socketio/socket.io/issues/1995#issuecomment-74017995