### PR TITLE
[_]: feat/ignore-macos-packages

### DIFF
--- a/ignored-files.json
+++ b/ignored-files.json
@@ -1,1 +1,1 @@
-[".DS_Store", "~$*", "*.tmp", "*.swp", "*.photoslibrary/*"]
+[".DS_Store", "~$*", "*.tmp", "*.swp", "*.photoslibrary/*", ".localized"]

--- a/ignored-files.json
+++ b/ignored-files.json
@@ -1,1 +1,1 @@
-[".DS_Store", "~$*", "*.tmp", "*.swp"]
+[".DS_Store", "~$*", "*.tmp", "*.swp", "*.photoslibrary/*"]


### PR DESCRIPTION
Added 2 ignore patterns:

* "\*.photoslibrary/\*": Files like Phots Library.photolibray (provably present on most macOS users Pictures folder) is, in reality, a [package](https://en.wikipedia.org/wiki/Package_(macOS)). In short, we treat it like a folder. But since is filled with program files it most probably has lots of empty files.

* "\*.localized": 

> .localized files is a localization file used by some macOS system directories. It contains no data. The presence of an empty LOCALIZED file allows macOS to show a system directory's name in a user's preferred language. Do not delete LOCALIZED files stored in macOS system directories.
[source](https://fileinfo.com/extension/localized)

 If any user tries to sync or backup a macOS system directory as could be Pictures or Documents will run into an empty file error