### PR TITLE
[PB-604]: Feat/Show "Virtual Drive" instead of localhost

### DIFF
--- a/src/workers/webdav/VirtualDrive.ts
+++ b/src/workers/webdav/VirtualDrive.ts
@@ -10,7 +10,7 @@ export enum VirtualDriveStatus {
   UNMOUNTED = 'UNMOUNTED',
 }
 const driveObject = {
-  host: 'localhost',
+  host: 'Virtual.Drive.Internxt.com',
   port: '1900',
 };
 const driveURL = `http://${driveObject.host}:${driveObject.port}`;

--- a/src/workers/webdav/worker/server.ts
+++ b/src/workers/webdav/worker/server.ts
@@ -19,7 +19,7 @@ export class InternxtWebdavServer {
     storageManager?: IStorageManager
   ) {
     this.server = new WebDAVServer({
-      hostname: 'localhost',
+      hostname: 'virtual.drive.internxt.com',
       port,
       requireAuthentification: false,
       storageManager: storageManager,

--- a/src/workers/webdav/worker/server.ts
+++ b/src/workers/webdav/worker/server.ts
@@ -19,7 +19,7 @@ export class InternxtWebdavServer {
     storageManager?: IStorageManager
   ) {
     this.server = new WebDAVServer({
-      hostname: 'virtual.drive.internxt.com',
+      hostname: 'Virtual.Drive.Internxt.com',
       port,
       requireAuthentification: false,
       storageManager: storageManager,


### PR DESCRIPTION
- Server is now created with the hostname 'Virtual.Drive.Internxt.com' which points to localhost ip. It's a temporary solution to the Finder name problem while we find another better solution