### PR TITLE
[_] feat: reenable auto start on linux

### DIFF
--- a/src/main/auto-launch/linux-desktop-entry.ts
+++ b/src/main/auto-launch/linux-desktop-entry.ts
@@ -1,0 +1,42 @@
+import fs from 'fs';
+import os from 'os';
+
+import packageJson from '../../../package.json';
+
+const fileName = `${packageJson.name}.desktop`;
+const desktopFilePath = `${os.homedir()}/.config/autostart`;
+const desktopFile = `${desktopFilePath}/${fileName}`;
+
+function createDesktopEntry() {
+  const fileContent = `[Desktop Entry]
+  Type=Application
+  Version=${packageJson.version}
+  Name=${packageJson.name}
+  Comment=${packageJson.name} startup script
+  Exec=${packageJson.name} --process-start-args --hidden
+  StartupNotify=false
+  Terminal=false
+  `;
+
+  if (!fs.existsSync(desktopFilePath)) {
+    fs.mkdirSync(desktopFilePath);
+  }
+
+  fs.writeFileSync(desktopFile, fileContent);
+}
+
+function deleteDesktopEntry() {
+  fs.unlinkSync(desktopFile);
+}
+
+export function desktopEntryIsPresent(): boolean {
+  return fs.existsSync(desktopFile);
+}
+
+export function toggleDesktopEntry() {
+  if (desktopEntryIsPresent()) {
+    deleteDesktopEntry();
+    return;
+  }
+  createDesktopEntry();
+}

--- a/src/main/auto-launch/service.ts
+++ b/src/main/auto-launch/service.ts
@@ -1,5 +1,9 @@
 import { app } from 'electron';
 import Path from 'path';
+import {
+  desktopEntryIsPresent,
+  toggleDesktopEntry,
+} from './linux-desktop-entry';
 
 const appFolder = Path.dirname(process.execPath);
 const appExe = Path.resolve(appFolder, 'Internxt Drive.exe');
@@ -12,11 +16,15 @@ const args =
     : undefined;
 
 export function isAutoLaunchEnabled() {
-  const loginItem = app.getLoginItemSettings({ path, args });
-  return loginItem.openAtLogin;
+  if (process.platform !== 'linux') {
+    const loginItem = app.getLoginItemSettings({ path, args });
+    return loginItem.openAtLogin;
+  }
+
+  return desktopEntryIsPresent();
 }
 
-export function toggleAutoLaunch() {
+function toggleAppSettings() {
   const currentSetting = isAutoLaunchEnabled();
 
   app.setLoginItemSettings({
@@ -25,4 +33,9 @@ export function toggleAutoLaunch() {
     openAtLogin: !currentSetting,
     openAsHidden: true,
   });
+}
+
+export function toggleAutoLaunch() {
+  if (process.platform !== 'linux') toggleAppSettings();
+  else toggleDesktopEntry();
 }

--- a/src/renderer/pages/Settings/General/StartAutomatically.tsx
+++ b/src/renderer/pages/Settings/General/StartAutomatically.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import useClientPlatform from '../../../hooks/ClientPlatform';
 import Checkbox from '../../../components/Checkbox';
 
 export default function StartAutomatically({
@@ -8,7 +7,6 @@ export default function StartAutomatically({
   className: string;
 }) {
   const [value, setValue] = useState(false);
-  const platform = useClientPlatform();
 
   function refreshValue() {
     window.electron.isAutoLaunchEnabled().then(setValue);
@@ -22,10 +20,6 @@ export default function StartAutomatically({
     await window.electron.toggleAutoLaunch();
     refreshValue();
   };
-
-  if (platform === 'linux') {
-    return <></>;
-  }
 
   return (
     <Checkbox


### PR DESCRIPTION
To enable the application auto start on Linux a file is needed to be created on `.config/autostart`.

Adds and removes the .desktop file and checks if it is present to determine if auto-start is enabled.

This solution has the downside that we cannot clean this configuration when the app is uninstalled, so a further installation would maintain the configuration of the previous installation