### PR TITLE
fix: avoid pulling folders with different modtime

### DIFF
--- a/src/workers/filesystems/application/PullFolderQueueConsumer.ts
+++ b/src/workers/filesystems/application/PullFolderQueueConsumer.ts
@@ -79,6 +79,6 @@ export class PullFolderQueueConsumer {
       }
     );
 
-    await async.series<unknown, unknown>(tasks).catch(Logger.error);
+    await async.series<unknown, unknown, unknown>(tasks).catch(Logger.error);
   }
 }

--- a/src/workers/filesystems/test/__mocks__/FileSystemMock.ts
+++ b/src/workers/filesystems/test/__mocks__/FileSystemMock.ts
@@ -24,6 +24,8 @@ export class FileSystemMock implements FileSystem<PartialListing> {
 
   private mockGetSource = jest.fn();
 
+  public mockGetFolderData = jest.fn();
+
   private mockSmokeTest = jest.fn();
 
   public kind: FileSystemKind = 'LOCAL';
@@ -68,6 +70,10 @@ export class FileSystemMock implements FileSystem<PartialListing> {
     progressCallback: FileSystemProgressCallback
   ): Promise<Source> {
     return this.mockGetSource(name, progressCallback);
+  }
+
+  getFolderData(folderFullPath: string): Promise<{ modtime: number; }> {
+    return this.mockGetFolderData(folderFullPath);
   }
 
   smokeTest(): Promise<void> {

--- a/src/workers/sync/Actions/application/ActionBuilders/KeepMostRecentActionBuilder.ts
+++ b/src/workers/sync/Actions/application/ActionBuilders/KeepMostRecentActionBuilder.ts
@@ -38,7 +38,16 @@ export class KeepMostRecentActionBuilder extends ActionBuilder {
       return;
     }
 
-    if (this.actual.listing.isFolder || this.mirror.listing.isFolder) {
+
+
+    if(this.actual.listing === undefined) {
+      console.log(JSON.stringify(this.actual.listing));
+    }
+
+    if (
+      this.actual.listing !== undefined && this.actual?.listing.isFolder &&
+      this.mirror?.listing.isFolder
+    ) {
       // Remote FS cannot update the modification time
       return;
     }

--- a/src/workers/sync/test/Actions/application/GenerateHierarchyActions.test.ts
+++ b/src/workers/sync/test/Actions/application/GenerateHierarchyActions.test.ts
@@ -640,10 +640,10 @@ describe('actions generation', () => {
         queues.folder;
 
       expect(pullFromLocal.sort()).toEqual(
-        ['c', 'g', 'i', 'n', 'k', 'o', 'q', 's'].sort()
+        ['g', 'i', 'k', 'o', 'q', 's'].sort()
       );
       expect(pullFromRemote.sort()).toEqual(
-        ['a', 'b', 'e', 'd', 'f', 'm', 'l'].sort()
+        ['b', 'e', 'd', 'f', 'm', 'l'].sort()
       );
 
       expect(deleteInLocal).toEqual(['p']);

--- a/src/workers/sync/test/sync.test.ts
+++ b/src/workers/sync/test/sync.test.ts
@@ -173,7 +173,7 @@ describe('sync tests', () => {
       },
     };
 
-    const sync = new Sync(local, remote, listingStore());
+    const sync = new Sync(local, remote, listingStore(), {remote, local});
 
     const {
       smokeTestingCB,


### PR DESCRIPTION
Modified KeepMostRecent to avoid pulling folders with different modtime as the remote file system can update it. And updated test to match new beheviour