### PR TITLE
[_] fix: resync

### DIFF
--- a/src/workers/filesystems/infrastructure/SyncLocalFileSystem.ts
+++ b/src/workers/filesystems/infrastructure/SyncLocalFileSystem.ts
@@ -209,7 +209,7 @@ export function getLocalFilesystem(
       const osSpecificRelative = name.replaceAll('/', path.sep);
       const fullPath = path.join(localPath, osSpecificRelative);
 
-      await fs.mkdir(path.parse(fullPath).dir, { recursive: true });
+      await fs.mkdir(fullPath);
     },
 
     renameFile(oldName: string, newName: string) {


### PR DESCRIPTION
Filter folders out when doing a resync and use previous file systems.
When both file systems are empty the listing is not created, to create the listing a resync is needed to pull the first files. Once those files are on both file systems normal synchronizations will be executed