### PR TITLE
[_] fix: use base instead of name property from the selected folder

### DIFF
--- a/src/main/device/service.ts
+++ b/src/main/device/service.ts
@@ -141,8 +141,8 @@ export async function getBackupsFromDevice(): Promise<
 
 export async function addBackup(): Promise<void> {
   async function createBackup(pathname: string): Promise<void> {
-    const { name } = path.parse(pathname);
-    const newBackup = await postBackup(name);
+    const { base } = path.parse(pathname);
+    const newBackup = await postBackup(base);
 
     const backupList = configStore.get('backupList');
 


### PR DESCRIPTION
`ParsedPath` name is `The file name without extension (if any) such as 'index'`, that creates an issue when a selected folder has a dot on it (ex: `folder . with a dot`) where it treats the second part from the dot as an extension and it gets deleted from the name, the base property contains the extension part, but the selected items are constrained to folders