### PR TITLE
[PB-708]:(fix) Store files in tmp directory before upload

### DIFF
--- a/src/workers/webdav/worker/InternxtFileSystem/InternxtFileSystem.ts
+++ b/src/workers/webdav/worker/InternxtFileSystem/InternxtFileSystem.ts
@@ -177,8 +177,8 @@ export class InternxtFileSystem extends FileSystem {
     }
 
     this.container.fileCreator
-      .run(path.toString(false), ctx.estimatedSize)
-      .then(({ stream }: { stream: Writable; upload: Promise<string> }) => {
+      .run(path.toString(false))
+      .then(({ stream }: { stream: Writable }) => {
         callback(undefined, stream);
       })
       .catch((error: Error) => {


### PR DESCRIPTION
On MacOS we don't receive the file size when opening a write stream since the Finder doesn't send it in the headers. This PR solves that problem by creating a tmp file which we later stat to get the real size