### PR TITLE
[_] fix: app crashes loading the localhost

### DIFF
--- a/src/main/background-processes/sync-engine.ts
+++ b/src/main/background-processes/sync-engine.ts
@@ -29,25 +29,29 @@ function spawnSyncEngineWorker() {
     });
 
   worker.on('close', () => {
-    Logger.debug('[MAIN] SYNC ENGINE WORKER CLOSED');
     worker?.destroy();
   });
 
-  ipcMain.once('SYNC_ENGINE_PROCESS_SETUP_SUCCESSFUL', () => {
+  ipcMain.on('SYNC_ENGINE_PROCESS_SETUP_SUCCESSFUL', () => {
+    Logger.debug('[MAIN] SYNC ENGINE RUNNIG');
     workerIsRunning = true;
   });
 
-  ipcMain.once('SYNC_ENGINE_PROCESS_SETUP_FAILED', () => {
+  ipcMain.on('SYNC_ENGINE_PROCESS_SETUP_FAILED', () => {
+    Logger.debug('[MAIN] SYNC ENGINE NOT RUNNIG');
     workerIsRunning = false;
   });
 }
 
 export async function stopSyncEngineWatcher() {
+  Logger.info('[MAIN] STOPING SYNC ENGINE WORKER...');
+
   if (!workerIsRunning) {
+    Logger.info('[MAIN] WORKER WAS NOT RUNNIG');
+    worker?.destroy();
+    worker = null;
     return;
   }
-
-  Logger.info('[MAIN] STOPING SYNC ENGINE WORKER...');
 
   const stopPromise = new Promise<void>((resolve, reject) => {
     ipcMain.once('SYNC_ENGINE_STOP_ERROR', (_, err: Error) => {
@@ -68,8 +72,10 @@ export async function stopSyncEngineWatcher() {
   } catch (err) {
     // TODO: handle error
     Logger.error(err);
+  } finally {
     worker?.destroy();
-    // no op
+    workerIsRunning = false;
+    worker = null;
   }
 }
 

--- a/src/main/background-processes/sync-engine.ts
+++ b/src/main/background-processes/sync-engine.ts
@@ -22,10 +22,10 @@ function spawnSyncEngineWorker() {
         : `${path.join(__dirname, '..', 'webdav')}/index.html`
     )
     .then(() => {
-      Logger.info('[MAIN] SYNC ENGINE WORKER LOADED');
+      Logger.info('[MAIN] Sync engine worker loaded');
     })
     .catch((err) => {
-      Logger.error('[MAIN] ERROR LOADING SYNC ENGINE WORKER', err);
+      Logger.error('[MAIN] Error loading sync engine worker', err);
     });
 
   worker.on('close', () => {
@@ -54,15 +54,25 @@ export async function stopSyncEngineWatcher() {
   }
 
   const stopPromise = new Promise<void>((resolve, reject) => {
-    ipcMain.once('SYNC_ENGINE_STOP_ERROR', (_, err: Error) => {
-      Logger.error('[MAIN] ERROR STOPING SYNC ENGINE WORKER', err);
-      reject();
+    ipcMain.once('SYNC_ENGINE_STOP_ERROR', (_, error: Error) => {
+      Logger.error('[MAIN] Error stoping sync engine worker', error);
+      reject(error);
     });
 
     ipcMain.once('SYNC_ENGINE_STOP_SUCCESS', () => {
       resolve();
-      Logger.info('[MAIN] SYNC ENGINE STOPPED');
+      Logger.info('[MAIN] Sync engine stopped');
     });
+
+    const millisecndsToWait = 10_000;
+
+    setTimeout(() => {
+      reject(
+        new Error(
+          `Timeout waiting for sync engien to stop after ${millisecndsToWait} milliseconds`
+        )
+      );
+    }, millisecndsToWait);
   });
 
   try {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -111,7 +111,6 @@ eventBus.on('USER_LOGGED_IN', async () => {
     if (!AppDataSource.isInitialized) {
       await AppDataSource.initialize();
     }
-    getAuthWindow()?.destroy();
 
     nativeTheme.themeSource = configStore.get('preferedTheme') as Theme;
 
@@ -121,6 +120,8 @@ eventBus.on('USER_LOGGED_IN', async () => {
     if (widget && tray) {
       setBoundsOfWidgetByPath(widget, tray);
     }
+
+    getAuthWindow()?.destroy();
 
     const lastOnboardingShown = configStore.get('lastOnboardingShown');
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -112,6 +112,8 @@ eventBus.on('USER_LOGGED_IN', async () => {
       await AppDataSource.initialize();
     }
 
+    getAuthWindow()?.hide();
+
     nativeTheme.themeSource = configStore.get('preferedTheme') as Theme;
 
     setTrayStatus('STANDBY');

--- a/src/workers/webdav/BindingManager.ts
+++ b/src/workers/webdav/BindingManager.ts
@@ -37,7 +37,7 @@ export class BindingsManager {
   }
 
   async start(version: string, providerId: string) {
-    await this.drive.unregisterSyncRoot();
+    await this.stop();
 
     const callbacks = {
       notifyDeleteCallback: (
@@ -137,6 +137,7 @@ export class BindingsManager {
   }
 
   async stop() {
+    await this.drive.disconnectSyncRoot();
     await this.drive.unregisterSyncRoot();
   }
 }

--- a/src/workers/webdav/index.ts
+++ b/src/workers/webdav/index.ts
@@ -10,30 +10,27 @@ async function ensureTheFolderExist(path: string) {
   try {
     await fs.access(path);
   } catch {
-    Logger.info('ROOT FOLDER ', path, 'NOT FOUND, CREATING IT...');
+    Logger.info(`Folder <${path}> does not exists, goint to  create it`);
     await fs.mkdir(path);
   }
 }
 
 async function setUp() {
-  Logger.debug('STARTING SYNC ENGINE PROCESS');
+  Logger.info('[SYNC ENGINE] Starting sync engine process');
 
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { VirtualDrive } = require('virtual-drive/dist');
 
   const virtualDrivePath = await ipcRenderer.invoke('get-virtual-drive-root');
 
-  Logger.info('WATCHING ON PATH: ', virtualDrivePath);
+  Logger.info(
+    '[SYNC ENGINE] Going to create root sync folder on: ',
+    virtualDrivePath
+  );
 
   await ensureTheFolderExist(virtualDrivePath);
 
   const virtualDrive = new VirtualDrive(virtualDrivePath);
-
-  ipcRenderer.on('STOP_SYNC_ENGINE_PROCESS', async (event) => {
-    await virtualDrive.unregisterSyncRoot();
-
-    event.sender.send('SYNC_ENGINE_STOP_SUCCESS');
-  });
 
   const factory = new DependencyContainerFactory();
   const container = await factory.build();
@@ -45,6 +42,16 @@ async function setUp() {
     controllers,
     virtualDrivePath
   );
+
+  ipcRenderer.on('STOP_SYNC_ENGINE_PROCESS', async (event) => {
+    Logger.info('[SYNC ENGINE] Stoping sync engine');
+
+    await bindings.stop();
+
+    Logger.info('[SYNC ENGINE] sync engine stopped succesfully');
+
+    event.sender.send('SYNC_ENGINE_STOP_SUCCESS');
+  });
 
   await bindings.start(
     packageJson.version,
@@ -60,9 +67,10 @@ async function setUp() {
 
 setUp()
   .then(() => {
-    ipcRenderer.emit('SYNC_ENGINE_PROCESS_SETUP_SUCCESSFUL');
+    Logger.info('[SYNC ENGINE] Sync engine has succesfully started');
+    ipcRenderer.send('SYNC_ENGINE_PROCESS_SETUP_SUCCESSFUL');
   })
   .catch((error) => {
     Logger.error('[SYNC ENGINE] Error setting up', error);
-    ipcRenderer.emit('SYNC_ENGINE_PROCESS_SETUP_FAILED');
+    ipcRenderer.send('SYNC_ENGINE_PROCESS_SETUP_FAILED');
   });


### PR DESCRIPTION
ℹ️  This PR needs the changes on https://github.com/internxt/node-win/pull/14

***Problem***
After logging out and logging back in or starting the app without being logged and login in crashes the app.

***Why***
Found out that when we close all windows the local server that serves the UI closes and then when we create another window it cannot load the page making the app crash

***Solution***
On the `USER_LOGGED_IN` event I changed the order of the creation of the widget window and the deletion of the auth window.

***Side effects***
As of now, we can log out and back in without the app crashing during the testing found out that we were not closing the background process correctly. Also solved in this pr