### PR TITLE
[DT-34] Fix: blank issues page when renaming backed folder

### DIFF
--- a/src/main/background-processes/backups.ts
+++ b/src/main/background-processes/backups.ts
@@ -183,7 +183,7 @@ function processBackupsItem(
     ipcMain.handleOnce('get-backups-details', () => item);
     onExitFuncs.push(() => ipcMain.removeHandler('get-backups-details'));
 
-    ipcMain.once('BACKUP_FATAL_ERROR', (_, errorName) =>
+    ipcMain.once('BACKUP_FATAL_ERROR', (_, _folderId, errorName) =>
       onExit({ reason: 'FATAL_ERROR', errorName })
     );
     onExitFuncs.push(() => ipcMain.removeAllListeners('BACKUP_FATAL_ERROR'));

--- a/src/renderer/actions/backsups-error-actions.ts
+++ b/src/renderer/actions/backsups-error-actions.ts
@@ -1,0 +1,24 @@
+import { tryAgain } from './shared-actions';
+import { FatalErrorActionMap } from './types';
+
+const findBackupFolder = async (error: { path: string }) => {
+  const result = await window.electron.changeBackupPath(error.path);
+  if (result) window.electron.startBackupsProcess();
+};
+
+export const backupsErrorActions: FatalErrorActionMap = {
+  CANNOT_ACCESS_BASE_DIRECTORY: {
+    name: 'Find folder',
+    func: findBackupFolder,
+  },
+  CANNOT_ACCESS_TMP_DIRECTORY: tryAgain,
+  CANNOT_GET_CURRENT_LISTINGS: tryAgain,
+  NO_INTERNET: tryAgain,
+  NO_REMOTE_CONNECTION: tryAgain,
+  BASE_DIRECTORY_DOES_NOT_EXIST: {
+    name: 'Find folder',
+    func: findBackupFolder,
+  },
+  INSUFICIENT_PERMISION_ACCESSING_BASE_DIRECTORY: tryAgain,
+  UNKNOWN: tryAgain,
+};

--- a/src/renderer/actions/shared-actions.ts
+++ b/src/renderer/actions/shared-actions.ts
@@ -1,0 +1,6 @@
+import { Action } from './types';
+
+export const tryAgain: Action = {
+  name: 'Try again',
+  func: window.electron.startBackupsProcess,
+};

--- a/src/renderer/actions/sync-error-actions.ts
+++ b/src/renderer/actions/sync-error-actions.ts
@@ -1,0 +1,24 @@
+import { tryAgain } from './shared-actions';
+import { FatalErrorActionMap } from './types';
+
+const selectRootSyncFolder = async () => {
+  const result = await window.electron.chooseSyncRootWithDialog();
+  if (result) window.electron.startSyncProcess();
+};
+
+export const syncErrorActions: FatalErrorActionMap = {
+  CANNOT_ACCESS_BASE_DIRECTORY: {
+    name: 'Select folder',
+    func: selectRootSyncFolder,
+  },
+  CANNOT_ACCESS_TMP_DIRECTORY: tryAgain,
+  CANNOT_GET_CURRENT_LISTINGS: tryAgain,
+  NO_INTERNET: tryAgain,
+  NO_REMOTE_CONNECTION: tryAgain,
+  BASE_DIRECTORY_DOES_NOT_EXIST: {
+    name: 'Select folder',
+    func: selectRootSyncFolder,
+  },
+  INSUFICIENT_PERMISION_ACCESSING_BASE_DIRECTORY: tryAgain,
+  UNKNOWN: tryAgain,
+};

--- a/src/renderer/actions/types.ts
+++ b/src/renderer/actions/types.ts
@@ -1,0 +1,9 @@
+import { ProcessFatalErrorName } from '../../workers/types';
+import { BackupFatalError } from '../../main/background-processes/backups';
+
+export interface Action {
+  name: string;
+  func: (error: BackupFatalError | undefined) => Promise<void> | void;
+}
+
+export type FatalErrorActionMap = Record<ProcessFatalErrorName, Action>;

--- a/src/renderer/hooks/FatalErrorActions.ts
+++ b/src/renderer/hooks/FatalErrorActions.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+import { backupsErrorActions } from '../actions/backsups-error-actions';
+import { syncErrorActions } from '../actions/sync-error-actions';
+import { Process } from '../../shared/types/Process';
+import { FatalErrorActionMap } from '../actions/types';
+
+const actionsMap: Record<Process, FatalErrorActionMap> = {
+  SYNC: syncErrorActions,
+  BACKUPS: backupsErrorActions,
+};
+
+export default function useFatalErrorActions(
+  process: Process
+): FatalErrorActionMap {
+  const [actions, setActions] = useState<FatalErrorActionMap>(actionsMap.SYNC);
+
+  useEffect(() => {
+    setActions(actionsMap[process]);
+  }, [process]);
+
+  return actions;
+}

--- a/src/renderer/pages/ProcessIssues/List.tsx
+++ b/src/renderer/pages/ProcessIssues/List.tsx
@@ -14,6 +14,8 @@ import {
 } from '../../../workers/types';
 import { BackupFatalError } from '../../../main/background-processes/backups';
 import messages from '../../messages/process-fatal-error';
+import useFatalErrorActions from '../../hooks/FatalErrorActions';
+import { Action } from '../../actions/types';
 
 export default function ProcessIssuesList({
   processIssues,
@@ -29,6 +31,9 @@ export default function ProcessIssuesList({
   ) => void;
 }) {
   const [isLoading, setIsLoading] = useState(false);
+  const fatalErrorActionMap = useFatalErrorActions(
+    showBackupFatalErrors ? 'BACKUPS' : 'SYNC'
+  );
 
   const [selectedErrorName, setSelectedErrorName] =
     useState<ProcessErrorName | null>(null);
@@ -43,32 +48,12 @@ export default function ProcessIssuesList({
     });
   }
 
-  const defaultAction = {
-    name: 'Try again',
-    func: window.electron.startBackupsProcess,
-  };
-
-  const fatalErrorActionMap: Record<
-    ProcessFatalErrorName,
-    { name: string; func: (error: BackupFatalError) => void }
-  > = {
-    CANNOT_ACCESS_BASE_DIRECTORY: {
-      name: 'Find folder',
-      func: async (error) => {
-        setIsLoading(true);
-        const result = await window.electron.changeBackupPath(error.path);
-        setIsLoading(false);
-        if (result) window.electron.startBackupsProcess();
-      },
-    },
-    CANNOT_ACCESS_TMP_DIRECTORY: defaultAction,
-    CANNOT_GET_CURRENT_LISTINGS: defaultAction,
-    NO_INTERNET: defaultAction,
-    NO_REMOTE_CONNECTION: defaultAction,
-    BASE_DIRECTORY_DOES_NOT_EXIST: defaultAction,
-    INSUFICIENT_PERMISION_ACCESSING_BASE_DIRECTORY: defaultAction,
-    UNKNOWN: defaultAction,
-  };
+  const actionWrapper =
+    (action: Action) => async (error: BackupFatalError | undefined) => {
+      setIsLoading(true);
+      await action.func(error);
+      setIsLoading(false);
+    };
 
   return (
     <div className="no-scrollbar relative m-4 min-h-0 flex-grow overflow-y-auto rounded-lg border border-l-neutral-30 bg-white">
@@ -80,7 +65,7 @@ export default function ProcessIssuesList({
             path={error.path}
             actionName={fatalErrorActionMap[error.errorName].name}
             onActionClick={() =>
-              fatalErrorActionMap[error.errorName].func(error)
+              actionWrapper(fatalErrorActionMap[error.errorName])(error)
             }
           />
         ))}

--- a/src/shared/types/Process.ts
+++ b/src/shared/types/Process.ts
@@ -1,0 +1,1 @@
+export type Process = 'SYNC' | 'BACKUPS';


### PR DESCRIPTION
When a backup folder was renamed the folder id was sent as the error name making the UI not work.

I also refactored the issues actions to be able to show different actions depending on the process, and show an action to change the backup folder path instead of the sync root one
