### PR TITLE
[_] fix: photos usage

### DIFF
--- a/src/main/auth/service.ts
+++ b/src/main/auth/service.ts
@@ -1,5 +1,6 @@
 import { safeStorage } from 'electron';
 import Logger from 'electron-log';
+import { HeadersInit } from 'electron-fetch';
 import ConfigStore, { defaults, fieldsToSave } from '../config';
 import packageConfig from '../../../package.json';
 import { User } from '../types';

--- a/src/main/usage/service.ts
+++ b/src/main/usage/service.ts
@@ -7,25 +7,19 @@ import { Usage } from './usage';
 const driveUrl = process.env.API_URL;
 const photosUrl = process.env.PHOTOS_URL;
 
-let photosSubmodule: PhotosSubmodule | null = null;
-
-function sataticPhotosSubmodule(): PhotosSubmodule {
-  if (photosSubmodule) return photosSubmodule;
-
+async function getPhotosUsage(): Promise<number> {
   if (!photosUrl) {
     throw new Error('PHOTOS API URL NOT DEFINED');
   }
 
-  photosSubmodule = new PhotosSubmodule({
+  const accessToken = getNewToken();
+
+  const photosSubmodule = new PhotosSubmodule({
     baseUrl: photosUrl,
-    accessToken: getNewToken(),
+    accessToken,
   });
 
-  return photosSubmodule;
-}
-
-async function getPhotosUsage(): Promise<number> {
-  const { usage } = await sataticPhotosSubmodule().getUsage();
+  const { usage } = await photosSubmodule.getUsage();
 
   return usage;
 }

--- a/src/main/usage/service.ts
+++ b/src/main/usage/service.ts
@@ -12,16 +12,24 @@ async function getPhotosUsage(): Promise<number> {
     throw new Error('PHOTOS API URL NOT DEFINED');
   }
 
-  const accessToken = getNewToken();
+  try {
+    const accessToken = getNewToken();
 
-  const photosSubmodule = new PhotosSubmodule({
-    baseUrl: photosUrl,
-    accessToken,
-  });
+    const photosSubmodule = new PhotosSubmodule({
+      baseUrl: photosUrl,
+      accessToken,
+    });
 
-  const { usage } = await photosSubmodule.getUsage();
+    const { usage } = await photosSubmodule.getUsage();
 
-  return usage;
+    return usage;
+  } catch (error: any) {
+    Logger.warn(
+      'User is missing new access token, photos usage will not be counted'
+    );
+  }
+
+  return 0;
 }
 
 async function getDriveUsage(headers: HeadersInit): Promise<number> {

--- a/src/renderer/hooks/Usage.tsx
+++ b/src/renderer/hooks/Usage.tsx
@@ -7,6 +7,10 @@ export default function useUsage() {
   );
 
   async function updateUsage() {
+    if (!(await window.electron.isUserLoggedIn())) {
+      return;
+    }
+
     try {
       const usage = await window.electron.getUsage();
       setRawUsage(usage);


### PR DESCRIPTION
Due we were not storing the `new token` the user will need to log out and log in again in order to be able to get the total usage of his account.

Also, since the check for if the user is logged in is asynchronous it was leading to checking the account usage at startup when was not logged in