### PR TITLE
[PB-62] fix: delete tmp files when remote fs pull file fails

### DIFF
--- a/src/workers/filesystems/infrastructure/SyncRemoteFileSystem.ts
+++ b/src/workers/filesystems/infrastructure/SyncRemoteFileSystem.ts
@@ -319,6 +319,8 @@ export function getRemoteFilesystem({
       });
 
       if (source.size > TransferLimits.UploadFileSize) {
+        source.stream.destroy(new Error('FILE TOO BIG'));
+
         throw new ProcessError(
           'FILE_TOO_BIG',
           createErrorDetails(
@@ -337,6 +339,8 @@ export function getRemoteFilesystem({
               if (err) {
                 // Don't include the stream in the details
                 const { stream, ...sourceWithoutStream } = source;
+
+                source.stream.destroy(new Error('MULTIPART UPLOAD FAILED'));
 
                 const details = createErrorDetails(
                   err,
@@ -368,6 +372,8 @@ export function getRemoteFilesystem({
               if (err) {
                 // Don't include the stream in the details
                 const { stream, ...sourceWithoutStream } = source;
+
+                stream.destroy(new Error('LOCAL UPLOADED FAILED'));
 
                 const details = createErrorDetails(
                   err,


### PR DESCRIPTION
Destroy the stream received on the source so the temporal file created is deleted when the is an error on the remote FS `pullFile`