### PR TITLE
[PB-556] fix: workaround open external url in linux

### DIFF
--- a/src/main/platform/handlers.ts
+++ b/src/main/platform/handlers.ts
@@ -1,9 +1,16 @@
 import { ipcMain, shell } from 'electron';
+import { exec } from 'child_process';
 
 ipcMain.handle('get-platform', () => {
   return process.platform;
 });
 
 ipcMain.handle('open-url', (_, url: string) => {
+
+  if (process.platform === 'linux') {
+    return exec(`xdg-open ${url} &`);
+  }
+
+
   return shell.openExternal(url);
 });

--- a/src/main/platform/handlers.ts
+++ b/src/main/platform/handlers.ts
@@ -8,7 +8,16 @@ ipcMain.handle('get-platform', () => {
 ipcMain.handle('open-url', (_, url: string) => {
 
   if (process.platform === 'linux') {
-    return exec(`xdg-open ${url} &`);
+    // shell.openExternal is not working as intended on the current verions of electron
+    // this is only a workaround to fix it
+    return new Promise<void>((resolve, reject) => {
+      exec(`xdg-open ${url} &`, (error) => {
+        if (error) reject(error);
+
+        resolve();
+      });
+    });
+    
   }
 
 


### PR DESCRIPTION
Added a workaround on Linux to open an external URL in the browser due to this [issue](https://github.com/electron/electron/issues/28436). But this can produce some unexpected behavior as depending the way the browser are installed xdg-open may fail to open the default one.

More info on the [Jira task](https://inxt.atlassian.net/browse/PB-556)