### PR TITLE
[DT-26] fix: dont encrypt tokens when safe storage is not available

### DIFF
--- a/src/main/auth/refresh-token.ts
+++ b/src/main/auth/refresh-token.ts
@@ -1,6 +1,9 @@
 import Logger from 'electron-log';
 import { TokenScheduler } from '../token-scheduler/TokenScheduler';
-import { getNewToken, getToken, updateCredentials } from './service';
+import {
+  obtainTokens as obtainStoredTokens,
+  updateCredentials,
+} from './service';
 import { getClient } from '../../shared/HttpClient/main-process-client';
 import { onUserUnauthorized } from './handlers';
 
@@ -33,7 +36,7 @@ async function refreshToken() {
 }
 
 export async function createTokenSchedule(refreshedTokens?: Array<string>) {
-  const tokens = refreshedTokens || [getToken(), getNewToken()];
+  const tokens = refreshedTokens || obtainStoredTokens();
 
   const shceduler = new TokenScheduler(5, tokens, onUserUnauthorized);
   const schedule = shceduler.schedule(refreshToken);

--- a/src/main/auth/service.ts
+++ b/src/main/auth/service.ts
@@ -6,6 +6,9 @@ import { User } from '../types';
 
 const TOKEN_ENCODING = 'latin1';
 
+const tokensKeys = ['bearerToken', 'newToken'] as const;
+type TokenKey = typeof tokensKeys[number];
+
 export function encryptToken() {
   const bearerTokenEncrypted = ConfigStore.get('bearerTokenEncrypted');
 
@@ -26,53 +29,64 @@ export function encryptToken() {
   ConfigStore.set('bearerTokenEncrypted', true);
 }
 
+function ecnryptToken(token: string): string {
+  const buffer = safeStorage.encryptString(token);
+  return buffer.toString(TOKEN_ENCODING);
+}
+
 export function setCredentials(
   userData: User,
   mnemonic: string,
   bearerToken: string,
   newToken: string
 ) {
-  if (!safeStorage.isEncryptionAvailable()) {
-    throw new Error('Safe Storage is not available');
-  }
-
   ConfigStore.set('mnemonic', mnemonic);
   ConfigStore.set('userData', userData);
 
-  const buffer = safeStorage.encryptString(bearerToken);
-  const encryptedToken = buffer.toString(TOKEN_ENCODING);
+  const isSafeStorageAvailable = safeStorage.isEncryptionAvailable();
 
-  ConfigStore.set('bearerToken', encryptedToken);
-  ConfigStore.set('bearerTokenEncrypted', true);
+  const token = isSafeStorageAvailable
+    ? ecnryptToken(bearerToken)
+    : bearerToken;
 
-  const newTokenBuffer = safeStorage.encryptString(newToken);
-  const encryptedNewToken = newTokenBuffer.toString(TOKEN_ENCODING);
+  ConfigStore.set('bearerToken', token);
+  ConfigStore.set('bearerTokenEncrypted', isSafeStorageAvailable);
 
-  ConfigStore.set('newToken', encryptedNewToken);
+  const secondToken = isSafeStorageAvailable
+    ? ecnryptToken(newToken)
+    : newToken;
+
+  ConfigStore.set('newToken', secondToken);
+  ConfigStore.set('newTokenEncrypted', isSafeStorageAvailable);
 }
 
 export function updateCredentials(
   bearerToken: string,
   newBearerToken?: string
 ) {
-  const buffer = safeStorage.encryptString(bearerToken);
-  const encryptedToken = buffer.toString(TOKEN_ENCODING);
+  const isSafeStorageAvailable = safeStorage.isEncryptionAvailable();
 
-  ConfigStore.set('bearerToken', encryptedToken);
-  ConfigStore.set('bearerTokenEncrypted', true);
+  const token = isSafeStorageAvailable
+    ? ecnryptToken(bearerToken)
+    : bearerToken;
+
+  ConfigStore.set('bearerToken', token);
+  ConfigStore.set('bearerTokenEncrypted', isSafeStorageAvailable);
 
   if (!newBearerToken) {
     return;
   }
 
-  const newTokenBuffer = safeStorage.encryptString(newBearerToken);
-  const encryptedNewToken = newTokenBuffer.toString(TOKEN_ENCODING);
+  const secondToken = isSafeStorageAvailable
+    ? ecnryptToken(newBearerToken)
+    : newBearerToken;
 
-  ConfigStore.set('newToken', encryptedNewToken);
+  ConfigStore.set('newToken', secondToken);
+  ConfigStore.set('newTokenEncrypted', isSafeStorageAvailable);
 }
 
 export function getHeaders(includeMnemonic = false): Record<string, string> {
-  const token = getToken();
+  const token = obtainToken('bearerToken');
 
   const header = {
     Authorization: `Bearer ${token}`,
@@ -94,32 +108,25 @@ export function getUser(): User | null {
   return Object.keys(user).length ? user : null;
 }
 
-export function getToken(): string {
-  const bearerTokenEncrypted = ConfigStore.get('bearerTokenEncrypted');
+export function obtainToken(tokenName: TokenKey): string {
+  const token = ConfigStore.get(tokenName);
+  const isEncrypted = ConfigStore.get(`${tokenName}Encrypted`);
 
-  if (!bearerTokenEncrypted) {
-    return ConfigStore.get('bearerToken');
-  }
+  if (!isEncrypted) return token;
 
   if (!safeStorage.isEncryptionAvailable()) {
-    throw new Error('Safe Storage is not available');
+    throw new Error(
+      '[AUTH] Safe Storage was not available when decrypting encrypted token'
+    );
   }
 
-  const encrypedToken = ConfigStore.get('bearerToken');
-  const buffer = Buffer.from(encrypedToken, TOKEN_ENCODING);
+  const buffer = Buffer.from(token, TOKEN_ENCODING);
 
   return safeStorage.decryptString(buffer);
 }
 
-export function getNewToken(): string {
-  if (!safeStorage.isEncryptionAvailable()) {
-    throw new Error('Safe Storage is not available');
-  }
-
-  const encrypedToken = ConfigStore.get('newToken');
-  const buffer = Buffer.from(encrypedToken, TOKEN_ENCODING);
-
-  return safeStorage.decryptString(buffer);
+export function obtainTokens(): Array<string> {
+  return tokensKeys.map(obtainToken);
 }
 
 function resetCredentials() {

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -18,6 +18,7 @@ interface ConfigStore {
   bearerToken: string;
   bearerTokenEncrypted: boolean;
   newToken: string;
+  newTokenEncrypted: boolean;
   userData: User;
   mnemonic: string;
   backupsEnabled: boolean;
@@ -42,6 +43,9 @@ const schema: Schema<ConfigStore> = {
   },
   newToken: {
     type: 'string',
+  },
+  newTokenEncrypted: {
+    type: 'boolean',
   },
   userData: {
     type: 'object',
@@ -88,6 +92,7 @@ export const defaults: ConfigStore = {
   bearerToken: '',
   bearerTokenEncrypted: false,
   newToken: '',
+  newTokenEncrypted: false,
   userData: {} as User,
   mnemonic: '',
   backupsEnabled: false,

--- a/src/main/realtime.ts
+++ b/src/main/realtime.ts
@@ -7,7 +7,7 @@ import ignore from 'ignore';
 import path from 'path';
 import { getSyncStatus, startSyncProcess } from './background-processes/sync';
 import configStore from './config';
-import { getToken } from './auth/service';
+import { obtainToken } from './auth/service';
 import { broadcastToWindows } from './windows';
 import eventBus from './event-bus';
 import ignoredFiles from '../../ignored-files.json';
@@ -107,7 +107,7 @@ function cleanAndStartRemoteNotifications() {
 
   socket = io(process.env.NOTIFICATIONS_URL, {
     auth: {
-      token: getToken(),
+      token: obtainToken('bearerToken'),
     },
     withCredentials: true,
   });

--- a/src/main/usage/service.ts
+++ b/src/main/usage/service.ts
@@ -1,7 +1,7 @@
 import PhotosSubmodule from '@internxt/sdk/dist/photos/photos';
 import Logger from 'electron-log';
 import fetch, { HeadersInit } from 'electron-fetch';
-import { getHeaders, getNewToken } from '../auth/service';
+import { getHeaders, obtainToken } from '../auth/service';
 import { Usage } from './usage';
 
 const driveUrl = process.env.API_URL;
@@ -13,7 +13,7 @@ async function getPhotosUsage(): Promise<number> {
   }
 
   try {
-    const accessToken = getNewToken();
+    const accessToken = obtainToken('newToken');
 
     const photosSubmodule = new PhotosSubmodule({
       baseUrl: photosUrl,


### PR DESCRIPTION
Don't encrypt tokens when safe storage is not available. Added the key `newTokenEncrypted` to the app config to know if the new Token was encrypted or not