### PR TITLE
Feature/macos migration banner

### DIFF
--- a/src/main/app-info/handlers.ts
+++ b/src/main/app-info/handlers.ts
@@ -1,8 +1,15 @@
 import { ipcMain, app } from 'electron';
 
 import { executeQuery } from './service';
+import axios from 'axios';
 
 ipcMain.handle('execute-app-query', (_, query) => executeQuery(query));
+
+ipcMain.handle('get-download-urls', async () => {
+  const response = await axios.get('https://internxt.com/api/download');
+
+  return response.data;
+});
 
 ipcMain.handle('get-path', (_, path) => {
   const result = app.getPath(path);

--- a/src/main/background-processes/webdav.ts
+++ b/src/main/background-processes/webdav.ts
@@ -3,8 +3,10 @@ import { ipcWebdav } from '../ipcs/webdav';
 import path from 'path';
 import Logger from 'electron-log';
 import eventBus from '../event-bus';
-import { ejectMacOSInstallerDisks, unmountDrive } from '../../workers/webdav/VirtualDrive';
-
+import {
+  ejectMacOSInstallerDisks,
+  unmountDrive,
+} from '../../workers/webdav/VirtualDrive';
 
 let webdavWorker: BrowserWindow | null = null;
 
@@ -47,19 +49,8 @@ function stopWebDavServer() {
   webdavWorker?.webContents.send('STOP_WEBDAV_SERVER_PROCESS');
 }
 
-function startWebDavServer() {
-  webdavWorker?.webContents.send('START_WEBDAV_SERVER_PROCESS');
-}
-
 eventBus.on('USER_LOGGED_OUT', stopWebDavServer);
 eventBus.on('USER_WAS_UNAUTHORIZED', stopWebDavServer);
-eventBus.on('USER_LOGGED_IN', () => {
-  if (webdavWorker === null) {
-    spawnWebdavServerWorker();
-  } else {
-    startWebDavServer();
-  }
-});
 
 if (process.platform === 'darwin') {
   eventBus.on('APP_IS_READY', ejectMacOSInstallerDisks);
@@ -72,6 +63,8 @@ ipcMain.handle('retry-virtual-drive-mount', () => {
 ipcMain.handle('unmount-virtual-drive-and-quit', async () => {
   try {
     await unmountDrive();
-  } catch (onMenuQuitClickError) { Logger.error({ onMenuQuitClickError }); };
+  } catch (onMenuQuitClickError) {
+    Logger.error({ onMenuQuitClickError });
+  }
   await app.quit();
 });

--- a/src/main/preload.d.ts
+++ b/src/main/preload.d.ts
@@ -205,6 +205,7 @@ declare interface Window {
     retryVirtualDriveMount(): void;
     unmountVirtualDriveAndQuit: () => Promise<boolean>;
     startRemoteSync: () => Promise<void>;
+    getDownloadUrls: () => Promise<{ platforms: Record<string, string> }>;
     openUrl: (url: string) => Promise<void>;
     // DEV
     resizeWindow: () => typeof import('../main/dev/service').resizeCurrentWindow;

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -287,6 +287,9 @@ contextBridge.exposeInMainWorld('electron', {
   unmountVirtualDriveAndQuit() {
     return ipcRenderer.invoke('unmount-virtual-drive-and-quit');
   },
+  getDownloadUrls() {
+    return ipcRenderer.invoke('get-download-urls');
+  },
   onVirtualDriveStatusChange(callback) {
     const eventName = 'virtual-drive-status-change';
     const callbackWrapper = (_, v) => {

--- a/src/renderer/localize/locales/en.json
+++ b/src/renderer/localize/locales/en.json
@@ -123,6 +123,10 @@
     }
   },
   "widget": {
+    "macos-available": {
+      "title": "Desktop v2.0 is already here!",
+      "message": "The native macOS app is faster and more efficient, install it today"
+    },
     "header": {
       "usage": {
         "of": "of",

--- a/src/renderer/localize/locales/es.json
+++ b/src/renderer/localize/locales/es.json
@@ -123,6 +123,10 @@
     }
   },
   "widget": {
+    "macos-available": {
+      "title": "Desktop v2.0 está disponible!",
+      "message": "La versión nativa de MacOS es más rapida y eficiente, instálala hoy"
+    },
     "header": {
       "usage": {
         "of": "de",

--- a/src/renderer/localize/locales/fr.json
+++ b/src/renderer/localize/locales/fr.json
@@ -123,6 +123,10 @@
     }
   },
   "widget": {
+    "macos-available": {
+      "title": "Desktop v2.0 est disponible!",
+      "message": "L'application native de macOS est plus rapide et plus efficace, installez-la dès aujourd'hui"
+    },
     "header": {
       "usage": {
         "of": "de",

--- a/src/renderer/pages/Widget/MacOSVersionAvailableBanner.tsx
+++ b/src/renderer/pages/Widget/MacOSVersionAvailableBanner.tsx
@@ -3,49 +3,16 @@ import React, { useEffect, useState } from 'react';
 import { useTranslationContext } from '../../context/LocalContext';
 import { reportError } from '../../utils/errors';
 
-interface AssetInfo {
-  browser_download_url: string;
-}
+const getDownloadUrl = async () => {
+  const { platforms } = await window.electron.getDownloadUrls();
 
-interface LatestReleaseInfo {
-  id: number;
-  name: string;
-  published_at: Date;
-  assets: AssetInfo[];
-}
-
-export async function getLatestReleaseInfo(
-  user: string,
-  repo: string
-): Promise<string | undefined> {
-  const fetchUrl = `https://api.github.com/repos/${user}/${repo}/releases/latest`;
-  const res = await fetch(fetchUrl);
-
-  if (res.status !== 200) {
-    throw Error('Release not found');
-  }
-
-  const info: LatestReleaseInfo = await res.json();
-
-  let url: string | undefined = undefined;
-  info.assets.forEach((asset) => {
-    const match = asset.browser_download_url.match(/\.(\w+)$/);
-
-    if (match && match[1]) {
-      url = asset.browser_download_url;
-    }
-  });
-
-  return url;
-}
-
+  return platforms['MacOS'];
+};
 export const MacOSVersionAvailableBanner: React.FC = () => {
   const { translate } = useTranslationContext();
   const [downloadURL, setDownloadURL] = useState<string>();
   useEffect(() => {
-    getLatestReleaseInfo('internxt', 'drive-desktop-macos')
-      .then(setDownloadURL)
-      .catch(reportError);
+    getDownloadUrl().then(setDownloadURL).catch(reportError);
   }, []);
 
   const handleDownloadMacOSNative = async () => {

--- a/src/renderer/pages/Widget/MacOSVersionAvailableBanner.tsx
+++ b/src/renderer/pages/Widget/MacOSVersionAvailableBanner.tsx
@@ -1,0 +1,77 @@
+import { ArrowRight } from '@phosphor-icons/react';
+import React, { useEffect, useState } from 'react';
+import { useTranslationContext } from '../../context/LocalContext';
+import { reportError } from '../../utils/errors';
+
+interface AssetInfo {
+  browser_download_url: string;
+}
+
+interface LatestReleaseInfo {
+  id: number;
+  name: string;
+  published_at: Date;
+  assets: AssetInfo[];
+}
+
+export async function getLatestReleaseInfo(
+  user: string,
+  repo: string
+): Promise<string | undefined> {
+  const fetchUrl = `https://api.github.com/repos/${user}/${repo}/releases/latest`;
+  const res = await fetch(fetchUrl);
+
+  if (res.status !== 200) {
+    throw Error('Release not found');
+  }
+
+  const info: LatestReleaseInfo = await res.json();
+
+  let url: string | undefined = undefined;
+  info.assets.forEach((asset) => {
+    const match = asset.browser_download_url.match(/\.(\w+)$/);
+
+    if (match && match[1]) {
+      url = asset.browser_download_url;
+    }
+  });
+
+  return url;
+}
+
+export const MacOSVersionAvailableBanner: React.FC = () => {
+  const { translate } = useTranslationContext();
+  const [downloadURL, setDownloadURL] = useState<string>();
+  useEffect(() => {
+    getLatestReleaseInfo('internxt', 'drive-desktop-macos')
+      .then(setDownloadURL)
+      .catch(reportError);
+  }, []);
+
+  const handleDownloadMacOSNative = () => {
+    try {
+      if (!downloadURL) return;
+      window.electron.openUrl(downloadURL);
+    } catch (error) {
+      reportError(error);
+    }
+  };
+  return (
+    <div
+      className="flex flex-row bg-primary px-5 py-4"
+      onClick={handleDownloadMacOSNative}
+    >
+      <div className="mr-4">
+        <h2 className="mb-1 text-sm font-semibold">
+          {translate('widget.macos-available.title')}
+        </h2>
+        <h3 className="text-sm">
+          {translate('widget.macos-available.message')}
+        </h3>
+      </div>
+      <div className="flex items-center">
+        <ArrowRight size={24} />
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/pages/Widget/MacOSVersionAvailableBanner.tsx
+++ b/src/renderer/pages/Widget/MacOSVersionAvailableBanner.tsx
@@ -48,10 +48,10 @@ export const MacOSVersionAvailableBanner: React.FC = () => {
       .catch(reportError);
   }, []);
 
-  const handleDownloadMacOSNative = () => {
+  const handleDownloadMacOSNative = async () => {
     try {
       if (!downloadURL) return;
-      window.electron.openUrl(downloadURL);
+      await window.electron.openUrl(downloadURL);
     } catch (error) {
       reportError(error);
     }

--- a/src/renderer/pages/Widget/index.tsx
+++ b/src/renderer/pages/Widget/index.tsx
@@ -9,10 +9,15 @@ import { SyncStatus } from '../../../main/background-processes/sync';
 import { SyncFailed } from './SyncFailed';
 import useVirtualDriveStatus from 'renderer/hooks/VirtualDriveStatus';
 import { VirtualDriveError } from './VirtualDriveError';
+import { MacOSVersionAvailableBanner } from './MacOSVersionAvailableBanner';
+import useClientPlatform from '../../hooks/ClientPlatform';
 
 export default function Widget() {
   const [syncStatus, setSyncStatus] = useState<SyncStatus>('RUNNING');
   useSyncStatus(setSyncStatus);
+
+  const platform = useClientPlatform();
+
   const { status: virtualDriveStatus } = useVirtualDriveStatus();
   const handleRetrySync = () => {
     window.electron.startRemoteSync().catch((err) => {
@@ -50,6 +55,7 @@ export default function Widget() {
   return (
     <div className="flex h-screen flex-col overflow-hidden">
       <Header />
+      {platform === 'darwin' ? <MacOSVersionAvailableBanner /> : null}
       <SyncErrorBanner />
       <BackupsFatalErrorBanner />
       {displayErrorInWidget ? renderWidgetError() : <SyncInfo />}


### PR DESCRIPTION
This PR displays a banner for MacOS users with Electron app, that opens a browser and downloads the native MacOS dmg installer