### PR TITLE
[_] fix: do not block exit if not runing

### DIFF
--- a/src/main/background-processes/sync-engine.ts
+++ b/src/main/background-processes/sync-engine.ts
@@ -4,6 +4,7 @@ import Logger from 'electron-log';
 import eventBus from '../event-bus';
 
 let worker: BrowserWindow | null = null;
+let workerIsRunning = false;
 
 function spawnSyncEngineWorker() {
   worker = new BrowserWindow({
@@ -31,9 +32,21 @@ function spawnSyncEngineWorker() {
     Logger.debug('[MAIN] SYNC ENGINE WORKER CLOSED');
     worker?.destroy();
   });
+
+  ipcMain.once('SYNC_ENGINE_PROCESS_SETUP_SUCCESSFUL', () => {
+    workerIsRunning = true;
+  });
+
+  ipcMain.once('SYNC_ENGINE_PROCESS_SETUP_FAILED', () => {
+    workerIsRunning = false;
+  });
 }
 
 export async function stopSyncEngineWatcher() {
+  if (!workerIsRunning) {
+    return;
+  }
+
   Logger.info('[MAIN] STOPING SYNC ENGINE WORKER...');
 
   const stopPromise = new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
***Context*** 
When we exit the app we need to stop the sync engine from watching the folder and we need to unregister the sync provider. Both of those tasks are done in the sync engine background process so we need to await a message from that process to know that it has been done. 

***Problem***
When the setup of the syn engine fails we cannot add the handler to stop the engine so when the main process tries to close it, it awaits a promise that will never be fulfilled.

***Proposed solution***
Communicate to the main process whether the setup of the sync engine has been successful or not to await the stop message when it has been successful.

Also changed the import of virtual drive dependency to a `require` so it can be part of the setup function since the build of node-win can be finicky 