### PR TITLE
[PB-584]:(fix) Fix webdav error handling

### DIFF
--- a/src/main/analytics/service.ts
+++ b/src/main/analytics/service.ts
@@ -275,14 +275,14 @@ export function trackWebdavEvent(
 export function trackWebdavError(
   event: TrackedWebdavServerErrorEvents,
   error: Error,
-  context: WebdavErrorContext
+  context?: WebdavErrorContext
 ) {
   const userData = ConfigStore.get('userData');
   const clientId = ConfigStore.get('clientId');
 
   const properties = {
-    item: context.from,
-    type: context.itemType,
+    item: context?.from ?? 'NO_ITEM_IN_CONTEXT',
+    type: context?.itemType ?? 'NO_ITEM_TYPE_IN_CONTEXT',
     error: error.message,
   };
 

--- a/src/main/analytics/webdav-handlers.ts
+++ b/src/main/analytics/webdav-handlers.ts
@@ -1,10 +1,6 @@
 import Logger from 'electron-log';
 import { ipcWebdav, IpcWebdavFlow, IpcWebdavFlowErrors } from '../ipcs/webdav';
-import {
-  trackHandledWebdavError,
-  trackWebdavError,
-  trackWebdavEvent,
-} from './service';
+import { trackWebdavError, trackWebdavEvent } from './service';
 import { WebdavErrorContext } from '../../shared/IPC/events/webdav';
 
 function subscribeToFlowEvents(ipc: IpcWebdavFlow) {
@@ -81,12 +77,14 @@ function subscribeToFlowEvents(ipc: IpcWebdavFlow) {
 function subscribeToFlowErrors(ipc: IpcWebdavFlowErrors) {
   ipc.on('WEBDAV_FILE_UPLOADED_ERROR', (_, payload) => {
     const { name, error } = payload;
-    trackWebdavError('Upload Error', { name, error });
+    const errorObj = new Error(error);
+    errorObj.name = name;
+    trackWebdavError('Upload Error', errorObj);
   });
 
   ipc.on('WEBDAV_ACTION_ERROR', (_, error: Error, ctx: WebdavErrorContext) => {
     const errorName = `${ctx.action} Error` as const;
-    trackHandledWebdavError(errorName, error, ctx);
+    trackWebdavError(errorName, error, ctx);
   });
 }
 

--- a/src/main/analytics/webdav-handlers.ts
+++ b/src/main/analytics/webdav-handlers.ts
@@ -77,9 +77,13 @@ function subscribeToFlowEvents(ipc: IpcWebdavFlow) {
 function subscribeToFlowErrors(ipc: IpcWebdavFlowErrors) {
   ipc.on('WEBDAV_FILE_UPLOADED_ERROR', (_, payload) => {
     const { name, error } = payload;
-    const errorObj = new Error(error);
-    errorObj.name = name;
-    trackWebdavError('Upload Error', errorObj);
+
+    trackWebdavError('Upload Error', new Error(error), {
+      itemType: 'File',
+      root: '',
+      from: name,
+      action: 'Upload',
+    });
   });
 
   ipc.on('WEBDAV_ACTION_ERROR', (_, error: Error, ctx: WebdavErrorContext) => {


### PR DESCRIPTION
There was a missing export, and missing arguments in the `trackWebdavError` function