### PR TITLE
[_]:(fix) Fix webdav events errors when logged out

### DIFF
--- a/src/main/analytics/service.ts
+++ b/src/main/analytics/service.ts
@@ -257,7 +257,11 @@ export function trackWebdavEvent(
   event: TrackedWebdavServerEvents,
   properties: Record<string, any>
 ) {
-  const { uuid: userId } = ConfigStore.get('userData');
+  const userData = ConfigStore.get('userData');
+
+  if (!userData) return;
+
+  const { uuid: userId } = userData;
   Logger.debug('Tracked event', {
     userId,
     event: event,
@@ -278,7 +282,11 @@ export function trackWebdavError(
   error: Error,
   context: WebdavErrorContext
 ) {
-  const { uuid: userId } = ConfigStore.get('userData');
+  const userData = ConfigStore.get('userData');
+
+  if (!userData) return;
+
+  const { uuid: userId } = userData;
 
   const properties = {
     item: context.from,


### PR DESCRIPTION
Fixed some cases where we attempt to track an event, pulling the user from the config store, but no user is found, so this error pops up
![08d9c818-f1cc-41b3-8f4c-fb13fb34b0a9](https://github.com/internxt/drive-desktop/assets/42890253/c3be0af1-aaa5-4d3d-a8c9-94a8b918e90a)
