### PR TITLE
[PB-635]: In memory items for faster feedback

### DIFF
--- a/src/main/remote-sync/RemoteSyncManager.ts
+++ b/src/main/remote-sync/RemoteSyncManager.ts
@@ -103,25 +103,9 @@ export class RemoteSyncManager {
       reportError(error as Error);
     } finally {
       const totalDuration = Date.now() - start;
-
-      Logger.info('-----------------');
-      Logger.info('REMOTE SYNC STATS\n');
       Logger.info('Total synced files: ', this.totalFilesSynced);
-
-      Logger.info(
-        `Files sync speed: ${
-          this.totalFilesSynced / (totalDuration / 1000)
-        } files/second`
-      );
-
       Logger.info('Total synced folders: ', this.totalFoldersSynced);
-      Logger.info(
-        `Folders sync speed: ${
-          this.totalFoldersSynced / (totalDuration / 1000)
-        } folders/second`
-      );
       Logger.info(`Total remote to local sync time: ${totalDuration}ms`);
-      Logger.info('-----------------');
     }
   }
 

--- a/src/workers/webdav/dependencyInjection/DependencyContainer.ts
+++ b/src/workers/webdav/dependencyInjection/DependencyContainer.ts
@@ -21,6 +21,8 @@ import { UsedSpaceCalculator } from '../modules/userUsage/application/UsedSpaceC
 import { UserUsageDecrementer } from '../modules/userUsage/application/UserUsageDecrementer';
 import { UserUsageIncrementer } from '../modules/userUsage/application/UserUsageIncrementer';
 import { WebdavUserUsageRepository } from '../modules/userUsage/domain/WebdavUserUsageRepository';
