### PR TITLE
[PB-436] feat: handle main process errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "detect-port": "^1.3.0",
     "dotenv": "^10.0.0",
     "dotenv-webpack": "^7.0.3",
-    "electron": "23.0.0",
+    "electron": "^21.0.0",
     "electron-builder": "^23.0.3",
     "electron-devtools-installer": "^3.2.0",
     "electron-notarize": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -123,9 +123,9 @@
     },
     "testURL": "http://localhost/",
     "transformIgnorePatterns": [
-      "node_modules/(?!axios)"
+      "node_modules/(?!(axios)|(@sentry))"
     ],
-    "testEnvironment": "jsdom",
+    "testEnvironment": "node",
     "transform": {
       "\\.(ts|tsx|js|jsx)$": "ts-jest"
     },

--- a/src/main/auth/handlers.ts
+++ b/src/main/auth/handlers.ts
@@ -8,71 +8,73 @@ import { setupRootFolder } from '../sync-root-folder/service';
 import { getWidget } from '../windows/widget';
 import { createTokenSchedule } from './refresh-token';
 import {
-	canHisConfigBeRestored,
-	encryptToken,
-	getHeaders,
-	getNewApiHeaders,
-	getUser,
-	logout,
-	setCredentials,
+  canHisConfigBeRestored,
+  encryptToken,
+  getHeaders,
+  getNewApiHeaders,
+  getUser,
+  logout,
+  setCredentials,
 } from './service';
 
 let isLoggedIn: boolean;
 setIsLoggedIn(!!getUser());
 
 export function setIsLoggedIn(value: boolean) {
-	isLoggedIn = value;
+  isLoggedIn = value;
 
-	getWidget()?.webContents.send('user-logged-in-changed', value);
+  getWidget()?.webContents.send('user-logged-in-changed', value);
 }
 
 export function getIsLoggedIn() {
-	return isLoggedIn;
+  return isLoggedIn;
 }
 
 ipcMain.handle('is-user-logged-in', getIsLoggedIn);
 
 ipcMain.handle('get-user', getUser);
 
-ipcMain.handle('get-headers', (_, includeMnemonic) => getHeaders(includeMnemonic));
+ipcMain.handle('get-headers', (_, includeMnemonic) =>
+  getHeaders(includeMnemonic)
+);
 
 ipcMain.handle('get-headers-for-new-api', () => getNewApiHeaders());
 
 export function onUserUnauthorized() {
-	eventBus.emit('USER_WAS_UNAUTHORIZED');
+  eventBus.emit('USER_WAS_UNAUTHORIZED');
 
-	logout();
-	Logger.info('[AUTH] User has been logged out because it was unauthorized');
-	setIsLoggedIn(false);
+  logout();
+  Logger.info('[AUTH] User has been logged out because it was unauthorized');
+  setIsLoggedIn(false);
 }
 
 ipcMain.on('user-is-unauthorized', onUserUnauthorized);
 
 ipcMain.on('user-logged-in', async (_, data: AccessResponse) => {
-	setCredentials(data.user, data.user.mnemonic, data.token, data.newToken);
-	if (!canHisConfigBeRestored(data.user.uuid)) {
-		await setupRootFolder();
-	}
+  setCredentials(data.user, data.user.mnemonic, data.token, data.newToken);
+  if (!canHisConfigBeRestored(data.user.uuid)) {
+    await setupRootFolder();
+  }
 
-	setIsLoggedIn(true);
-	eventBus.emit('USER_LOGGED_IN');
+  setIsLoggedIn(true);
+  eventBus.emit('USER_LOGGED_IN');
 });
 
 ipcMain.on('user-logged-out', () => {
-	eventBus.emit('USER_LOGGED_OUT');
+  setIsLoggedIn(false);
 
-	logout();
+  eventBus.emit('USER_LOGGED_OUT');
 
-	setIsLoggedIn(false);
+  logout();
 });
 
 eventBus.on('APP_IS_READY', async () => {
-	if (!isLoggedIn) {
-		return;
-	}
+  if (!isLoggedIn) {
+    return;
+  }
 
-	encryptToken();
-	applicationOpened();
-	await createTokenSchedule();
-	eventBus.emit('USER_LOGGED_IN');
+  encryptToken();
+  applicationOpened();
+  await createTokenSchedule();
+  eventBus.emit('USER_LOGGED_IN');
 });

