### PR TITLE
[_] fix: remove the user name from the onboarding

### DIFF
--- a/src/renderer/pages/Onboarding/index.tsx
+++ b/src/renderer/pages/Onboarding/index.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Transition } from '@headlessui/react';
 import Button from '../../components/Button';
-import { User } from '../../../main/types';
 import widgedWidget from '../../assets/onboarding/widget.png';
 import macFinderWidgetAsset from '../../assets/onboarding/mac-finder-widget.png';
 import Logo from '../../assets/onboarding/logo.svg';
@@ -54,11 +53,6 @@ function SideTextAnimation({
 
 export default function Onboarding() {
   const [slide, setSlide] = useState<number>(0);
-  const [user, setUser] = useState<User | null>(null);
-
-  useEffect(() => {
-    window.electron.getUser().then(setUser);
-  }, []);
 
   const nextSlide = () => {
     setSlide(slide + 1);
@@ -100,7 +94,7 @@ export default function Onboarding() {
             <Logo />
             <div>
               <h3 className="mb-2 text-2xl font-semibold tracking-wide text-neutral-900">
-                Welcome to Internxt, {user?.name}!
+                Welcome to Internxt!
               </h3>
               <p>
                 Client-side encrypted, fragmented, simple, fast, secure and

--- a/src/test/onboarding.e2e.ts
+++ b/src/test/onboarding.e2e.ts
@@ -34,9 +34,7 @@ test.describe('onboarding', () => {
   test.describe('welcome slide', () => {
     test('onboarding windows starts with welcome message', async () => {
       const content = await page.innerHTML('h3');
-      expect(content).toBe(
-        `Welcome to Internxt, ${AccessResponseFixtures.user.name}!`
-      );
+      expect(content).toBe(`Welcome to Internxt!`);
     });
 
     test('welcome slide has lets go button', async () => {


### PR DESCRIPTION
When the register flow was changed, the user name is no longer asked on the registration process and defaults to "My".
This will cause the onboarding to show the message `Welcome to Internxt, My!` on the onboarding if the user does not change his name before opening the app.

So it's changed to simply `Welcome to Internxt!`