### PR TITLE
[_]: fix/add-descriptive-lock-error-messages

### DIFF
--- a/src/main/background-processes/lock-erros.ts
+++ b/src/main/background-processes/lock-erros.ts
@@ -1,0 +1,48 @@
+const reasons = [
+  'FOLDER_IS_LOCKED',
+  'SERVICE_UNAVAILABE',
+  'UNKNONW_LOCK_SERVICE_ERROR',
+  'LOCK_UNAUTHORIZED',
+] as const;
+
+export type LockErrorReason = typeof reasons[number];
+
+export function isLockError(maybe: unknown): maybe is LockErrorReason {
+  return (
+    typeof maybe === 'string' && reasons.includes(maybe as LockErrorReason)
+  );
+}
+
+export class LockError extends Error {
+  readonly reason: LockErrorReason;
+
+  constructor(reason: LockErrorReason, msg?: string) {
+    super(msg);
+
+    this.reason = reason;
+  }
+}
+
+export class FolderIsLocked extends LockError {
+  constructor(msg?: string) {
+    super('FOLDER_IS_LOCKED', msg);
+  }
+}
+
+export class LockServiceUnavailabe extends LockError {
+  constructor(msg?: string) {
+    super('SERVICE_UNAVAILABE', msg);
+  }
+}
+
+export class UnknonwLockServiceError extends LockError {
+  constructor(msg?: string) {
+    super('UNKNONW_LOCK_SERVICE_ERROR', msg);
+  }
+}
+
+export class UnauthorizedError extends LockError {
+  constructor(msg?: string) {
+    super('LOCK_UNAUTHORIZED', msg);
+  }
+}

--- a/src/main/background-processes/locks-service.ts
+++ b/src/main/background-processes/locks-service.ts
@@ -1,45 +1,71 @@
 import fetch from 'electron-fetch';
 import Logger from 'electron-log';
 import { onUserUnauthorized } from '../auth/handlers';
-
 import { getHeaders } from '../auth/service';
+import {
+  FolderIsLocked,
+  LockServiceUnavailabe,
+  UnknonwLockServiceError,
+} from './lock-erros';
 
