### PR TITLE
[] fix: ignore file creation after move

### DIFF
--- a/src/workers/sync-engine/dependency-injection/DependencyContainerFactory.ts
+++ b/src/workers/sync-engine/dependency-injection/DependencyContainerFactory.ts
@@ -47,7 +47,8 @@ export class DependencyContainerFactory {
     const foldersContainer = await buildFoldersContainer(placeholderContainer);
     const { container: filesContainer } = await buildFilesContainer(
       foldersContainer,
-      placeholderContainer
+      placeholderContainer,
+      sharedContainer
     );
     const boundaryBridgeContainer = buildBoundaryBridgeContainer(
       contentsContainer,

--- a/src/workers/sync-engine/dependency-injection/boundaryBridge/build.ts
+++ b/src/workers/sync-engine/dependency-injection/boundaryBridge/build.ts
@@ -9,7 +9,8 @@ export function buildBoundaryBridgeContainer(
 ): BoundaryBridgeContainer {
   const fileCreationOrchestrator = new FileCreationOrchestrator(
     contentsContainer.contentsUploader,
-    filesContainer.fileCreator
+    filesContainer.fileCreator,
+    filesContainer.sameFileWasMoved
   );
 
   return { fileCreationOrchestrator };

--- a/src/workers/sync-engine/dependency-injection/common/eventHistory.ts
+++ b/src/workers/sync-engine/dependency-injection/common/eventHistory.ts
@@ -1,0 +1,16 @@
+import { EventHistory } from 'workers/sync-engine/modules/shared/domain/EventRepository';
+import { InMemoryEventHistory } from 'workers/sync-engine/modules/shared/infrastructure/InMemoryEventHistory';
+
+export class DependencyInjectionEventHistory {
+  private static history: EventHistory;
+
+  static get(): EventHistory {
+    if (DependencyInjectionEventHistory.history) {
+      return DependencyInjectionEventHistory.history;
+    }
+
+    DependencyInjectionEventHistory.history = new InMemoryEventHistory();
+
+    return DependencyInjectionEventHistory.history;
+  }
+}

--- a/src/workers/sync-engine/dependency-injection/files/FilesContainer.ts
+++ b/src/workers/sync-engine/dependency-injection/files/FilesContainer.ts
@@ -7,6 +7,7 @@ import { FilePathUpdater } from '../../modules/files/application/FilePathUpdater
 import { FilePlaceholderCreatorFromContentsId } from '../../modules/files/application/FilePlaceholderCreatorFromContentsId';
 import { FileSearcher } from '../../modules/files/application/FileSearcher';
 import { LocalRepositoryRepositoryRefresher } from '../../modules/files/application/LocalRepositoryRepositoryRefresher';
+import { SameFileWasMoved } from '../../modules/files/application/SameFileWasMoved';
 
 export interface FilesContainer {
   fileFinderByContentsId: FileFinderByContentsId;
@@ -18,4 +19,5 @@ export interface FilesContainer {
   fileSearcher: FileSearcher;
   filePlaceholderCreatorFromContentsId: FilePlaceholderCreatorFromContentsId;
   createFilePlaceholderOnDeletionFailed: CreateFilePlaceholderOnDeletionFailed;
+  sameFileWasMoved: SameFileWasMoved;
 }

--- a/src/workers/sync-engine/dependency-injection/files/builder.ts
+++ b/src/workers/sync-engine/dependency-injection/files/builder.ts
@@ -17,10 +17,13 @@ import { DependencyInjectionUserProvider } from '../common/user';
 import { FoldersContainer } from '../folders/FoldersContainer';
 import { PlaceholderContainer } from '../placeholders/PlaceholdersContainer';
 import { FilesContainer } from './FilesContainer';
+import { SharedContainer } from '../shared/SharedContainer';
+import { SameFileWasMoved } from 'workers/sync-engine/modules/files/application/SameFileWasMoved';
 
 export async function buildFilesContainer(
   folderContainer: FoldersContainer,
-  placeholderContainer: PlaceholderContainer
+  placeholderContainer: PlaceholderContainer,
+  sharedContainer: SharedContainer
 ): Promise<{
   container: FilesContainer;
   subscribers: any;
@@ -58,11 +61,17 @@ export async function buildFilesContainer(
 
   const fileByPartialSearcher = new FileByPartialSearcher(fileRepository);
 
+  const sameFileWasMoved = new SameFileWasMoved(
+    fileByPartialSearcher,
+    sharedContainer.localFileIdProvider
+  );
+
   const filePathUpdater = new FilePathUpdater(
     fileRepository,
     fileFinderByContentsId,
     folderContainer.folderFinder,
-    ipcRendererSyncEngine
+    ipcRendererSyncEngine,
+    sharedContainer.localFileIdProvider
   );
 
   const fileCreator = new FileCreator(
@@ -97,6 +106,7 @@ export async function buildFilesContainer(
     filePlaceholderCreatorFromContentsId: filePlaceholderCreatorFromContentsId,
     createFilePlaceholderOnDeletionFailed:
       createFilePlaceholderOnDeletionFailed,
+    sameFileWasMoved,
   };
 
   return { container, subscribers: [] };

--- a/src/workers/sync-engine/dependency-injection/files/builder.ts
+++ b/src/workers/sync-engine/dependency-injection/files/builder.ts
@@ -19,6 +19,7 @@ import { PlaceholderContainer } from '../placeholders/PlaceholdersContainer';
 import { FilesContainer } from './FilesContainer';
 import { SharedContainer } from '../shared/SharedContainer';
 import { SameFileWasMoved } from 'workers/sync-engine/modules/files/application/SameFileWasMoved';
+import { DependencyInjectionEventHistory } from '../common/eventHistory';
 
 export async function buildFilesContainer(
   folderContainer: FoldersContainer,
@@ -31,8 +32,8 @@ export async function buildFilesContainer(
   const clients = DependencyInjectionHttpClientsProvider.get();
   const traverser = DependencyInjectionTraverserProvider.get();
   const user = DependencyInjectionUserProvider.get();
-
   const { bus: eventBus } = DependencyInjectionEventBus;
+  const eventHistory = DependencyInjectionEventHistory.get();
 
   const fileRepository = new HttpFileRepository(
     crypt,
@@ -63,7 +64,8 @@ export async function buildFilesContainer(
 
   const sameFileWasMoved = new SameFileWasMoved(
     fileByPartialSearcher,
-    sharedContainer.localFileIdProvider
+    sharedContainer.localFileIdProvider,
+    eventHistory
   );
 
   const filePathUpdater = new FilePathUpdater(
@@ -71,7 +73,8 @@ export async function buildFilesContainer(
     fileFinderByContentsId,
     folderContainer.folderFinder,
     ipcRendererSyncEngine,
-    sharedContainer.localFileIdProvider
+    sharedContainer.localFileIdProvider,
+    eventHistory
   );
 
   const fileCreator = new FileCreator(

--- a/src/workers/sync-engine/dependency-injection/shared/SharedContainer.ts
+++ b/src/workers/sync-engine/dependency-injection/shared/SharedContainer.ts
@@ -1,7 +1,9 @@
+import { LocalFileIdProvider } from 'workers/sync-engine/modules/shared/application/LocalFileIdProvider';
 import { AbsolutePathToRelativeConverter } from '../../modules/shared/application/AbsolutePathToRelativeConverter';
 import { RelativePathToAbsoluteConverter } from '../../modules/shared/application/RelativePathToAbsoluteConverter';
 
 export interface SharedContainer {
   absolutePathToRelativeConverter: AbsolutePathToRelativeConverter;
   relativePathToAbsoluteConverter: RelativePathToAbsoluteConverter;
+  localFileIdProvider: LocalFileIdProvider;
 }

--- a/src/workers/sync-engine/dependency-injection/shared/builder.ts
+++ b/src/workers/sync-engine/dependency-injection/shared/builder.ts
@@ -1,7 +1,8 @@
-import { AbsolutePathToRelativeConverter } from 'workers/sync-engine/modules/shared/application/AbsolutePathToRelativeConverter';
+import { AbsolutePathToRelativeConverter } from '../../modules/shared/application/AbsolutePathToRelativeConverter';
 import { SharedContainer } from './SharedContainer';
 import { DependencyInjectionLocalRootFolderPath } from '../common/localRootFolderPath';
-import { RelativePathToAbsoluteConverter } from 'workers/sync-engine/modules/shared/application/RelativePathToAbsoluteConverter';
+import { RelativePathToAbsoluteConverter } from '../../modules/shared/application/RelativePathToAbsoluteConverter';
+import { LocalFileIdProvider } from '../../modules/shared/application/LocalFileIdProvider';
 
 export function buildSharedContainer(): SharedContainer {
   const localRootFolderPath = DependencyInjectionLocalRootFolderPath.get();
@@ -13,5 +14,13 @@ export function buildSharedContainer(): SharedContainer {
     localRootFolderPath
   );
 
-  return { absolutePathToRelativeConverter, relativePathToAbsoluteConverter };
+  const localFileIdProvider = new LocalFileIdProvider(
+    relativePathToAbsoluteConverter
+  );
+
+  return {
+    absolutePathToRelativeConverter,
+    relativePathToAbsoluteConverter,
+    localFileIdProvider,
+  };
 }

--- a/src/workers/sync-engine/modules/boundaryBridge/application/FileCreationOrchestrator.ts
+++ b/src/workers/sync-engine/modules/boundaryBridge/application/FileCreationOrchestrator.ts
@@ -1,16 +1,26 @@
 import { RetryContentsUploader } from '../../contents/application/RetryContentsUploader';
 import { FileCreator } from '../../files/application/FileCreator';
+import { SameFileWasMoved } from '../../files/application/SameFileWasMoved';
 import { File } from '../../files/domain/File';
 import { FilePath } from '../../files/domain/FilePath';
 
 export class FileCreationOrchestrator {
   constructor(
     private readonly contentsUploader: RetryContentsUploader,
-    private readonly fileCreator: FileCreator
+    private readonly fileCreator: FileCreator,
+    private readonly sameFileWasMoved: SameFileWasMoved
   ) {}
 
   async run(posixRelativePath: string): Promise<File['contentsId']> {
     const path = new FilePath(posixRelativePath);
+
+    const wasMoved = await this.sameFileWasMoved.run(path);
+
+    if (wasMoved.result) {
+      // When a file gets moved, a file creation get triggered.
+      // if we find out that its the same file return the contents Id of that file
+      return wasMoved.contentsId;
+    }
 
     const fileContents = await this.contentsUploader.run(posixRelativePath);
 

--- a/src/workers/sync-engine/modules/files/domain/File.ts
+++ b/src/workers/sync-engine/modules/files/domain/File.ts
@@ -10,6 +10,7 @@ import { FileActionCannotModifyExtension } from './errors/FileActionCannotModify
 import { FileDeletedDomainEvent } from './FileDeletedDomainEvent';
 import { FileStatus, FileStatuses } from './FileStatus';
 import { ContentsId } from '../../contents/domain/ContentsId';
+import { FileMovedDomainEvent } from './events/FileMovedDomainEvent';
 
 export type FileAttributes = {
   contentsId: string;
@@ -122,7 +123,7 @@ export class File extends AggregateRoot {
     );
   }
 
-  moveTo(folder: Folder): void {
+  moveTo(folder: Folder, trackerId: string): void {
     if (this.folderId === folder.id) {
       throw new FileCannotBeMovedToTheOriginalFolderError(this.path.value);
     }
@@ -130,7 +131,12 @@ export class File extends AggregateRoot {
     this._folderId = folder.id;
     this._path = this._path.changeFolder(folder.path.value);
 
-    //TODO: record file moved event
+    this.record(
+      new FileMovedDomainEvent({
+        aggregateId: this._contentsId.value,
+        trackerId,
+      })
+    );
   }
 
   clone(contentsId: string, folderId: number, newPath: FilePath) {

--- a/src/workers/sync-engine/modules/files/domain/FilePath.ts
+++ b/src/workers/sync-engine/modules/files/domain/FilePath.ts
@@ -49,7 +49,7 @@ export class FilePath extends Path {
   }
 
   changeFolder(folder: string): FilePath {
-    return FilePath.fromParts([folder, this.name()]);
+    return FilePath.fromParts([folder, this.nameWithExtension()]);
   }
 
   updateName(name: string): FilePath {

--- a/src/workers/sync-engine/modules/files/domain/events/FileMovedDomainEvent.ts
+++ b/src/workers/sync-engine/modules/files/domain/events/FileMovedDomainEvent.ts
@@ -1,0 +1,29 @@
+import { DomainEvent } from '../../../shared/domain/DomainEvent';
+
+export class FileMovedDomainEvent extends DomainEvent {
+  static readonly EVENT_NAME = 'file.moved';
+
+  readonly trackerId: string;
+
+  constructor({
+    aggregateId,
+    trackerId,
+  }: {
+    aggregateId: string;
+    trackerId: string;
+  }) {
+    super({
+      eventName: FileMovedDomainEvent.EVENT_NAME,
+      aggregateId,
+    });
+
+    this.trackerId = trackerId;
+  }
+
+  toPrimitives() {
+    return {
+      contentsId: this.aggregateId,
+      trackerId: this.trackerId,
+    };
+  }
+}

--- a/src/workers/sync-engine/modules/files/infrastructure/HttpFileRepository.ts
+++ b/src/workers/sync-engine/modules/files/infrastructure/HttpFileRepository.ts
@@ -79,11 +79,7 @@ export class HttpFileRepository implements FileRepository {
     });
 
     if (file) {
-      const response = File.from(file.attributes());
-      file.pullDomainEvents().forEach((event) => {
-        response.record(event);
-      });
-      return response;
+      return File.from(file.attributes());
     }
 
     return undefined;

--- a/src/workers/sync-engine/modules/files/test/application/FilePathUpdater.test.ts
+++ b/src/workers/sync-engine/modules/files/test/application/FilePathUpdater.test.ts
@@ -6,13 +6,17 @@ import { FolderFinder } from '../../../folders/application/FolderFinder';
 import { FolderFinderMock } from '../../../folders/test/__mocks__/FolderFinderMock';
 import { FileFinderByContentsId } from '../../application/FileFinderByContentsId';
 import { IpcRendererSyncEngineMock } from '../../../shared/test/__mock__/IpcRendererSyncEngineMock';
+import { LocalFileIdProvider } from 'workers/sync-engine/modules/shared/application/LocalFileIdProvider';
+import { InMemoryEventHistory } from 'workers/sync-engine/modules/shared/infrastructure/InMemoryEventHistory';
 
 describe('File path updater', () => {
   let repository: FileRepositoryMock;
   let fileFinderByContentsId: FileFinderByContentsId;
   let folderFinder: FolderFinderMock;
-  let SUT: FilePathUpdater;
   let ipcRendererMock: IpcRendererSyncEngineMock;
+  let localFileIdProvider: LocalFileIdProvider;
+  let eventHistory: InMemoryEventHistory;
+  let SUT: FilePathUpdater;
 
   beforeEach(() => {
     repository = new FileRepositoryMock();
@@ -24,7 +28,9 @@ describe('File path updater', () => {
       repository,
       fileFinderByContentsId,
       folderFinder as unknown as FolderFinder,
-      ipcRendererMock
+      ipcRendererMock,
+      localFileIdProvider,
+      eventHistory
     );
   });
 

--- a/src/workers/sync-engine/modules/shared/application/LocalFileIdProvider.ts
+++ b/src/workers/sync-engine/modules/shared/application/LocalFileIdProvider.ts
@@ -1,0 +1,16 @@
+import { RelativePathToAbsoluteConverter } from './RelativePathToAbsoluteConverter';
+import fs from 'fs/promises';
+
+export class LocalFileIdProvider {
+  constructor(
+    private readonly relativePathToAbsoluteConverter: RelativePathToAbsoluteConverter
+  ) {}
+
+  async run(path: string): Promise<string> {
+    const win32AbsolutePath = this.relativePathToAbsoluteConverter.run(path);
+
+    const { ino, dev } = await fs.stat(win32AbsolutePath);
+
+    return `${dev}-${ino}`;
+  }
+}

--- a/src/workers/sync-engine/modules/shared/domain/EventRepository.ts
+++ b/src/workers/sync-engine/modules/shared/domain/EventRepository.ts
@@ -1,0 +1,6 @@
+import { DomainEvent } from './DomainEvent';
+
+export interface EventHistory {
+  store(event: DomainEvent): Promise<void>;
+  search(aggregateId: string): Promise<Array<DomainEvent>>;
+}

--- a/src/workers/sync-engine/modules/shared/infrastructure/InMemoryEventHistory.ts
+++ b/src/workers/sync-engine/modules/shared/infrastructure/InMemoryEventHistory.ts
@@ -1,0 +1,25 @@
+import { DomainEvent } from '../domain/DomainEvent';
+import { EventHistory } from '../domain/EventRepository';
+
+export class InMemoryEventHistory implements EventHistory {
+  private static readonly MAX_EVENTS_STORED = 3_000;
+  private events: Array<DomainEvent> = [];
+
+  store(event: DomainEvent): Promise<void> {
+    if (this.events.length >= InMemoryEventHistory.MAX_EVENTS_STORED) {
+      const eventsToRemove =
+        this.events.length - InMemoryEventHistory.MAX_EVENTS_STORED + 1;
+      this.events.splice(0, eventsToRemove);
+    }
+
+    this.events.push(event);
+
+    return Promise.resolve();
+  }
+
+  search(aggregateId: string): Promise<Array<DomainEvent>> {
+    return Promise.resolve(
+      this.events.filter((e) => e.aggregateId === aggregateId)
+    );
+  }
+}


### PR DESCRIPTION
**Why:**
When a file has been moved, after the move is done we get a file creation callback.

**How:**
Added a rename file domain event that stores a combination of the local file data, the `dev`, and `ino` values.
When a file is going to be created it searches if there is a file on the destination. If it exists search for a _move_ event and compares the `dev` and `ino`. If they are the same the file that is going to be created is ignored and the id of that file is returned
