### PR TITLE
[PB-705]: Refresh folder after notification event

### DIFF
--- a/src/main/realtime.ts
+++ b/src/main/realtime.ts
@@ -17,7 +17,7 @@ function cleanAndStartRemoteNotifications() {
   socket = io(process.env.NOTIFICATIONS_URL, {
     transports: ['websocket'],
     auth: {
-      token: obtainToken('bearerToken'),
+      token: obtainToken('newToken'),
     },
     withCredentials: true,
   });


### PR DESCRIPTION
- Connect to notifications server with newToken (drive-server is now fixed)