### PR TITLE
[PB-69] fix: update folder modtime on local

### DIFF
--- a/src/workers/filesystems/domain/FileSystem.ts
+++ b/src/workers/filesystems/domain/FileSystem.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import { PartialListing } from '../../sync/Listings/domain/Listing';
 import {
   FileSystemKind,
@@ -50,10 +51,11 @@ export interface FileSystem<T extends PartialListing> {
   ): Promise<number | void>;
 
   /**
-   * Creates a folder into this FileSystem
+   * Creates a folder into this FileSystem and updates its modtime
    * @param name
+   * @param modtime
    */
-  pullFolder(name: string): Promise<void>;
+  pullFolder(name: string, modtime: number): Promise<void>;
 
   /**
    * Checks if a folder exists in the filesystem
@@ -85,4 +87,6 @@ export interface FileSystem<T extends PartialListing> {
    * and throw an error if it's not operative
    */
   smokeTest(): Promise<void>;
+
+  getFolderData(folderFullPath: string): Promise<{ modtime: number }>;
 }

--- a/src/workers/filesystems/infrastructure/SyncRemoteFileSystem.ts
+++ b/src/workers/filesystems/infrastructure/SyncRemoteFileSystem.ts
@@ -5,6 +5,7 @@ import { Readable } from 'stream';
 import Logger from 'electron-log';
 import EventEmitter from 'events';
 import { ipcRenderer } from 'electron';
+import { partialRight } from 'lodash';
 import { fileNameIsValid } from '../../utils/name-verification';
 import crypt from '../../utils/crypt';
 import {
@@ -27,23 +28,22 @@ import { RemoteItemMetaData } from '../../sync/Listings/domain/RemoteItemMetaDat
 import { FileCreatedResponseDTO } from '../../../shared/HttpClient/responses/file-created';
 import { TransferLimits } from '../domain/Transfer';
 
+type CacheData = {
+  id: number;
+  parentId: number;
+  isFolder: boolean;
+  bucket: string | null;
+  fileId?: string;
+  modificationTime?: number;
+  size?: number;
+};
+
 /**
  * Server cannot find a file given its route,
  * while we traverse the tree we also store in a cache
  * the info of every file by its route so we can operate with them
  */
-type RemoteCache = Record<
-  string,
-  {
-    id: number;
-    parentId: number;
-    isFolder: boolean;
-    bucket: string | null;
-    fileId?: string;
-    modificationTime?: number;
-    size?: number;
-  }
->;
+type RemoteCache = Record<string, CacheData>;
 
 export function getRemoteFilesystem({
   baseFolderId,
@@ -205,6 +205,7 @@ export function getRemoteFilesystem({
             parentId: folder.parent_id as number,
             isFolder: true,
             bucket: folder.bucket,
+            modificationTime: getSecondsFromDateString(folder.updated_at),
           };
           traverse(folder.id, `${name}/`);
         });
@@ -246,7 +247,7 @@ export function getRemoteFilesystem({
           `${process.env.API_URL}/api/storage/file/${fileInCache.fileId}/meta`,
           {
             method: 'POST',
-            headers: headers,
+            headers,
             body: JSON.stringify({
               metadata: { itemName: newNameBase },
               bucketId: fileInCache.bucket,
@@ -391,7 +392,7 @@ export function getRemoteFilesystem({
             fileSize: source.size,
             source: source.stream,
           });
-        }        
+        }
       });
 
       const oldFileInCache = cache[name];
@@ -471,7 +472,6 @@ export function getRemoteFilesystem({
         const fileCreated: FileCreatedResponseDTO = await res.json();
 
         return fileCreated.id;
-
       } catch (err) {
         await handleFetchError(
           err,
@@ -483,7 +483,7 @@ export function getRemoteFilesystem({
       return Promise.reject();
     },
 
-    async pullFolder(name: string): Promise<void> {
+    async pullFolder(name: string, _modtime: number): Promise<void> {
       const route = name.split('/');
 
       const n = route.at(-1);
@@ -495,7 +495,7 @@ export function getRemoteFilesystem({
       const lastParentId =
         folderInCache !== undefined ? folderInCache.id : baseFolderId;
 
-      httpRequest(`${process.env.API_URL}/api/storage/folder`, {
+      await httpRequest(`${process.env.API_URL}/api/storage/folder`, {
         method: 'POST',
         headers,
         body: JSON.stringify({
@@ -574,6 +574,27 @@ export function getRemoteFilesystem({
           `folderInCache: ${JSON.stringify(folderInCache, null, 2)}`
         );
       }
+    },
+
+    getFolderData(folderName: string) {
+      const folder = cache[folderName];
+
+      Logger.debug('CACHE: ', JSON.stringify(cache, null, 2));
+      Logger.debug('FOLDER: ', JSON.stringify(folder, null, 2));
+      Logger.debug('FOLDER name: ', folderName);
+
+      if (!folder.isFolder) {
+        throw new Error('[SYNC REMOTE FS] Item is not a folder');
+      }
+
+      if (!folder.modificationTime) {
+        // The end point for creating folders do not accept the modification time
+        // and the update metada endpoint only workd for changing the name
+        // so until the cache gets refreshed its undefined
+        throw new Error('[SYNC REMOTE FS] Folder has no modificationTime');
+      }
+
+      return Promise.resolve({ modtime: folder.modificationTime });
     },
 
     getSource(

--- a/src/workers/sync/index.ts
+++ b/src/workers/sync/index.ts
@@ -68,6 +68,7 @@ async function setUp() {
     userInfo: user,
     clients,
   });
+
   const local = getLocalFilesystem(localPath, tmpPath);
 
   const listingStore = new ConfigFileListingStore(configStore);
@@ -266,7 +267,7 @@ async function setUp() {
   try {
     Logger.debug('SYNC STARTING ');
     const result = await sync.run();
-    Logger.log('Sync done, result: ', result);
+    Logger.log('Sync done, result: ', JSON.stringify(result, null, 2));
     ipcRenderer.send('SYNC_EXIT', result);
   } catch (err) {
     if (err instanceof ProcessFatalError) {

--- a/src/workers/sync/sync.ts
+++ b/src/workers/sync/sync.ts
@@ -141,8 +141,16 @@ class Sync extends Process {
       JSON.stringify(pullFoldersFromLocal, null, 2)
     );
 
-    const remoteFolderPullConsumer = new PullFolderQueueConsumer(this.remote, this);
-    const localFolderPullConsumer = new PullFolderQueueConsumer(this.local, this);
+    const remoteFolderPullConsumer = new PullFolderQueueConsumer(
+      this.local,
+      this.remote,
+      this
+    );
+    const localFolderPullConsumer = new PullFolderQueueConsumer(
+      this.remote,
+      this.local,
+      this
+    );
 
     await remoteFolderPullConsumer.consume(pullFoldersFromRemote);
     await localFolderPullConsumer.consume(pullFoldersFromLocal);


### PR DESCRIPTION
Introduced a method to get folder information from the FS in order to get the modification time when pulling a folder.

Added the modification of the folders on the local FS after the creation of them
Fixed error when trying to pull a folder that already exists. This was the case when a local folder had a modification time older than the remote one