### PR TITLE
[PB-1031] fix: return only base if path comes from a folder

### DIFF
--- a/src/workers/sync-engine/modules/folders/domain/FolderPath.ts
+++ b/src/workers/sync-engine/modules/folders/domain/FolderPath.ts
@@ -17,7 +17,7 @@ export class FolderPath extends Path {
       return 'Internxt Drive';
     }
 
-    return super.name();
+    return super.name(true);
   }
 
   updateName(name: string): FolderPath {

--- a/src/workers/sync-engine/modules/shared/domain/Path.ts
+++ b/src/workers/sync-engine/modules/shared/domain/Path.ts
@@ -14,8 +14,9 @@ export abstract class Path extends ValueObject<string> {
     return p.split(path.win32.sep).join(path.posix.sep);
   }
 
-  name(): string {
+  name(isFolder?:boolean): string {
     const base = path.basename(this.value);
+    if(isFolder) return base;
     const { name } = path.parse(base);
     return name;
   }


### PR DESCRIPTION
- Prevent extract last letter from a folderPath that contains multiple dots.