### PR TITLE
[_] fix: login broke the app

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -41,7 +41,7 @@ import * as Sentry from '@sentry/electron/main';
 import { AppDataSource } from './database/data-source';
 import { getIsLoggedIn } from './auth/handlers';
 import {
-  createWidget,
+  getOrCreateWidged,
   getWidget,
   setBoundsOfWidgetByPath,
 } from './windows/widget';
@@ -115,9 +115,8 @@ eventBus.on('USER_LOGGED_IN', async () => {
 
     nativeTheme.themeSource = configStore.get('preferedTheme') as Theme;
 
-    await createWidget();
     setTrayStatus('STANDBY');
-    const widget = getWidget();
+    const widget = await getOrCreateWidged();
     const tray = getTray();
     if (widget && tray) {
       setBoundsOfWidgetByPath(widget, tray);
@@ -133,6 +132,7 @@ eventBus.on('USER_LOGGED_IN', async () => {
 
     setCleanUpFunction(stopSyncEngineWatcher);
   } catch (error) {
+    Logger.error(error);
     reportError(error as Error);
   }
 });


### PR DESCRIPTION
Fix from the 2.0.0-a03 version where after logging out and back in the app crashed. The problem seems to be that after logging out when the user logs back in 2 widgets were created