### PR TITLE
[_] fix: listing in sync check

### DIFF
--- a/src/workers/sync/Listings/application/ListingsAreInSync.ts
+++ b/src/workers/sync/Listings/application/ListingsAreInSync.ts
@@ -9,9 +9,13 @@ export function listingsAreInSync(
 
     if (!remoteListing) return false;
 
+    if (localListing.isFolder) {
+      return true;
+    }
+
     return (
       localListing.isFolder === remoteListing.isFolder &&
-      localListing.size === remoteListing.size &&
+      localListing.size == remoteListing.size &&
       localListing.modtime === remoteListing.modtime
     );
   });


### PR DESCRIPTION
Folders were not saved in listings due in the remote listings appeared as size 0 and remote modtime cannot be modified via the API