### PR TITLE
[PB-69] added timer to try to fix desync from listings local and remote

### DIFF
--- a/src/workers/sync/sync.ts
+++ b/src/workers/sync/sync.ts
@@ -419,6 +419,8 @@ class Sync extends Process {
   }
 
   private async finalize(): Promise<ProcessResult> {
+    await new Promise(res => setTimeout(res, 1000));
+
     this.emit('FINALIZING');
 
     const result = await this.generateResult();


### PR DESCRIPTION
Sometimes, even if a file was successfully uploaded does not appear in the current remote listing, generating a wrong diff for the listings to save