### PR TITLE
[🧪] run test on ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,9 @@ jobs:
         run: yarn --ignore-scripts
       - name: Lint
         run: yarn run lint
-      - name: Build process
+      - name: Build main process
         run: yarn build:main
+      - name: Build main process
+        run: yarn build:renderer
       - name: Run test
         run: yarn test:unit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,7 @@ jobs:
         run: yarn --ignore-scripts
       - name: Lint
         run: yarn run lint
+      - name: Build process
+        run: yarn build:main
       - name: Run test
         run: yarn test:unit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           # You have to use a PAT instead https://github.com/actions/setup-node/issues/49
           echo //npm.pkg.github.com/:_authToken=${{ secrets.PERSONAL_ACCESS_TOKEN }} >> .npmrc
           echo "always-auth=true" >> .npmrc
-      - name: Install dependenciies
+      - name: Install dependencies
         run: yarn --ignore-scripts
       - name: Lint
         run: yarn run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   test:
     name: 🧪 Lint and test
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - name: Check out Git repository
@@ -26,9 +26,7 @@ jobs:
         run: yarn --ignore-scripts
       - name: Lint
         run: yarn run lint
-      - name: Build main process
-        run: yarn build:main
-      - name: Build main process
-        run: yarn build:renderer
+      - name: Build processes
+        run: yarn build:main && yarn build:renderer
       - name: Run test
         run: yarn test:unit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,5 @@ jobs:
         run: yarn --ignore-scripts
       - name: Lint
         run: yarn run lint
-      - name: Build process
-        run: yarn build
       - name: Run test
         run: yarn test:unit

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "start:sync": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.sync.ts",
     "start:backups": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.backups.ts",
     "start:webdav": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.webdav.ts",
-    "setup-test": "concurrently \"npm run build:main\" \"npm run build:renderer\" \"npm run build:backups\" \"npm run build:webdav\"",
     "test": "jest && playwright test --config=src/test",
     "test:unit": "jest --silent",
     "test:e2e": "playwright test --config=src/test",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,9 @@
     "url": "https://github.com/internxt/drive-desktop"
   },
   "scripts": {
-    "build": "concurrently \"npm run build:main\" \"npm run build:renderer\" \"npm run build:sync\" \"npm run build:backups\" \"npm run build:webdav\"",
+    "build": "concurrently \"npm run build:main\" \"npm run build:renderer\" \"npm run build:backups\" \"npm run build:webdav\"",
     "build:main": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.main.prod.ts",
     "build:renderer": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.renderer.prod.ts",
-    "build:sync": "echo '-- WARNING --: Sync worker has been removed, skipping build'",
     "build:backups": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.backups.ts",
     "build:webdav": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.webdav.ts",
     "rebuild": "electron-rebuild --parallel --types prod,dev,optional --module-dir release/app",
@@ -26,6 +25,7 @@
     "start:sync": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.sync.ts",
     "start:backups": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.backups.ts",
     "start:webdav": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.webdav.ts",
+    "setup-test": "concurrently \"npm run build:main\" \"npm run build:renderer\" \"npm run build:backups\" \"npm run build:webdav\"",
     "test": "jest && playwright test --config=src/test",
     "test:unit": "jest --silent",
     "test:e2e": "playwright test --config=src/test",


### PR DESCRIPTION
Updates the test ci to run on Windows and changes the build to only build the main and renderer processes since node-win is installed from local machines