### PR TITLE
[PB-634](fix): Use webContents API to send events to the webdav worker

### DIFF
--- a/src/main/background-processes/webdav.ts
+++ b/src/main/background-processes/webdav.ts
@@ -43,7 +43,7 @@ function stopWebDavServer() {
   ipcWebdav.once('WEBDAV_SERVER_STOP_ERROR', (_, err: Error) => {
     Logger.error('ERROR STOPING WEBDAV SERVER', err);
   });
-  ipcWebdav.emit('STOP_WEBDAV_SERVER_PROCESS');
+  webdavWorker?.webContents.send('STOP_WEBDAV_SERVER_PROCESS');
 }
 
 eventBus.on('USER_LOGGED_OUT', stopWebDavServer);
@@ -54,5 +54,5 @@ eventBus.on('USER_LOGGED_IN', () => {
 });
 
 ipcMain.handle('retry-virtual-drive-mount', () => {
-  webdavWorker?.webContents.send('RETRY_VIRTUAL_DRIVE_MOUNT', '');
+  webdavWorker?.webContents.send('RETRY_VIRTUAL_DRIVE_MOUNT');
 });

--- a/src/workers/webdav/index.ts
+++ b/src/workers/webdav/index.ts
@@ -65,7 +65,9 @@ async function setUp() {
   });
 
   ipc.on('STOP_WEBDAV_SERVER_PROCESS', () => {
-    unmountDrive();
+    unmountDrive().catch((err) => {
+      Logger.error('Failed to unmount the Virtual Drive ', err);
+    });
     server
       .stop()
       .then(() => {


### PR DESCRIPTION
Send event to webdav worker using webContents API instead of ipcWebdav