### PR TITLE
[PB-717]: Eject installer disks on app start

### DIFF
--- a/src/main/background-processes/webdav.ts
+++ b/src/main/background-processes/webdav.ts
@@ -61,7 +61,9 @@ eventBus.on('USER_LOGGED_IN', () => {
   }
 });
 
-eventBus.on('APP_IS_READY', ejectMacOSInstallerDisks);
+if (process.platform === 'darwin') {
+  eventBus.on('APP_IS_READY', ejectMacOSInstallerDisks);
+}
 
 ipcMain.handle('retry-virtual-drive-mount', () => {
   webdavWorker?.webContents.send('RETRY_VIRTUAL_DRIVE_MOUNT');

--- a/src/main/background-processes/webdav.ts
+++ b/src/main/background-processes/webdav.ts
@@ -3,6 +3,7 @@ import { ipcWebdav } from '../ipcs/webdav';
 import path from 'path';
 import Logger from 'electron-log';
 import eventBus from '../event-bus';
+import { ejectMacOSInstallerDisks } from '../../workers/webdav/VirtualDrive';
 
 
 let webdavWorker: BrowserWindow | null = null;
@@ -59,6 +60,8 @@ eventBus.on('USER_LOGGED_IN', () => {
     startWebDavServer();
   }
 });
+
+eventBus.on('APP_IS_READY', ejectMacOSInstallerDisks);
 
 ipcMain.handle('retry-virtual-drive-mount', () => {
   webdavWorker?.webContents.send('RETRY_VIRTUAL_DRIVE_MOUNT');

--- a/src/workers/webdav/VirtualDrive.ts
+++ b/src/workers/webdav/VirtualDrive.ts
@@ -36,7 +36,6 @@ export const mountDrive = async (): Promise<void> => {
     }
     return;
   } else if (process.platform === 'darwin') {
-    ejectMacOSInstallerDisks();
     await mountMacOSDrive(driveName);
     return;
   } else if (process.platform === 'linux') {
@@ -328,7 +327,7 @@ const getMacOSMountedInstallerDisks = (): Promise<string[]> => {
   });
 };
 
-const ejectMacOSInstallerDisks = async (): Promise<void> => {
+export const ejectMacOSInstallerDisks = async (): Promise<void> => {
   const installerDisks = await getMacOSMountedInstallerDisks();
   installerDisks.forEach((installerDisk) => {
     ejectMacOSDisk(installerDisk);

--- a/src/workers/webdav/VirtualDrive.ts
+++ b/src/workers/webdav/VirtualDrive.ts
@@ -330,7 +330,7 @@ const getMacOSMountedInstallerDisks = (): Promise<string[]> => {
 export const ejectMacOSInstallerDisks = async (): Promise<void> => {
   const installerDisks = await getMacOSMountedInstallerDisks();
   installerDisks.forEach((installerDisk) => {
-    ejectMacOSDisk(installerDisk);
+    ejectMacOSDisk(installerDisk).catch();
   });
 };
 


### PR DESCRIPTION
- Moved the ejection of the MacOS installer disks to the 'APP_IS_READY' event