### PR TITLE
[PB-1077] Fix: dont create placeholders from deleted items

### DIFF
--- a/src/workers/sync-engine/modules/items/application/AllStatusesTraverser.ts
+++ b/src/workers/sync-engine/modules/items/application/AllStatusesTraverser.ts
@@ -1,6 +1,9 @@
 import Logger from 'electron-log';
 import { ServerFile } from '../../../../filesystems/domain/ServerFile';
-import { ServerFolder } from '../../../../filesystems/domain/ServerFolder';
+import {
+  ServerFolder,
+  ServerFolderStatus,
+} from '../../../../filesystems/domain/ServerFolder';
 import { fileNameIsValid } from '../../../../utils/name-verification';
 import { File } from '../../files/domain/File';
 import { FolderStatus } from '../../folders/domain/FolderStatus';
@@ -113,7 +116,13 @@ export class AllStatusesTraverser implements Traverser {
         status: folder.status,
       });
 
-      this.traverse(folder.id, `${name}`);
+      if (folder.status === ServerFolderStatus.EXISTS) {
+        // The folders and the files from trashed or deleted folders
+        // will have the status "EXISTS", to avoid filtering witch folders and files
+        // are in a deleted or trashed folder they not included on the collection.
+        // We cannot perform any action on them either way
+        this.traverse(folder.id, `${name}`);
+      }
     });
   }
 

--- a/src/workers/sync-engine/modules/placeholders/infrastructure/VirtualDrivePlaceholderCreator.ts
+++ b/src/workers/sync-engine/modules/placeholders/infrastructure/VirtualDrivePlaceholderCreator.ts
@@ -4,11 +4,17 @@ import { Folder } from '../../folders/domain/Folder';
 import { PlaceholderCreator } from '../domain/PlaceholderCreator';
 import { createFolderPlaceholderId } from '../domain/FolderPlaceholderId';
 import { createFilePlaceholderId } from '../domain/FilePlaceholderId';
+import { FolderStatuses } from '../../folders/domain/FolderStatus';
+import { FileStatuses } from '../../files/domain/FileStatus';
 
 export class VirtualDrivePlaceholderCreator implements PlaceholderCreator {
   constructor(private readonly drive: VirtualDrive) {}
 
   folder(folder: Folder): void {
+    if (!folder.hasStatus(FolderStatuses.EXISTS)) {
+      return;
+    }
+
     const folderPath = `${folder.path.value}/`;
 
     const placeholderId = createFolderPlaceholderId(folder.uuid);
@@ -23,6 +29,10 @@ export class VirtualDrivePlaceholderCreator implements PlaceholderCreator {
   }
 
   file(file: File): void {
+    if (!file.hasStatus(FileStatuses.EXISTS)) {
+      return;
+    }
+
     const placeholderId = createFilePlaceholderId(file.contentsId);
 
     this.drive.createFileByPath(


### PR DESCRIPTION
**Issue:** 
When performing a synchronization from the remote items (after a notification arrived) deleted folders and files were shown on the file explorer.

**Why:**
On the traverse of all items regardless of the status folders and files that were in a deleted or trashed folder were included. Once in the synchronization, a placeholder for those folders and files was created as they had the status `EXISTS`.
When a placeholder for a folder or a file is created and the folders containing them do not exist Windows creates it as well.

For example, if I create a placeholder for a file with the path `\my_folder\my_file.txt` and the folder my_folder does not exist it will be created (without an ID controlled by us).


**Proposed solution:**
When traversing all the remote items if a folder does not have the status `EXISTS` do not traverse its contents