-async function acquireOrRefreshLock(folderId: number, lockId: string) {
+async function acquireOrRefreshLock(
+  folderId: number,
+  lockId: string
+): Promise<'OK' | never> {
   const res = await fetch(
     `${process.env.API_URL}/api/storage/folder/${folderId}/lock/${lockId}/acquireOrRefresh`,
     { method: 'PUT', headers: getHeaders() }
   );
-  if (!res.ok) {
-    if (res.status === 401) {
-      onUserUnauthorized();
-    }
-    throw new Error(
-      `Lock for folderId ${folderId} with id ${lockId} could not be acquired/refreshed, status: ${res.status}`
-    );
-  } else {
-    Logger.debug(
-      `Lock for folderId ${folderId} with id ${lockId} acquired/refreshed with status: ${res.status}`
-    );
+
+  Logger.debug(
+    `Lock for folderId ${folderId} with id ${lockId} acquired/refreshed with status: ${res.status}`
+  );
+
+  if (res.ok) return 'OK';
+
+  if (res.status === 401) {
+    onUserUnauthorized();
   }
+
+  if (res.status === 409) {
+    throw new FolderIsLocked();
+  }
+
+  if (res.status === 503) {
+    throw new LockServiceUnavailabe();
+  }
+
+  throw new UnknonwLockServiceError(
+    `Lock for folderId ${folderId} with id ${lockId} could not be acquired/refreshed, status: ${res.status}`
+  );
 }
 
-async function releaseLock(folderId: number, lockId: string) {
+async function releaseLock(
+  folderId: number,
+  lockId: string
+): Promise<'OK' | never> {
   const res = await fetch(
     `${process.env.API_URL}/api/storage/folder/${folderId}/lock/${lockId}`,
     { method: 'DELETE', headers: getHeaders() }
   );
-  if (!res.ok) {
-    if (res.status === 401) {
-      onUserUnauthorized();
-    }
-    Logger.error(
-      `Request to release the lock ${lockId} for folder ${folderId} was not succesful, status: ${res.status}`
-    );
-  } else {
-    Logger.debug(
-      `Lock for folderId ${folderId} with id ${lockId} released with status: ${res.status}`
-    );
+
+  Logger.debug(
+    `Lock for folderId ${folderId} with id ${lockId} released with status: ${res.status}`
+  );
+
+  if (res.ok) return 'OK';
+
+  if (res.status === 401) {
+    onUserUnauthorized();
   }
+
+  if (res.status === 503) {
+    throw new LockServiceUnavailabe();
+  }
+
+  throw new UnknonwLockServiceError(
+    `Lock for folderId ${folderId} with id ${lockId} could not be released, status: ${res.status}`
+  );
 }
 
 export default { releaseLock, acquireOrRefreshLock };

--- a/src/renderer/pages/Widget/SyncErrorBanner.tsx
+++ b/src/renderer/pages/Widget/SyncErrorBanner.tsx
@@ -5,6 +5,7 @@ import useSyncStatus from '../../hooks/SyncStatus';
 import useSyncStopped from '../../hooks/SyncStopped';
 import { SyncStatus } from '../../../main/background-processes/sync';
 import { ProcessFatalErrorName } from '../../../workers/types';
+import { LockErrorReason } from '../../../main/background-processes/lock-erros';
 
 const fatalErrorActionMap: Record<
   ProcessFatalErrorName,
@@ -32,6 +33,16 @@ const fatalErrorActionMap: Record<
   UNKNOWN: undefined,
 };
 
+const lockErrorMessages: Record<LockErrorReason, string> = {
+  FOLDER_IS_LOCKED:
+    "Looks like other of your devices is already syncing, we'll try again later",
+  SERVICE_UNAVAILABE:
+    'We cannot perform the action at the moment, please try again later',
+  UNKNONW_LOCK_SERVICE_ERROR: 'An unkown error has occured',
+  LOCK_UNAUTHORIZED:
+    'Your session has expired, if the app does not log out shortly please log out manually',
+};
+
 export default function SyncErrorBanner() {
   const [stopReason, setStopReason] = useSyncStopped();
 
@@ -53,8 +64,7 @@ export default function SyncErrorBanner() {
   let message = '';
 
   if (stopReason?.reason === 'COULD_NOT_ACQUIRE_LOCK')
-    message =
-      "Looks like other of your devices is already syncing, we'll try again later";
+    message = lockErrorMessages[stopReason?.cause];
   else if (stopReason?.reason === 'FATAL_ERROR')
     message = FatalErrorMessages[stopReason.errorName];
 

--- a/src/renderer/pages/Widget/SyncErrorBanner.tsx
+++ b/src/renderer/pages/Widget/SyncErrorBanner.tsx
@@ -35,10 +35,10 @@ const fatalErrorActionMap: Record<
 
 const lockErrorMessages: Record<LockErrorReason, string> = {
   FOLDER_IS_LOCKED:
-    "Looks like other of your devices is already syncing, we'll try again later",
+    "Looks like other of your devices are already syncing, we'll try again later",
   SERVICE_UNAVAILABE:
     'We cannot perform the action at the moment, please try again later',
-  UNKNONW_LOCK_SERVICE_ERROR: 'An unkown error has occured',
+  UNKNONW_LOCK_SERVICE_ERROR: 'An unknown error has occurred',
   LOCK_UNAUTHORIZED:
     'Your session has expired, if the app does not log out shortly please log out manually',
 };


### PR DESCRIPTION
Added descriptive messages when the folder lock requests fail:

The messages are:
| Cause | Response Status | Message Displayed |
--------|----------|----------
| The service failed to lock the folder | 503 | We cannot perform the action at the moment, please try again later |
| The folder is already locked | 409 | Looks like other of your devices are already syncing, we'll try again later
| User is unauthorized | 401 | Your session has expired, if the app does not log out shortly please log out manually*
| An unknown error has occurred | any of the above nor 200 | An unknown error has occurred


(*) The user should be automatically prompted with the login page but since it's done via an event it is possible that it takes a little bit