### PR TITLE
[PB-583]:(fix) Check for user correctly from config.json

### DIFF
--- a/src/main/auth/service.ts
+++ b/src/main/auth/service.ts
@@ -122,7 +122,7 @@ export function getNewApiHeaders(): Record<string, string> {
 export function getUser(): User | null {
   const user = ConfigStore.get('userData');
 
-  return Object.keys(user).length ? user : null;
+  return user && Object.keys(user).length ? user : null;
 }
 
 export function obtainToken(tokenName: TokenKey): string {
@@ -179,6 +179,7 @@ export function canHisConfigBeRestored(uuid: string) {
 }
 
 export function logout() {
+  Logger.info('Loggin out');
   saveConfig();
   resetConfig();
   resetCredentials();

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -51,7 +51,7 @@ function LoggedInWrapper({ children }: { children: JSX.Element }) {
 }
 
 function Loader() {
-  return <div>loading...</div>;
+  return <></>;
 }
 
 export default function App() {


### PR DESCRIPTION
Check for user existence before trying to get the keys length, some errors were thrown when user is null and we try to do `Object.keys(user)`