### PR TITLE
[_] chore: undo app type overwrite

### DIFF
--- a/src/main/app-info/service.ts
+++ b/src/main/app-info/service.ts
@@ -2,20 +2,17 @@ import { App, app } from 'electron';
 
 import { AvaliableMethods } from './AvaliableAppQuery';
 
-type OverridedApp = Omit<App, 'getPreferredSystemLanguages'> & {
-  getPreferredSystemLanguages: () => Array<string>;
-};
-
 export type AppQuery<T extends AvaliableMethods> = {
   method: string;
-  params: Parameters<OverridedApp[T]>;
+  params: Parameters<App[T]>;
 };
 
 export const executeQuery = ({
   method,
   params = [],
-}: AppQuery<AvaliableMethods>): ReturnType<OverridedApp[AvaliableMethods]> => {
-  const fn = (app as OverridedApp)[method as AvaliableMethods];
+}: AppQuery<AvaliableMethods>): ReturnType<App[AvaliableMethods]> => {
+  app.getPreferredSystemLanguages();
+  const fn = app[method as AvaliableMethods];
 
   return params.length === 0 ? fn() : fn(...params);
 };


### PR DESCRIPTION
https://github.com/electron/electron/pull/37821 solves the problem with the `getPreferredSystemLanguages` method signature. We no longer need to override it 