+import { WebdavFileRepository } from '../modules/files/domain/WebdavFileRepository';
+import { InMemoryTemporalFileMetadataCollection } from '../modules/files/infrastructure/persistance/InMemoryTemporalFileMetadataCollection';
 
 export interface DependencyContainer {
   drive: Axios;
@@ -33,6 +35,7 @@ export interface DependencyContainer {
   userUsageDecrementer: UserUsageDecrementer;
   incrementDriveUsageOnFileCreated: IncrementDriveUsageOnFileCreated;
 
+  fileRepository: WebdavFileRepository;
   fileClonner: WebdavFileClonner;
   fileDeleter: WebdavFileDeleter;
   fileMover: WebdavFileMover;
@@ -51,6 +54,6 @@ export interface DependencyContainer {
   itemMetadataDealer: WebdavUnkownItemMetadataDealer;
   itemSearcher: WebdavUnknownItemTypeSearcher;
   allItemsLister: AllWebdavItemsNameLister;
-
+  inMemoryFiles: InMemoryTemporalFileMetadataCollection;
   eventBus: WebdavServerEventBus;
 }

--- a/src/workers/webdav/dependencyInjection/DependencyContainerFactory.ts
+++ b/src/workers/webdav/dependencyInjection/DependencyContainerFactory.ts
@@ -174,7 +174,8 @@ export class DependencyContainerFactory {
         folderFinder,
         fileRenamer,
         eventBus,
-        ipc
+        ipc,
+        temporalItemsCollection
       ),
       fileCreator: new WebdavFileCreator(
         fileRepository,

--- a/src/workers/webdav/dependencyInjection/DependencyContainerFactory.ts
+++ b/src/workers/webdav/dependencyInjection/DependencyContainerFactory.ts
@@ -205,7 +205,8 @@ export class DependencyContainerFactory {
       folderMover: new WebdavFolderMover(
         folderRepository,
         folderFinder,
-        folderRenamer
+        folderRenamer,
+        temporalItemsCollection
       ),
       folderDeleter: new WebdavFolderDeleter(
         folderRepository,

--- a/src/workers/webdav/index.ts
+++ b/src/workers/webdav/index.ts
@@ -77,7 +77,10 @@ async function setUp() {
   }
 }
 
-const startWebdavServer = async (server: InternxtWebdavServer, fileSystem: InternxtFileSystem) => {
+const startWebdavServer = async (
+  server: InternxtWebdavServer,
+  fileSystem: InternxtFileSystem
+) => {
   await server.start([{ path: '/', fs: fileSystem }], { debug: false });
   await mountDrive();
   ipc.send('WEBDAV_VIRTUAL_DRIVE_MOUNTED_SUCCESSFULLY');

--- a/src/workers/webdav/modules/files/application/WebdavFileDeleter.ts
+++ b/src/workers/webdav/modules/files/application/WebdavFileDeleter.ts
@@ -27,6 +27,7 @@ export class WebdavFileDeleter {
 
       await this.eventBus.publish(file.pullDomainEvents());
 
+      this.repository.runRemoteSync();
       this.ipc.send('WEBDAV_FILE_DELETED', {
         name: file.name,
         extension: file.type,

--- a/src/workers/webdav/modules/files/application/WebdavFileDeleter.ts
+++ b/src/workers/webdav/modules/files/application/WebdavFileDeleter.ts
@@ -1,27 +1,41 @@
 import { WebdavIpc } from '../../../ipc';
+import { ItemMetadata } from '../../shared/domain/ItemMetadata';
 import { WebdavServerEventBus } from '../../shared/domain/WebdavServerEventBus';
 import { WebdavFile } from '../domain/WebdavFile';
 import { WebdavFileRepository } from '../domain/WebdavFileRepository';
+import { InMemoryTemporalFileMetadataCollection } from '../infrastructure/persistance/InMemoryTemporalFileMetadataCollection';
 
 export class WebdavFileDeleter {
   constructor(
     private readonly repository: WebdavFileRepository,
     private readonly eventBus: WebdavServerEventBus,
-    private readonly ipc: WebdavIpc
+    private readonly ipc: WebdavIpc,
+    private readonly inMemoryItems: InMemoryTemporalFileMetadataCollection
   ) {}
 
   async run(file: WebdavFile): Promise<void> {
-    file.trash();
+    try {
+      this.inMemoryItems.add(
+        file.path.value,
+        ItemMetadata.extractFromFile(file)
+      );
+      file.trash();
+      this.inMemoryItems.update(file.path.value, {
+        visible: false,
+      });
+      await this.repository.delete(file);
 
-    await this.repository.delete(file);
+      await this.eventBus.publish(file.pullDomainEvents());
 
-    await this.eventBus.publish(file.pullDomainEvents());
-
-    this.ipc.send('WEBDAV_FILE_DELETED', {
-      name: file.name,
-      extension: file.type,
-      nameWithExtension: file.nameWithExtension,
-      size: file.size,
-    });
+      this.ipc.send('WEBDAV_FILE_DELETED', {
+        name: file.name,
+        extension: file.type,
+        nameWithExtension: file.nameWithExtension,
+        size: file.size,
+      });
+    } catch (error) {
+      this.inMemoryItems.remove(file.path.value);
+      throw error;
+    }
   }
 }

--- a/src/workers/webdav/modules/files/domain/FileMetadataCollection.ts
+++ b/src/workers/webdav/modules/files/domain/FileMetadataCollection.ts
@@ -5,4 +5,5 @@ export interface FileMetadataCollection {
   remove(path: string): void;
   exists(path: string): boolean;
   get(path: string): ItemMetadata | undefined;
+  update(path: string, metadata: Partial<ItemMetadata>): ItemMetadata | null;
 }

--- a/src/workers/webdav/modules/files/domain/FileMetadataCollection.ts
+++ b/src/workers/webdav/modules/files/domain/FileMetadataCollection.ts
@@ -5,6 +5,8 @@ export interface FileMetadataCollection {
   remove(path: string): void;
   exists(path: string): boolean;
   existsByLastPath(path: string): boolean;
+  get(path: string): ItemMetadata | undefined;
   getByLastPath(path: string): ItemMetadata | undefined;
+  getAllByType(type: ItemMetadata['type']): Record<string, ItemMetadata>;
   update(path: string, metadata: Partial<ItemMetadata>): ItemMetadata | null;
 }

--- a/src/workers/webdav/modules/files/domain/FileMetadataCollection.ts
+++ b/src/workers/webdav/modules/files/domain/FileMetadataCollection.ts
@@ -4,6 +4,7 @@ export interface FileMetadataCollection {
   add(path: string, metadata: ItemMetadata): void;
   remove(path: string): void;
   exists(path: string): boolean;
-  get(path: string): ItemMetadata | undefined;
+  existsByLastPath(path: string): boolean;
+  getByLastPath(path: string): ItemMetadata | undefined;
   update(path: string, metadata: Partial<ItemMetadata>): ItemMetadata | null;
 }

--- a/src/workers/webdav/modules/files/domain/WebdavFileRepository.ts
+++ b/src/workers/webdav/modules/files/domain/WebdavFileRepository.ts
@@ -17,4 +17,6 @@ export interface WebdavFileRepository {
   searchOnFolder(
     folderId: WebdavFolderAttributes['id']
   ): Promise<Array<WebdavFile>>;
+
+  runRemoteSync(): Promise<void>;
 }

--- a/src/workers/webdav/modules/files/infrastructure/persistance/HttpWebdavFileRepository.ts
+++ b/src/workers/webdav/modules/files/infrastructure/persistance/HttpWebdavFileRepository.ts
@@ -115,7 +115,6 @@ export class HttpWebdavFileRepository implements WebdavFileRepository {
 
   search(path: FilePath): Nullable<WebdavFile> {
     const item = this.files[path.value];
-    Logger.info('ITEMS', this.files);
     if (!item) return;
 
     return WebdavFile.from(item.attributes());

--- a/src/workers/webdav/modules/files/infrastructure/persistance/HttpWebdavFileRepository.ts
+++ b/src/workers/webdav/modules/files/infrastructure/persistance/HttpWebdavFileRepository.ts
@@ -34,7 +34,8 @@ export class HttpWebdavFileRepository implements WebdavFileRepository {
     path: string,
     serverFile: WebdavFile
   ) {
-    const inMemoryFile = this.inMemoryItems.get(path);
+    const inMemoryFile =
+      this.inMemoryItems.get(path) || this.inMemoryItems.getByLastPath(path);
 
     const keepInMemoryItem = inMemoryFile?.visible === false;
 
@@ -73,7 +74,9 @@ export class HttpWebdavFileRepository implements WebdavFileRepository {
 
     const serverFiles = files.reduce((items, [path, value]) => {
       this.cleanInMemoryFileIfNeeded(path, value);
-      const existsInMemory = this.inMemoryItems.exists(path);
+      const existsInMemory =
+        this.inMemoryItems.exists(path) ||
+        this.inMemoryItems.existsByLastPath(path);
 
       if (existsInMemory) {
         return items;

--- a/src/workers/webdav/modules/files/infrastructure/persistance/InMemoryTemporalFileMetadataCollection.ts
+++ b/src/workers/webdav/modules/files/infrastructure/persistance/InMemoryTemporalFileMetadataCollection.ts
@@ -63,8 +63,22 @@ export class InMemoryTemporalFileMetadataCollection
     return exists;
   }
 
-  get(path: string): ItemMetadata | undefined {
-    return this.collection[path];
+  get(pathToCheck: string): ItemMetadata | undefined {
+    let match: ItemMetadata | undefined = undefined;
+    Object.keys(this.collection).forEach((path) => {
+      if (match) return;
+      const item = this.collection[path];
+
+      if (pathToCheck === path) {
+        match = item;
+      }
+
+      if (item.lastPath && item.lastPath === pathToCheck) {
+        match = item;
+      }
+    });
+
+    return match;
   }
 
   getAll() {

--- a/src/workers/webdav/modules/files/infrastructure/persistance/InMemoryTemporalFileMetadataCollection.ts
+++ b/src/workers/webdav/modules/files/infrastructure/persistance/InMemoryTemporalFileMetadataCollection.ts
@@ -7,22 +7,81 @@ export class InMemoryTemporalFileMetadataCollection
   private collection: Record<string, ItemMetadata> = {};
 
   add(path: string, metadata: ItemMetadata): void {
-    if (!this.collection[path]) {
-      this.collection[path] = metadata;
-    }
+    this.collection[path] = metadata;
+  }
+
+  update(path: string, metadata: Partial<ItemMetadata>): ItemMetadata | null {
+    if (!this.collection[path]) return null;
+
+    const actualItem = this.collection[path];
+
+    this.collection[path] = ItemMetadata.from({
+      createdAt:
+        metadata.createdAt === undefined
+          ? actualItem.createdAt
+          : metadata.createdAt,
+      updatedAt:
+        metadata.updatedAt === undefined
+          ? actualItem.updatedAt
+          : metadata.updatedAt,
+      name: metadata.name === undefined ? actualItem.name : metadata.name,
+      size: metadata.size === undefined ? actualItem.size : metadata.size,
+      extension:
+        metadata.extension === undefined
+          ? actualItem.extension
+          : metadata.extension,
+      type: metadata.type === undefined ? actualItem.type : metadata.type,
+      visible:
+        metadata.visible === undefined ? actualItem.visible : metadata.visible,
+      externalMetadata:
+        (metadata.externalMetadata === undefined
+          ? actualItem.externalMetadata
+          : metadata.externalMetadata) ?? {},
+    });
+
+    return this.collection[path];
   }
 
   remove(path: string): void {
     delete this.collection[path];
   }
 
-  exists(path: string): boolean {
-    return (
-      this.collection[path] !== undefined && this.collection[path] !== null
-    );
+  exists(pathToCheck: string): boolean {
+    let exists = false;
+    Object.keys(this.collection).forEach((path) => {
+      if (exists) return;
+      const item = this.collection[path];
+
+      if (pathToCheck === path) {
+        exists = true;
+      }
+
+      if (item.lastPath && item.lastPath === pathToCheck) {
+        exists = true;
+      }
+    });
+    return exists;
   }
 
   get(path: string): ItemMetadata | undefined {
     return this.collection[path];
+  }
+
+  getAll() {
+    return this.collection;
+  }
+
+  getAllByType(type: ItemMetadata['type']) {
+    const all: Record<string, ItemMetadata> = {};
+
+    Object.keys(this.collection).forEach((path) => {
+      const item = this.collection[path];
+
+      if (item.type === type) {
+        all[path] = item;
+      }
+    });
+
+    return all;
   }
 }

--- a/src/workers/webdav/modules/files/infrastructure/persistance/InMemoryTemporalFileMetadataCollection.ts
+++ b/src/workers/webdav/modules/files/infrastructure/persistance/InMemoryTemporalFileMetadataCollection.ts
@@ -47,6 +47,10 @@ export class InMemoryTemporalFileMetadataCollection
   }
 
   exists(pathToCheck: string): boolean {
+    return this.get(pathToCheck) ? true : false;
+  }
+
+  existsByLastPath(pathToCheck: string): boolean {
     let exists = false;
     Object.keys(this.collection).forEach((path) => {
       if (exists) return;
@@ -63,15 +67,11 @@ export class InMemoryTemporalFileMetadataCollection
     return exists;
   }
 
-  get(pathToCheck: string): ItemMetadata | undefined {
+  getByLastPath(pathToCheck: string): ItemMetadata | undefined {
     let match: ItemMetadata | undefined = undefined;
     Object.keys(this.collection).forEach((path) => {
       if (match) return;
       const item = this.collection[path];
-
-      if (pathToCheck === path) {
-        match = item;
-      }
 
       if (item.lastPath && item.lastPath === pathToCheck) {
         match = item;
@@ -79,6 +79,10 @@ export class InMemoryTemporalFileMetadataCollection
     });
 
     return match;
+  }
+
+  get(pathToCheck: string): ItemMetadata | undefined {
+    return this.collection[pathToCheck];
   }
 
   getAll() {

--- a/src/workers/webdav/modules/files/test/__mocks__/WebdavFileRepositoyMock.ts
+++ b/src/workers/webdav/modules/files/test/__mocks__/WebdavFileRepositoyMock.ts
@@ -10,7 +10,7 @@ export class WebdavFileRepositoryMock implements WebdavFileRepository {
   public mockUpdateName = jest.fn();
   public mockUpdateParentDir = jest.fn();
   public mockSearchOnFolder = jest.fn();
-
+  public mockRunRemoteSync = jest.fn();
   search(pathLike: FilePath): Nullable<WebdavFile> {
     return this.mockSearch(pathLike);
   }
@@ -32,6 +32,10 @@ export class WebdavFileRepositoryMock implements WebdavFileRepository {
 
   searchOnFolder(folderId: number): Promise<Array<WebdavFile>> {
     return this.mockSearchOnFolder(folderId);
+  }
+
+  async runRemoteSync(): Promise<void> {
+    return this.mockRunRemoteSync();
   }
 
   clearMocks() {

--- a/src/workers/webdav/modules/files/test/application/WebdavFileMover.test.ts
+++ b/src/workers/webdav/modules/files/test/application/WebdavFileMover.test.ts
@@ -10,6 +10,7 @@ import { FilePath } from '../../domain/FilePath';
 import { WebdavIpcMock } from '../../../shared/test/__mock__/WebdavIPC';
 import { WebdavFileRenamer } from '../../application/WebdavFileRenamer';
 import { FileContentRepositoryMock } from '../__mocks__/FileContentRepositoryMock';
+import { InMemoryItemsMock } from '../../../items/test/__mocks__/InMemoryItemsMock';
 
 describe('Webdav File Mover', () => {
   let repository: WebdavFileRepositoryMock;
@@ -19,7 +20,7 @@ describe('Webdav File Mover', () => {
   let contentsRepository: FileContentRepositoryMock;
   let eventBus: EventBusMock;
   let ipc: WebdavIpcMock;
-
+  let inMemoryItems: InMemoryItemsMock;
   let SUT: WebdavFileMover;
 
   beforeEach(() => {
@@ -29,12 +30,13 @@ describe('Webdav File Mover', () => {
     contentsRepository = new FileContentRepositoryMock();
     eventBus = new EventBusMock();
     ipc = new WebdavIpcMock();
-
+    inMemoryItems = new InMemoryItemsMock();
     fileRenamer = new WebdavFileRenamer(
       repository,
       contentsRepository,
       eventBus,
-      ipc
+      ipc,
+      inMemoryItems
     );
 
     SUT = new WebdavFileMover(
@@ -42,7 +44,8 @@ describe('Webdav File Mover', () => {
       folderFinder,
       fileRenamer,
       eventBus,
-      ipc
+      ipc,
+      inMemoryItems
     );
   });
 

--- a/src/workers/webdav/modules/files/test/application/WebdavFileRenamer.test.ts
+++ b/src/workers/webdav/modules/files/test/application/WebdavFileRenamer.test.ts
@@ -6,11 +6,13 @@ import { WebdavFileMother } from '../domain/WebdavFileMother';
 import { FileContentRepositoryMock } from '../__mocks__/FileContentRepositoryMock';
 import { WebdavFileRepositoryMock } from '../__mocks__/WebdavFileRepositoyMock';
 import { WebdavIpcMock } from '../../../shared/test/__mock__/WebdavIPC';
+import { InMemoryItemsMock } from '../../../items/test/__mocks__/InMemoryItemsMock';
 
 describe('File Rename', () => {
   let repository: WebdavFileRepositoryMock;
   let contentsRepository: FileContentRepositoryMock;
   let eventBus: EventBusMock;
+  let inMemoryItems: InMemoryItemsMock;
   let ipc: WebdavIpcMock;
   let SUT: WebdavFileRenamer;
 
@@ -19,7 +21,14 @@ describe('File Rename', () => {
     contentsRepository = new FileContentRepositoryMock();
     eventBus = new EventBusMock();
     ipc = new WebdavIpcMock();
-    SUT = new WebdavFileRenamer(repository, contentsRepository, eventBus, ipc);
+    inMemoryItems = new InMemoryItemsMock();
+    SUT = new WebdavFileRenamer(
+      repository,
+      contentsRepository,
+      eventBus,
+      ipc,
+      inMemoryItems
+    );
   });
 
   it('when the extension does not changes it updates the name of the file', async () => {

--- a/src/workers/webdav/modules/files/test/infrastructure/persistance/HttpWebdavFileRepository.test.ts
+++ b/src/workers/webdav/modules/files/test/infrastructure/persistance/HttpWebdavFileRepository.test.ts
@@ -7,7 +7,8 @@ import { ServerFileMother } from './ServerFileMother';
 import { ServerFolderMother } from '../../../../items/test/persistance/ServerFolderMother';
 import { WebdavFile } from '../../../domain/WebdavFile';
 import { fakeDecryptor } from '../../../../shared/test/domain/FakeCrypt';
-
+import { InMemoryItemsMock } from '../../../../items/test/__mocks__/InMemoryItemsMock';
+import Logger from 'electron-log';
 jest.mock('axios');
 
 const rootFolderId = 31420;
@@ -20,11 +21,12 @@ const rootFolder = ServerFolderMother.fromPartial({
 describe('Http File Repository', () => {
   let traverser: Traverser;
   let ipc: WebdavIpcMock;
+  let inMemoryItems: InMemoryItemsMock;
   let SUT: HttpWebdavFileRepository;
 
   beforeEach(() => {
     traverser = new Traverser(fakeDecryptor, rootFolderId);
-
+    inMemoryItems = new InMemoryItemsMock();
     ipc = new WebdavIpcMock();
 
     SUT = new HttpWebdavFileRepository(
@@ -33,7 +35,8 @@ describe('Http File Repository', () => {
       axios,
       traverser,
       'bucket',
-      ipc
+      ipc,
+      inMemoryItems
     );
   });
 
@@ -63,11 +66,11 @@ describe('Http File Repository', () => {
 
       fileSearchedBeforeRename.rename(new FilePath('/aa'));
 
+      Logger.info('File after', fileSearchedBeforeRename);
       await SUT.updateName(fileSearchedBeforeRename);
 
-      const fileSearchedAfterRename = SUT.search(new FilePath('/a'));
-
-      expect(fileSearchedAfterRename).not.toBeDefined();
+      expect(fileSearchedBeforeRename.lastPath?.value).toBe('/a');
+      expect(fileSearchedBeforeRename.path.value).toBe('/aa');
     });
   });
 });

--- a/src/workers/webdav/modules/folders/application/WebdavFolderCreator.ts
+++ b/src/workers/webdav/modules/folders/application/WebdavFolderCreator.ts
@@ -1,3 +1,5 @@
+import { InMemoryTemporalFileMetadataCollection } from '../../files/infrastructure/persistance/InMemoryTemporalFileMetadataCollection';
+import { ItemMetadata } from '../../shared/domain/ItemMetadata';
 import { FolderPath } from '../domain/FolderPath';
 import { WebdavFolderRepository } from '../domain/WebdavFolderRepository';
 import { WebdavFolderFinder } from './WebdavFolderFinder';
@@ -5,14 +7,42 @@ import { WebdavFolderFinder } from './WebdavFolderFinder';
 export class WebdavFolderCreator {
   constructor(
     private readonly repository: WebdavFolderRepository,
-    private readonly folderFinder: WebdavFolderFinder
+    private readonly folderFinder: WebdavFolderFinder,
+    private readonly inMemoryItems: InMemoryTemporalFileMetadataCollection
   ) {}
 
   async run(path: string): Promise<void> {
     const folderPath = new FolderPath(path);
+    try {
+      const parent = this.folderFinder.run(folderPath.dirname());
 
-    const parent = this.folderFinder.run(folderPath.dirname());
+      this.inMemoryItems.add(
+        folderPath.value,
+        ItemMetadata.from({
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          name: folderPath.name(),
+          size: 0,
+          extension: '',
+          type: 'FOLDER',
+          visible: true,
+          externalMetadata: {
+            parentId: parent.id,
+          },
+        })
+      );
 
-    await this.repository.create(folderPath, parent.id);
+      const folder = await this.repository.create(folderPath, parent.id);
+
+      this.inMemoryItems.update(folderPath.value, {
+        externalMetadata: {
+          id: folder.id,
+          parentId: folder.parentId,
+        },
+      });
+    } catch (error) {
+      this.inMemoryItems.remove(folderPath.value);
+      throw error;
+    }
   }
 }

--- a/src/workers/webdav/modules/folders/application/WebdavFolderCreator.ts
+++ b/src/workers/webdav/modules/folders/application/WebdavFolderCreator.ts
@@ -3,7 +3,7 @@ import { ItemMetadata } from '../../shared/domain/ItemMetadata';
 import { FolderPath } from '../domain/FolderPath';
 import { WebdavFolderRepository } from '../domain/WebdavFolderRepository';
 import { WebdavFolderFinder } from './WebdavFolderFinder';
-
+import Logger from 'electron-log';
 export class WebdavFolderCreator {
   constructor(
     private readonly repository: WebdavFolderRepository,
@@ -40,7 +40,10 @@ export class WebdavFolderCreator {
           parentId: folder.parentId,
         },
       });
+
+      await this.repository.runRemoteSync();
     } catch (error) {
+      Logger.error('Error creating folder: ', error);
       this.inMemoryItems.remove(folderPath.value);
       throw error;
     }

--- a/src/workers/webdav/modules/folders/application/WebdavFolderDeleter.ts
+++ b/src/workers/webdav/modules/folders/application/WebdavFolderDeleter.ts
@@ -1,4 +1,4 @@
-import { InMemoryTemporalFileMetadataCollection } from '../../files/infrastructure/persistance/InMemoryTemporalFileMetadataCollection';
+import { FileMetadataCollection } from '../../files/domain/FileMetadataCollection';
 import { ItemMetadata } from '../../shared/domain/ItemMetadata';
 import { WebdavFolder } from '../domain/WebdavFolder';
 import { WebdavFolderRepository } from '../domain/WebdavFolderRepository';
@@ -6,7 +6,7 @@ import { WebdavFolderRepository } from '../domain/WebdavFolderRepository';
 export class WebdavFolderDeleter {
   constructor(
     private readonly repository: WebdavFolderRepository,
-    private readonly inMemoryItems: InMemoryTemporalFileMetadataCollection
+    private readonly inMemoryItems: FileMetadataCollection
   ) {}
 
   async run(folder: WebdavFolder): Promise<void> {
@@ -21,6 +21,7 @@ export class WebdavFolderDeleter {
         visible: false,
       });
       await this.repository.trash(folder);
+      this.repository.runRemoteSync();
     } catch (error) {
       this.inMemoryItems.remove(folder.path.value);
       throw error;

--- a/src/workers/webdav/modules/folders/application/WebdavFolderDeleter.ts
+++ b/src/workers/webdav/modules/folders/application/WebdavFolderDeleter.ts
@@ -1,11 +1,29 @@
+import { InMemoryTemporalFileMetadataCollection } from '../../files/infrastructure/persistance/InMemoryTemporalFileMetadataCollection';
+import { ItemMetadata } from '../../shared/domain/ItemMetadata';
 import { WebdavFolder } from '../domain/WebdavFolder';
 import { WebdavFolderRepository } from '../domain/WebdavFolderRepository';
 
 export class WebdavFolderDeleter {
-  constructor(private readonly repository: WebdavFolderRepository) {}
+  constructor(
+    private readonly repository: WebdavFolderRepository,
+    private readonly inMemoryItems: InMemoryTemporalFileMetadataCollection
+  ) {}
 
   async run(folder: WebdavFolder): Promise<void> {
-    folder.trash();
-    await this.repository.trash(folder);
+    try {
+      this.inMemoryItems.add(
+        folder.path.value,
+        ItemMetadata.extractFromFolder(folder)
+      );
+
+      folder.trash();
+      this.inMemoryItems.update(folder.path.value, {
+        visible: false,
+      });
+      await this.repository.trash(folder);
+    } catch (error) {
+      this.inMemoryItems.remove(folder.path.value);
+      throw error;
+    }
   }
 }

--- a/src/workers/webdav/modules/folders/application/WebdavFolderMover.ts
+++ b/src/workers/webdav/modules/folders/application/WebdavFolderMover.ts
@@ -1,3 +1,5 @@
+import { FileMetadataCollection } from '../../files/domain/FileMetadataCollection';
+import { ItemMetadata } from '../../shared/domain/ItemMetadata';
 import { ActionNotPermitedError } from '../domain/errors/ActionNotPermitedError';
 import { FolderPath } from '../domain/FolderPath';
 import { WebdavFolder } from '../domain/WebdavFolder';
@@ -9,7 +11,8 @@ export class WebdavFolderMover {
   constructor(
     private readonly repository: WebdavFolderRepository,
     private readonly folderFinder: WebdavFolderFinder,
-    private readonly folderRenamer: WebdavFolderRenamer
+    private readonly folderRenamer: WebdavFolderRenamer,
+    private readonly inMemoryItems: FileMetadataCollection
   ) {}
 
   private async move(folder: WebdavFolder, parentFolder: WebdavFolder) {
@@ -20,21 +23,44 @@ export class WebdavFolderMover {
 
   async run(folder: WebdavFolder, to: string): Promise<void> {
     const destination = new FolderPath(to);
-    const resultFolder = this.repository.search(destination.value);
+    try {
+      const resultFolder = this.repository.search(destination.value);
 
-    const shouldBeMerge = resultFolder !== undefined;
+      const shouldBeMerge = resultFolder !== undefined;
 
-    if (shouldBeMerge) {
-      throw new ActionNotPermitedError('overwrite');
+      if (shouldBeMerge) {
+        throw new ActionNotPermitedError('overwrite');
+      }
+
+      const destinationFolder = this.folderFinder.run(destination.dirname());
+
+      if (folder.isIn(destinationFolder)) {
+        await this.folderRenamer.run(folder, to);
+        await this.repository.runRemoteSync();
+        return;
+      }
+      this.inMemoryItems.add(
+        destination.value,
+        ItemMetadata.from({
+          createdAt: folder.createdAt.getTime(),
+          updatedAt: folder.updatedAt.getTime(),
+          name: folder.name,
+          size: folder.size,
+          extension: '',
+          type: 'FOLDER',
+          visible: true,
+          lastPath: folder.path.value,
+          externalMetadata: {
+            parentId: destinationFolder.id,
+            folderId: folder.id,
+          },
+        })
+      );
+      await this.move(folder, destinationFolder);
+      await this.repository.runRemoteSync();
+    } catch (error) {
+      this.inMemoryItems.remove(destination.value);
+      throw error;
     }
-
-    const destinationFolder = this.folderFinder.run(destination.dirname());
-
-    if (folder.isIn(destinationFolder)) {
-      await this.folderRenamer.run(folder, to);
-      return;
-    }
-
-    await this.move(folder, destinationFolder);
   }
 }

--- a/src/workers/webdav/modules/folders/application/WebdavFolderRenamer.ts
+++ b/src/workers/webdav/modules/folders/application/WebdavFolderRenamer.ts
@@ -1,15 +1,29 @@
+import { InMemoryTemporalFileMetadataCollection } from '../../files/infrastructure/persistance/InMemoryTemporalFileMetadataCollection';
+import { ItemMetadata } from '../../shared/domain/ItemMetadata';
 import { FolderPath } from '../domain/FolderPath';
 import { WebdavFolder } from '../domain/WebdavFolder';
 import { WebdavFolderRepository } from '../domain/WebdavFolderRepository';
-
 export class WebdavFolderRenamer {
-  constructor(private readonly repository: WebdavFolderRepository) {}
+  constructor(
+    private readonly repository: WebdavFolderRepository,
+    private readonly inMemoryItems: InMemoryTemporalFileMetadataCollection
+  ) {}
 
   async run(folder: WebdavFolder, destination: string) {
     const path = new FolderPath(destination);
+    try {
+      this.inMemoryItems.remove(folder.path.value);
 
-    folder.rename(path);
+      folder.rename(path);
 
-    await this.repository.updateName(folder);
+      this.inMemoryItems.add(
+        path.value,
+        ItemMetadata.extractFromFolder(folder)
+      );
+      await this.repository.updateName(folder);
+    } catch (error) {
+      this.inMemoryItems.remove(path.value);
+      throw error;
+    }
   }
 }

--- a/src/workers/webdav/modules/folders/application/WebdavFolderRenamer.ts
+++ b/src/workers/webdav/modules/folders/application/WebdavFolderRenamer.ts
@@ -1,4 +1,4 @@
-import { InMemoryTemporalFileMetadataCollection } from '../../files/infrastructure/persistance/InMemoryTemporalFileMetadataCollection';
+import { FileMetadataCollection } from '../../files/domain/FileMetadataCollection';
 import { ItemMetadata } from '../../shared/domain/ItemMetadata';
 import { FolderPath } from '../domain/FolderPath';
 import { WebdavFolder } from '../domain/WebdavFolder';
@@ -6,7 +6,7 @@ import { WebdavFolderRepository } from '../domain/WebdavFolderRepository';
 export class WebdavFolderRenamer {
   constructor(
     private readonly repository: WebdavFolderRepository,
-    private readonly inMemoryItems: InMemoryTemporalFileMetadataCollection
+    private readonly inMemoryItems: FileMetadataCollection
   ) {}
 
   async run(folder: WebdavFolder, destination: string) {
@@ -20,7 +20,9 @@ export class WebdavFolderRenamer {
         path.value,
         ItemMetadata.extractFromFolder(folder)
       );
+
       await this.repository.updateName(folder);
+      await this.repository.runRemoteSync();
     } catch (error) {
       this.inMemoryItems.remove(path.value);
       throw error;

--- a/src/workers/webdav/modules/folders/domain/WebdavFolderRepository.ts
+++ b/src/workers/webdav/modules/folders/domain/WebdavFolderRepository.ts
@@ -17,4 +17,6 @@ export interface WebdavFolderRepository {
   searchOn(folder: WebdavFolder): Promise<Array<WebdavFolder>>;
 
   trash(folder: WebdavFolder): Promise<void>;
+
+  runRemoteSync(): Promise<void>;
 }

--- a/src/workers/webdav/modules/folders/infrastructure/HttpWebdavFolderRepository.ts
+++ b/src/workers/webdav/modules/folders/infrastructure/HttpWebdavFolderRepository.ts
@@ -37,7 +37,8 @@ export class HttpWebdavFolderRepository implements WebdavFolderRepository {
     path: string,
     serverFolder: WebdavFolder
   ) {
-    const inMemoryFolder = this.inMemoryItems.get(path);
+    const inMemoryFolder =
+      this.inMemoryItems.get(path) || this.inMemoryItems.getByLastPath(path);
 
     const keepInMemoryItem = inMemoryFolder?.visible === false;
 
@@ -70,7 +71,9 @@ export class HttpWebdavFolderRepository implements WebdavFolderRepository {
 
       const serverFolders = folders.reduce((items, [path, value]) => {
         this.cleanInMemoryFolderIfNeeded(path, value);
-        const existsInMemory = this.inMemoryItems.exists(path);
+        const existsInMemory =
+          this.inMemoryItems.exists(path) ||
+          this.inMemoryItems.existsByLastPath(path);
         if (existsInMemory) {
           return items;
         }

--- a/src/workers/webdav/modules/folders/infrastructure/HttpWebdavFolderRepository.ts
+++ b/src/workers/webdav/modules/folders/infrastructure/HttpWebdavFolderRepository.ts
@@ -71,6 +71,7 @@ export class HttpWebdavFolderRepository implements WebdavFolderRepository {
 
       const serverFolders = folders.reduce((items, [path, value]) => {
         this.cleanInMemoryFolderIfNeeded(path, value);
+
         const existsInMemory =
           this.inMemoryItems.exists(path) ||
           this.inMemoryItems.existsByLastPath(path);

--- a/src/workers/webdav/modules/folders/infrastructure/HttpWebdavFolderRepository.ts
+++ b/src/workers/webdav/modules/folders/infrastructure/HttpWebdavFolderRepository.ts
@@ -12,7 +12,7 @@ import { UpdateFolderNameDTO } from './dtos/UpdateFolderNameDTO';
 import { WebdavIpc } from '../../../ipc';
 import { RemoteItemsGenerator } from '../../items/application/RemoteItemsGenerator';
 import { FolderStatuses } from '../domain/FolderStatus';
-import { InMemoryTemporalFileMetadataCollection } from '../../files/infrastructure/persistance/InMemoryTemporalFileMetadataCollection';
+import { FileMetadataCollection } from '../../files/domain/FileMetadataCollection';
 
 export class HttpWebdavFolderRepository implements WebdavFolderRepository {
   private folders: Record<string, WebdavFolder> = {};
@@ -22,7 +22,7 @@ export class HttpWebdavFolderRepository implements WebdavFolderRepository {
     private readonly trashClient: Axios,
     private readonly traverser: Traverser,
     private readonly ipc: WebdavIpc,
-    private readonly inMemoryItems: InMemoryTemporalFileMetadataCollection
+    private readonly inMemoryItems: FileMetadataCollection
   ) {}
 
   private async getTree(): Promise<{
@@ -207,5 +207,9 @@ export class HttpWebdavFolderRepository implements WebdavFolderRepository {
       result.status,
       result.statusText
     );
+  }
+
+  async runRemoteSync() {
+    await this.ipc.invoke('START_REMOTE_SYNC');
   }
 }

--- a/src/workers/webdav/modules/folders/test/__mocks__/WebdavFolderRepositoryMock.ts
+++ b/src/workers/webdav/modules/folders/test/__mocks__/WebdavFolderRepositoryMock.ts
@@ -11,6 +11,7 @@ export class WebdavFolderRepositoryMock implements WebdavFolderRepository {
   public mockCreate = jest.fn();
   public mockSearchOnFolder = jest.fn();
   public mockTrash = jest.fn();
+  public mockRunRemoteSync = jest.fn();
 
   search(pathLike: string): Nullable<WebdavFolder> {
     return this.mockSearch(pathLike);
@@ -38,6 +39,10 @@ export class WebdavFolderRepositoryMock implements WebdavFolderRepository {
 
   trash(folder: WebdavFolder): Promise<void> {
     return this.mockTrash(folder);
+  }
+
+  async runRemoteSync(): Promise<void> {
+    return this.mockRunRemoteSync();
   }
 
   clearMocks() {

--- a/src/workers/webdav/modules/folders/test/application/WebdavFolderDeleter.test.ts
+++ b/src/workers/webdav/modules/folders/test/application/WebdavFolderDeleter.test.ts
@@ -2,14 +2,17 @@ import { WebdavFolderDeleter } from '../../application/WebdavFolderDeleter';
 import { FolderStatus } from '../../domain/FolderStatus';
 import { WebdavFolderMother } from '../domain/WebdavFolderMother';
 import { WebdavFolderRepositoryMock } from '../__mocks__/WebdavFolderRepositoryMock';
+import { InMemoryItemsMock } from '../../../items/test/__mocks__/InMemoryItemsMock';
 
 describe('Folder deleter', () => {
   let repository: WebdavFolderRepositoryMock;
+  let inMemoryItems: InMemoryItemsMock;
   let SUT: WebdavFolderDeleter;
 
   beforeEach(() => {
     repository = new WebdavFolderRepositoryMock();
-    SUT = new WebdavFolderDeleter(repository);
+    inMemoryItems = new InMemoryItemsMock();
+    SUT = new WebdavFolderDeleter(repository, inMemoryItems);
   });
 
   it('trashes an existing folder', () => {

--- a/src/workers/webdav/modules/folders/test/application/WebdavFolderMover.test.ts
+++ b/src/workers/webdav/modules/folders/test/application/WebdavFolderMover.test.ts
@@ -3,18 +3,26 @@ import { WebdavFolderMover } from '../../application/WebdavFolderMover';
 import { WebdavFolderRenamer } from '../../application/WebdavFolderRenamer';
 import { WebdavFolderMother } from '../domain/WebdavFolderMother';
 import { WebdavFolderRepositoryMock } from '../__mocks__/WebdavFolderRepositoryMock';
+import { InMemoryItemsMock } from '../../../items/test/__mocks__/InMemoryItemsMock';
 
 describe('Folder Mover', () => {
   let repository: WebdavFolderRepositoryMock;
   let folderFinder: WebdavFolderFinder;
   let folderRenamer: WebdavFolderRenamer;
+  let inMemoryItems: InMemoryItemsMock;
   let SUT: WebdavFolderMover;
 
   beforeEach(() => {
     repository = new WebdavFolderRepositoryMock();
     folderFinder = new WebdavFolderFinder(repository);
-    folderRenamer = new WebdavFolderRenamer(repository);
-    SUT = new WebdavFolderMover(repository, folderFinder, folderRenamer);
+    folderRenamer = new WebdavFolderRenamer(repository, inMemoryItems);
+    inMemoryItems = new InMemoryItemsMock();
+    SUT = new WebdavFolderMover(
+      repository,
+      folderFinder,
+      folderRenamer,
+      inMemoryItems
+    );
   });
 
   it('Folders cannot be ovewrited', async () => {

--- a/src/workers/webdav/modules/folders/test/infrastructure/HttpWebdavFolderRepository.test.ts
+++ b/src/workers/webdav/modules/folders/test/infrastructure/HttpWebdavFolderRepository.test.ts
@@ -5,6 +5,8 @@ import { HttpWebdavFolderRepository } from '../../infrastructure/HttpWebdavFolde
 import { fakeDecryptor } from '../../../shared/test/domain/FakeCrypt';
 import { WebdavIpcMock } from '../../../shared/test/__mock__/WebdavIPC';
 import { ServerFolderMother } from '../../../items/test/persistance/ServerFolderMother';
+import { FileMetadataCollection } from '../../../files/domain/FileMetadataCollection';
+import { InMemoryItemsMock } from '../../../items/test/__mocks__/InMemoryItemsMock';
 
 jest.mock('axios');
 
@@ -12,15 +14,22 @@ const rootFolderId = 4206870830;
 
 describe('Http Folder Repository', () => {
   let ipc: WebdavIpcMock;
+  let inMemoryItems: FileMetadataCollection;
   let SUT: HttpWebdavFolderRepository;
 
   describe('save', () => {
     beforeEach(() => {
       const traverser = new Traverser(fakeDecryptor, rootFolderId);
-
+      inMemoryItems = new InMemoryItemsMock();
       ipc = new WebdavIpcMock();
 
-      SUT = new HttpWebdavFolderRepository(axios, axios, traverser, ipc);
+      SUT = new HttpWebdavFolderRepository(
+        axios,
+        axios,
+        traverser,
+        ipc,
+        inMemoryItems
+      );
     });
 
     it.skip('after a folder is saved it has to have all its properties set', async () => {

--- a/src/workers/webdav/modules/items/test/__mocks__/InMemoryItemsMock.ts
+++ b/src/workers/webdav/modules/items/test/__mocks__/InMemoryItemsMock.ts
@@ -1,0 +1,43 @@
+import { FileMetadataCollection } from 'workers/webdav/modules/files/domain/FileMetadataCollection';
+import { ItemMetadata } from '../../../shared/domain/ItemMetadata';
+
+export class InMemoryItemsMock implements FileMetadataCollection {
+  public mockSearch = jest.fn();
+  public mockAdd = jest.fn();
+  public mockUpdate = jest.fn();
+  public mockRemove = jest.fn();
+  public mockExists = jest.fn();
+  public mockExistsByLastPath = jest.fn();
+  public mockGet = jest.fn();
+  public mockGetByLastPath = jest.fn();
+  public mockGetAll = jest.fn(() => ({}));
+  public mockGetAllByType = jest.fn((_: string) => ({}));
+
+  add(path: string, metadata: ItemMetadata): void {
+    return this.mockSearch(path, metadata);
+  }
+  update(path: string, metadata: Partial<ItemMetadata>): ItemMetadata | null {
+    return this.mockUpdate(path, metadata);
+  }
+  remove(path: string): void {
+    return this.mockRemove(path);
+  }
+  exists(pathToCheck: string): boolean {
+    return this.mockExists(pathToCheck);
+  }
+  existsByLastPath(pathToCheck: string): boolean {
+    return this.mockExistsByLastPath(pathToCheck);
+  }
+  getByLastPath(pathToCheck: string): ItemMetadata | undefined {
+    return this.mockGetByLastPath(pathToCheck);
+  }
+  get(pathToCheck: string): ItemMetadata | undefined {
+    return this.mockGet(pathToCheck);
+  }
+  getAll(): Record<string, ItemMetadata> {
+    return this.mockGetAll();
+  }
+  getAllByType(type: 'FILE' | 'FOLDER'): Record<string, ItemMetadata> {
+    return this.mockGetAllByType(type);
+  }
+}

--- a/src/workers/webdav/modules/shared/domain/ItemMetadata.ts
+++ b/src/workers/webdav/modules/shared/domain/ItemMetadata.ts
@@ -8,6 +8,14 @@ export type ItemMetadataAtributes = {
   size: number;
   extension: string;
   type: 'FILE' | 'FOLDER';
+  visible: boolean;
+  lastPath?: string;
+  externalMetadata: Partial<{
+    id: number;
+    parentId: number | null;
+    folderId: number;
+    fileId: string;
+  }>;
 };
 
 export class ItemMetadata {
@@ -17,7 +25,10 @@ export class ItemMetadata {
     readonly name: string,
     readonly size: number,
     readonly extension: string,
-    readonly type: 'FILE' | 'FOLDER'
+    readonly type: 'FILE' | 'FOLDER',
+    readonly visible: boolean,
+    readonly lastPath?: string,
+    readonly externalMetadata?: ItemMetadataAtributes['externalMetadata']
   ) {}
 
   static from(atributes: ItemMetadataAtributes): ItemMetadata {
@@ -27,7 +38,10 @@ export class ItemMetadata {
       atributes.name,
       atributes.size,
       atributes.extension,
-      atributes.type
+      atributes.type,
+      atributes.visible,
+      atributes.lastPath,
+      atributes.externalMetadata
     );
   }
 
@@ -38,7 +52,13 @@ export class ItemMetadata {
       file.nameWithExtension,
       file.size,
       file.type,
-      'FILE'
+      'FILE',
+      true,
+      file.lastPath?.value ?? undefined,
+      {
+        fileId: file.fileId,
+        folderId: file.folderId,
+      }
     );
   }
 
@@ -49,7 +69,13 @@ export class ItemMetadata {
       folder.name,
       folder.size,
       '',
-      'FOLDER'
+      'FOLDER',
+      true,
+      folder.lastPath?.value ?? undefined,
+      {
+        id: folder.id,
+        parentId: folder.parentId,
+      }
     );
   }
 }

--- a/src/workers/webdav/worker/InternxtFileSystem/InternxtFileSystem.ts
+++ b/src/workers/webdav/worker/InternxtFileSystem/InternxtFileSystem.ts
@@ -158,7 +158,10 @@ export class InternxtFileSystem extends FileSystem {
     if (item.isFolder()) {
       this.container.folderDeleter
         .run(item)
-        .then(() => callback())
+        .then(() => {
+          delete this.resources[item.path.value];
+          callback();
+        })
         .catch((error: Error) => {
           handleFileSystemError(error, 'Delete', 'Folder', ctx);
           callback(error);

--- a/src/workers/webdav/worker/InternxtStorageManager/InternxtStorageManager.ts
+++ b/src/workers/webdav/worker/InternxtStorageManager/InternxtStorageManager.ts
@@ -7,7 +7,7 @@ import {
   RequestContext,
   ResourcePropertyValue,
   ResourceType,
-} from 'webdav-server/lib/index.v2';
+} from '@internxt/webdav-server';
 import Logger from 'electron-log';
 import { DependencyContainer } from '../../dependencyInjection/DependencyContainer';
 
@@ -61,8 +61,8 @@ export class InternxtStorageManager implements IStorageManager {
       .then((space) => {
         callback(space);
       })
-      .catch(() => {
-        Logger.error('Error getting avaliable space');
+      .catch((error) => {
+        Logger.error('Error getting avaliable space: ', error);
         callback(0);
       });
   }


### PR DESCRIPTION
This system allow us to provide a faster feedback in the UI

**How**

When we perform an operation such a file rename, we first create an in memory renamed file, then we perform the actual HTTP operation, once we receive the HTTP operation result, we either rollback to the previous state if it failed, or we remove the in memory item and replace it with the local db one

**Why**

If we are going to aim to provide an almost native experience, we need to provide fast feedback to the user, otherwise this won't feel like the user is navigating though the OS filesystem. If we depend on the server latency to provide feedback, and the server is facing some slowness, we are going to pass that slowness to the UI feedback which is not a nice UX

**Corner cases**

Could be possible that if we perform an optimistic operation such folder creation, the user tries to perform an action under that optimistic folder, since the folder doesn't exist yet, the operation will fail.