--- a/src/main/bug-report/service.ts
+++ b/src/main/bug-report/service.ts
@@ -9,7 +9,7 @@ import packageJson from '../../../package.json';
 import { ErrorDetails } from '../../workers/types';
 import { obtainToken } from '../auth/service';
 import { BugReportResult } from './BugReportResult';
-import * as Sentry from '@sentry/electron';
+import * as Sentry from '@sentry/electron/main';
 
 /**
  * Reports an error to Sentry from the main process

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -37,11 +37,9 @@ import eventBus from './event-bus';
 import * as Sentry from '@sentry/electron/main';
 import { AppDataSource } from './database/data-source';
 
-if (process.env.NODE_ENV === 'production') {
-  process.on('uncaughtException', (error: unknown) => {
-    Logger.error('Uncaught exception: ', JSON.stringify(error, null, 2));
-  });
-}
+process.on('uncaughtException', (error: unknown) => {
+  Logger.error('Uncaught exception: ', JSON.stringify(error, null, 2));
+});
 
 Logger.log(`Running ${packageJson.version}`);
 
@@ -98,6 +96,8 @@ app.on('window-all-closed', () => {
 ipcMain.on('user-quit', () => {
   app.quit();
 });
+
+ipcMain.handle('app-is-ready', () => app.isReady());
 
 app
   .whenReady()

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -34,7 +34,7 @@ import { autoUpdater } from 'electron-updater';
 
 import packageJson from '../../package.json';
 import eventBus from './event-bus';
-import * as Sentry from '@sentry/electron';
+import * as Sentry from '@sentry/electron/main';
 import { AppDataSource } from './database/data-source';
 
 if (process.env.NODE_ENV === 'production') {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -38,7 +38,7 @@ import * as Sentry from '@sentry/electron/main';
 import { AppDataSource } from './database/data-source';
 
 process.on('uncaughtException', (error: unknown) => {
-  Logger.error('Uncaught exception: ', JSON.stringify(error, null, 2));
+  Logger.error('Uncaught exception: ', error);
 });
 
 Logger.log(`Running ${packageJson.version}`);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -37,9 +37,11 @@ import eventBus from './event-bus';
 import * as Sentry from '@sentry/electron';
 import { AppDataSource } from './database/data-source';
 
-process.on('uncaughtException', (error: unknown) => {
-  Logger.error('Uncaught exception: ', JSON.stringify(error, null, 2));
-});
+if (process.env.NODE_ENV === 'production') {
+  process.on('uncaughtException', (error: unknown) => {
+    Logger.error('Uncaught exception: ', JSON.stringify(error, null, 2));
+  });
+}
 
 Logger.log(`Running ${packageJson.version}`);
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -37,6 +37,10 @@ import eventBus from './event-bus';
 import * as Sentry from '@sentry/electron';
 import { AppDataSource } from './database/data-source';
 
+process.on('uncaughtException', (error: unknown) => {
+  Logger.error('Uncaught exception: ', JSON.stringify(error, null, 2));
+});
+
 Logger.log(`Running ${packageJson.version}`);
 
 Logger.log('Initializing Sentry for main process');

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -39,6 +39,8 @@ import { AppDataSource } from './database/data-source';
 
 process.on('uncaughtException', (error: unknown) => {
   Logger.error('Uncaught exception: ', error);
+  Logger.info('An unexpected error occurred. Closing the application.');
+  app.quit();
 });
 
 Logger.log(`Running ${packageJson.version}`);

--- a/src/main/realtime.ts
+++ b/src/main/realtime.ts
@@ -15,19 +15,19 @@ import { broadcastToWindows } from './windows';
 let thereArePendingChanges = false;
 
 export function getThereArePendingChanges() {
-	return thereArePendingChanges;
+  return thereArePendingChanges;
 }
 
 export function clearPendingChanges() {
-	thereArePendingChanges = false;
+  thereArePendingChanges = false;
 }
 
 function tryToStartSyncProcess() {
-	if (getSyncStatus() === 'STANDBY') {
-		startSyncProcess();
-	} else {
-		thereArePendingChanges = true;
-	}
+  if (getSyncStatus() === 'STANDBY') {
+    startSyncProcess();
+  } else {
+    thereArePendingChanges = true;
+  }
 }
 
 eventBus.on('USER_LOGGED_OUT', clearPendingChanges);
@@ -39,50 +39,64 @@ const LOCAL_DEBOUNCE_IN_MS = 2000;
 let subscription: watcher.AsyncSubscription | undefined;
 
 async function cleanAndStartLocalWatcher() {
-	stopLocalWatcher();
+  stopLocalWatcher();
 
-	const debouncedCallback = debounce(tryToStartSyncProcess, LOCAL_DEBOUNCE_IN_MS);
+  const debouncedCallback = debounce(
+    tryToStartSyncProcess,
+    LOCAL_DEBOUNCE_IN_MS
+  );
 
-	subscription = await watcher.subscribe(configStore.get('syncRoot'), (err, events) => {
-		if (err) {
-			return logger.warn('Error in local watcher ', JSON.stringify(err, null, 2));
-		}
+  subscription = await watcher.subscribe(
+    configStore.get('syncRoot'),
+    (err, events) => {
+      if (err) {
+        return logger.warn(
+          'Error in local watcher ',
+          JSON.stringify(err, null, 2)
+        );
+      }
 
-		logger.log('Local change(s) detected: ', JSON.stringify(events, null, 2));
+      logger.log('Local change(s) detected: ', JSON.stringify(events, null, 2));
 
-		const ig = ignore().add(ignoredFiles);
+      const ig = ignore().add(ignoredFiles);
 
-		const shouldBeIgnored = events.every((event) => {
-			const relativePath = path.relative(configStore.get('syncRoot'), event.path);
+      const shouldBeIgnored = events.every((event) => {
+        const relativePath = path.relative(
+          configStore.get('syncRoot'),
+          event.path
+        );
 
-			if (relativePath.length === 0) {
-				if (event.type === 'delete') {
-					logger.warn(
-						'The root folder was deleted, the synchronization will not work until a new one is selected'
-					);
-				}
+        if (relativePath.length === 0) {
+          if (event.type === 'delete') {
+            logger.warn(
+              'The root folder was deleted, the synchronization will not work until a new one is selected'
+            );
+          }
 
-				return true;
-			}
+          return true;
+        }
 
-			return ig.ignores(relativePath);
-		});
+        return ig.ignores(relativePath);
+      });
 
-		if (shouldBeIgnored) {
-			logger.log('Local watcher is not triggering because they are ignored files');
-		}
+      if (shouldBeIgnored) {
+        logger.log(
+          'Local watcher is not triggering because they are ignored files'
+        );
+      }
 
-		if (!shouldBeIgnored && getSyncStatus() === 'STANDBY') {
-			debouncedCallback();
-		}
-	});
+      if (!shouldBeIgnored && getSyncStatus() === 'STANDBY') {
+        debouncedCallback();
+      }
+    }
+  );
 }
 
 export async function stopLocalWatcher() {
-	if (subscription) {
-		await subscription.unsubscribe();
-		subscription = undefined;
-	}
+  if (subscription) {
+    await subscription.unsubscribe();
+    subscription = undefined;
+  }
 }
 
 eventBus.on('USER_LOGGED_IN', cleanAndStartLocalWatcher);
@@ -95,63 +109,85 @@ eventBus.on('USER_WAS_UNAUTHORIZED', stopLocalWatcher);
 let socket: Socket | undefined;
 
 function cleanAndStartRemoteNotifications() {
-	stopRemoteNotifications();
+  stopRemoteNotifications();
 
-	socket = io(process.env.NOTIFICATIONS_URL, {
-		auth: {
-			token: obtainToken('bearerToken'),
-		},
-		withCredentials: true,
-	});
+  socket = io(process.env.NOTIFICATIONS_URL, {
+    auth: {
+      token: obtainToken('bearerToken'),
+    },
+    withCredentials: true,
+  });
 
-	socket.io.on('open', () => {
-		socket?.io.engine.transport.on('pollComplete', () => {
-			const request = socket?.io.engine.transport.pollXhr.xhr;
-			const cookieHeader = request.getResponseHeader('set-cookie');
-			if (!cookieHeader) {
-				return;
-			}
-			cookieHeader.forEach((cookieString: string) => {
-				if (cookieString.includes('INGRESSCOOKIE=')) {
-					const cookie = cookieString.split(';')[0];
-					if (socket) {
-						socket.io.opts.extraHeaders = {
-							cookie,
-						};
-					}
-				}
-			});
-		});
-	});
+  socket.io.on('open', () => {
+    socket?.io.engine.transport.on('pollComplete', () => {
+      const request = socket?.io.engine.transport.pollXhr.xhr;
+      const cookieHeader = request.getResponseHeader('set-cookie');
+      if (!cookieHeader) {
+        return;
+      }
+      cookieHeader.forEach((cookieString: string) => {
+        if (cookieString.includes('INGRESSCOOKIE=')) {
+          const cookie = cookieString.split(';')[0];
+          if (socket) {
+            socket.io.opts.extraHeaders = {
+              cookie,
+            };
+          }
+        }
+      });
+    });
+  });
 
-	socket.on('connect', () => {
-		logger.log('Remote notifications connected');
-	});
+  socket.on('connect', () => {
+    logger.log('Remote notifications connected');
+  });
 
-	socket.on('disconnect', (reason) => {
-		logger.log('Remote notifications disconnected, reason: ', reason);
-	});
+  socket.on('disconnect', (reason) => {
+    logger.log('Remote notifications disconnected, reason: ', reason);
+  });
 
-	socket.on('connect_error', (error) => {
-		logger.error('Remote notifications connect error: ', error);
-	});
+  socket.on('connect_error', (error) => {
+    logger.error('Remote notifications connect error: ', error);
+  });
 
-	socket.on('event', (data) => {
-		logger.log('Notification received: ', JSON.stringify(data, null, 2));
+  socket.on('event', (data) => {
+    logger.log('Notification received: ', JSON.stringify(data, null, 2));
 
-		if (data.clientId !== configStore.get('clientId')) {
-			tryToStartSyncProcess();
-		}
+    if (data.clientId !== configStore.get('clientId')) {
+      tryToStartSyncProcess();
+    }
 
-		broadcastToWindows('remote-changes', undefined);
-	});
+    broadcastToWindows('remote-changes', undefined);
+  });
+
+  socket.on('reconnect', (attempt: number) => {
+    logger.log('Remote notifications reconnected on attempt n ', attempt);
+  });
+
+  socket.on('reconnect_attempt', (attempt: number) => {
+    logger.log(`Remote notifications trying to reconnect (${attempt} attempt)`);
+  });
+
+  socket.on('reconnect_error', (error: Error) => {
+    logger.error('Remote failed to reconnect ', error);
+  });
+
+  socket.on('reconnect_failed', () => {
+    logger.error(
+      'Remote notifications error failed to reconnect on all attempts'
+    );
+  });
+
+  socket.on('error', (error: Error) => {
+    logger.error('Remote notifications error: ', error);
+  });
 }
 
 function stopRemoteNotifications() {
-	if (socket) {
-		socket.close();
-		socket = undefined;
-	}
+  if (socket) {
+    socket.close();
+    socket = undefined;
+  }
 }
 
 eventBus.on('USER_LOGGED_IN', cleanAndStartRemoteNotifications);

--- a/src/main/remote-sync/RemoteSyncManager.test.ts
+++ b/src/main/remote-sync/RemoteSyncManager.test.ts
@@ -1,3 +1,4 @@
+jest.mock('@sentry/electron/main', () => ({ init: () => jest.fn(), captureException: () => jest.fn()}));
 import { DatabaseCollectionAdapter } from 'main/database/adapters/base';
 import { DriveFile } from 'main/database/entities/DriveFile';
 import { DriveFolder } from 'main/database/entities/DriveFolder';

--- a/src/test/app.e2e.ts
+++ b/src/test/app.e2e.ts
@@ -1,0 +1,45 @@
+
+import { expect, test } from '@playwright/test';
+import {
+  ipcMainInvokeHandler,
+} from 'electron-playwright-helpers';
+import { _electron as electron } from 'playwright';
+import { wait } from './utils';
+
+
+test.describe('production app', () => {
+
+  test('app is defined', async () => {
+    const electronApp = await electron.launch({
+      args: ['release/app/dist/main/main.js'],
+      env: {
+        ...process.env,
+        NODE_ENV: 'production',
+      },
+    });
+
+    expect(electronApp).toBeDefined();
+  
+  });
+
+    test('app is does not crash', async () => {
+      try {
+
+        const electronApp = await electron.launch({
+          args: ['release/app/dist/main/main.js'],
+      env: {
+        ...process.env,
+        NODE_ENV: 'production',
+      },
+    });
+
+    await wait(5);
+    
+    const isReady = await ipcMainInvokeHandler(electronApp, 'app-is-ready');
+    expect(isReady).toBe(true);
+  } catch (err) {
+    expect(err).not.toBeDefined();
+  }
+
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1201,20 +1201,21 @@
     glob "^7.1.6"
     minimatch "^3.0.4"
 
-"@electron/get@^2.0.0":
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/@electron/get/-/get-2.0.2.tgz"
-  integrity sha512-eFZVFoRXb3GFGd7Ak7W4+6jBl9wBtiZ4AaYOse97ej6mKj5tkyO0dUnUChs1IhJZtx1BENo4/p4WUTXpi6vT+g==
+"@electron/get@^1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.14.1.tgz#16ba75f02dffb74c23965e72d617adc721d27f40"
+  integrity sha512-BrZYyL/6m0ZXz/lDxy/nlVhQz+WF+iPS6qXolEU8atw7h6v1aYkjwJZ63m+bJMBTxDE66X+r2tPS4a/8C82sZw==
   dependencies:
     debug "^4.1.1"
     env-paths "^2.2.0"
     fs-extra "^8.1.0"
-    got "^11.8.5"
+    got "^9.6.0"
     progress "^2.0.3"
     semver "^6.2.0"
     sumchecker "^3.0.1"
   optionalDependencies:
     global-agent "^3.0.0"
+    global-tunnel-ng "^2.7.1"
 
 "@electron/universal@1.2.1":
   version "1.2.1"
@@ -1901,6 +1902,11 @@
   resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz"
   integrity sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==
 
+"@sindresorhus/is@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
+  integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
+
 "@sindresorhus/is@^4.0.0":
   version "4.6.0"
   resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz"
@@ -2030,6 +2036,13 @@
     "@svgr/core" "^6.5.1"
     "@svgr/plugin-jsx" "^6.5.1"
     "@svgr/plugin-svgo" "^6.5.1"
+
+"@szmarczak/http-timer@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
+  integrity sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
+  dependencies:
+    defer-to-connect "^1.0.1"
 
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.6"
@@ -3783,6 +3796,19 @@ cacheable-lookup@^5.0.3:
   resolved "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz"
   integrity sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==
 
+cacheable-request@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
+  integrity sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==
+  dependencies:
+    clone-response "^1.0.2"
+    get-stream "^5.1.0"
+    http-cache-semantics "^4.0.0"
+    keyv "^3.0.0"
+    lowercase-keys "^2.0.0"
+    normalize-url "^4.1.0"
+    responselike "^1.0.2"
+
 cacheable-request@^7.0.2:
   version "7.0.2"
   resolved "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz"
@@ -4205,6 +4231,14 @@ conf@^10.2.0:
     pkg-up "^3.1.0"
     semver "^7.3.5"
 
+config-chain@^1.1.11:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.13.tgz#fad0795aa6a6cdaff9ed1b68e9dff94372c232f4"
+  integrity sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==
+  dependencies:
+    ini "^1.3.4"
+    proto-list "~1.2.1"
+
 confusing-browser-globals@^1.0.10:
   version "1.0.11"
   resolved "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz"
@@ -4566,6 +4600,13 @@ decode-uri-component@^0.2.2:
   resolved "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
+decompress-response@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
+  integrity sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==
+  dependencies:
+    mimic-response "^1.0.0"
+
 decompress-response@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz"
@@ -4629,6 +4670,11 @@ defaults@^1.0.3:
   integrity sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==
   dependencies:
     clone "^1.0.2"
+
+defer-to-connect@^1.0.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"
+  integrity sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==
 
 defer-to-connect@^2.0.0:
   version "2.0.1"
@@ -4912,6 +4958,11 @@ dotenv@^9.0.2:
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz"
   integrity sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==
 
+duplexer3@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.5.tgz#0b5e4d7bad5de8901ea4440624c8e1d20099217e"
+  integrity sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==
+
 duplexer@^0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz"
@@ -5096,12 +5147,12 @@ electron-updater@^4.6.4:
     lodash.isequal "^4.5.0"
     semver "^7.3.5"
 
-electron@23.0.0:
-  version "23.0.0"
-  resolved "https://registry.npmjs.org/electron/-/electron-23.0.0.tgz"
-  integrity sha512-S6hVtTAjauMiiWP9sBVR5RpcUC464cNZ06I2EMUjeZBq+KooS6tLmNsfw0zLpAXDp1qosjlBP3v71NTZ3gd9iA==
+electron@^21.0.0:
+  version "21.4.4"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-21.4.4.tgz#46f24eae1ff99416312f4dfecf64b021524bb8e2"
+  integrity sha512-N5O7y7Gtt7mDgkJLkW49ETiT8M3myZ9tNIEvGTKhpBduX4WdgMj6c3hYeYBD6XW7SvbRkWEQaTl25RNday8Xpw==
   dependencies:
-    "@electron/get" "^2.0.0"
+    "@electron/get" "^1.14.1"
     "@types/node" "^16.11.26"
     extract-zip "^2.0.1"
 
@@ -5130,9 +5181,9 @@ enabled@2.0.x:
   resolved "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz"
   integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
 
-encodeurl@~1.0.2:
+encodeurl@^1.0.2, encodeurl@~1.0.2:
   version "1.0.2"
-  resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
 
 encoding@^0.1.13:
@@ -6158,6 +6209,13 @@ get-package-type@^0.1.0:
   resolved "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
+get-stream@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
+  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+  dependencies:
+    pump "^3.0.0"
+
 get-stream@^5.1.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz"
@@ -6244,6 +6302,16 @@ global-agent@^3.0.0:
     semver "^7.3.2"
     serialize-error "^7.0.1"
 
+global-tunnel-ng@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/global-tunnel-ng/-/global-tunnel-ng-2.7.1.tgz#d03b5102dfde3a69914f5ee7d86761ca35d57d8f"
+  integrity sha512-4s+DyciWBV0eK148wqXxcmVAbFVPqtc3sEtUE/GTQfuU80rySLcMhUmHKSHI7/LDj8q0gDYI1lIhRRB7ieRAqg==
+  dependencies:
+    encodeurl "^1.0.2"
+    lodash "^4.17.10"
+    npm-conf "^1.1.3"
+    tunnel "^0.0.6"
+
 globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz"
@@ -6313,9 +6381,9 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-got@^11.7.0, got@^11.8.5:
+got@^11.7.0:
   version "11.8.6"
-  resolved "https://registry.npmjs.org/got/-/got-11.8.6.tgz"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.8.6.tgz#276e827ead8772eddbcfc97170590b841823233a"
   integrity sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==
   dependencies:
     "@sindresorhus/is" "^4.0.0"
@@ -6329,6 +6397,23 @@ got@^11.7.0, got@^11.8.5:
     lowercase-keys "^2.0.0"
     p-cancelable "^2.0.0"
     responselike "^2.0.0"
+
+got@^9.6.0:
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
+  integrity sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==
+  dependencies:
+    "@sindresorhus/is" "^0.14.0"
+    "@szmarczak/http-timer" "^1.1.2"
+    cacheable-request "^6.0.0"
+    decompress-response "^3.3.0"
+    duplexer3 "^0.1.4"
+    get-stream "^4.1.0"
+    lowercase-keys "^1.0.1"
+    mimic-response "^1.0.1"
+    p-cancelable "^1.0.0"
+    to-readable-stream "^1.0.0"
+    url-parse-lax "^3.0.0"
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.11"
@@ -6738,6 +6823,11 @@ inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
   integrity sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
+
+ini@^1.3.4:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 internal-slot@^1.0.3, internal-slot@^1.0.4, internal-slot@^1.0.5:
   version "1.0.5"
@@ -7668,6 +7758,11 @@ jsesc@~0.5.0:
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
   integrity sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==
 
+json-buffer@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
+  integrity sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==
+
 json-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz"
@@ -7796,6 +7891,13 @@ keyboardevents-areequal@^0.2.1:
   version "0.2.2"
   resolved "https://registry.npmjs.org/keyboardevents-areequal/-/keyboardevents-areequal-0.2.2.tgz"
   integrity sha512-Nv+Kr33T0mEjxR500q+I6IWisOQ0lK1GGOncV0kWE6n4KFmpcu7RUX5/2B0EUtX51Cb0HjZ9VJsSY3u4cBa0kw==
+
+keyv@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
+  integrity sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==
+  dependencies:
+    json-buffer "3.0.0"
 
 keyv@^4.0.0:
   version "4.5.2"
@@ -8036,7 +8138,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
   integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
-lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -8089,6 +8191,11 @@ lower-case@^2.0.2:
   integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
   dependencies:
     tslib "^2.0.3"
+
+lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
+  integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
 lowercase-keys@^2.0.0:
   version "2.0.0"
@@ -8304,9 +8411,9 @@ mimic-fn@^3.0.0:
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz"
   integrity sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==
 
-mimic-response@^1.0.0:
+mimic-response@^1.0.0, mimic-response@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
 mimic-response@^3.1.0:
@@ -8610,10 +8717,23 @@ normalize-range@^0.1.2:
   resolved "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
   integrity sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==
 
+normalize-url@^4.1.0:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.1.tgz#0dd90cf1288ee1d1313b87081c9a5932ee48518a"
+  integrity sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==
+
 normalize-url@^6.0.1:
   version "6.1.0"
   resolved "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
+
+npm-conf@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/npm-conf/-/npm-conf-1.1.3.tgz#256cc47bd0e218c259c4e9550bf413bc2192aff9"
+  integrity sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==
+  dependencies:
+    config-chain "^1.1.11"
+    pify "^3.0.0"
 
 npm-run-path@^4.0.1:
   version "4.0.1"
@@ -8813,6 +8933,11 @@ ora@^5.1.0:
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
 
+p-cancelable@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
+  integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
+
 p-cancelable@^2.0.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz"
@@ -8992,6 +9117,11 @@ pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
   integrity sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==
+
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+  integrity sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==
 
 pirates@^4.0.1, pirates@^4.0.4:
   version "4.0.5"
@@ -9339,6 +9469,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
+prepend-http@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
+  integrity sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==
+
 prettier-linter-helpers@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz"
@@ -9421,6 +9556,11 @@ prop-types@^15.6.2, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proto-list@~1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
+  integrity sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==
 
 proxy-addr@~2.0.7:
   version "2.0.7"
@@ -9842,6 +9982,13 @@ resolve@^2.0.0-next.4:
     is-core-module "^2.9.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
+
+responselike@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
+  integrity sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==
+  dependencies:
+    lowercase-keys "^1.0.0"
 
 responselike@^2.0.0:
   version "2.0.1"
@@ -10855,6 +11002,11 @@ to-fast-properties@^2.0.0:
   resolved "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz"
   integrity sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==
 
+to-readable-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz#ce0aa0c2f3df6adf852efb404a783e77c0475771"
+  integrity sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz"
@@ -10990,6 +11142,11 @@ tsutils@^3.21.0:
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
+
+tunnel@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
+  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -11170,6 +11327,13 @@ url-loader@^4.1.1:
     loader-utils "^2.0.0"
     mime-types "^2.1.27"
     schema-utils "^3.0.0"
+
+url-parse-lax@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
+  integrity sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==
+  dependencies:
+    prepend-http "^2.0.0"
 
 url-parse@^1.5.3:
   version "1.5.10"


### PR DESCRIPTION
Added unhandled listener on the main process. When an unhandled error the app will close. Fixed the following problems that appeared on a local Linux build:
- Change import from `@Sentry/electron` to `@Sentry/electron/main`
- Downgrade the electron version due to the on-click event on the tray icon not working
- Change the jest configuration to run on `node` environment (Sentry checks if the imported module it is on the correct environment)
- Mocked the sentry calls on `RemoteSyncManager` to avoid internal Sentry error