### PR TITLE
[PB-552] Fix: move folders with content

### DIFF
--- a/src/workers/sync-engine/dependency-injection/folders/builder.ts
+++ b/src/workers/sync-engine/dependency-injection/folders/builder.ts
@@ -19,6 +19,7 @@ import { HttpFolderRepository } from '../../modules/folders/infrastructure/HttpF
 import { InMemoryOfflineFolderRepository } from '../../modules/folders/infrastructure/InMemoryOfflineFolderRepository';
 import { DependencyInjectionHttpClientsProvider } from '../common/clients';
 import { DependencyInjectionEventBus } from '../common/eventBus';
+import { DependencyInjectionEventRepository } from '../common/eventRepository';
 import { DependencyInjectionTraverserProvider } from '../common/traverser';
 import { PlaceholderContainer } from '../placeholders/PlaceholdersContainer';
 import { FoldersContainer } from './FoldersContainer';
@@ -29,6 +30,7 @@ export async function buildFoldersContainer(
   const clients = DependencyInjectionHttpClientsProvider.get();
   const traverser = DependencyInjectionTraverserProvider.get();
   const eventBus = DependencyInjectionEventBus.bus;
+  const eventRepository = DependencyInjectionEventRepository.get();
 
   const repository = new HttpFolderRepository(
     clients.drive,
@@ -60,7 +62,7 @@ export async function buildFoldersContainer(
     eventBus
   );
 
-  const folderMover = new FolderMover(repository, folderFinder);
+  const folderMover = new FolderMover(repository, folderFinder, eventBus);
   const folderRenamer = new FolderRenamer(repository, ipcRendererSyncEngine);
 
   const folderByPartialSearcher = new FolderByPartialSearcher(repository);
@@ -68,7 +70,8 @@ export async function buildFoldersContainer(
   const folderPathUpdater = new FolderPathUpdater(
     repository,
     folderMover,
-    folderRenamer
+    folderRenamer,
+    eventRepository
   );
 
   const folderClearer = new FolderClearer(repository);

--- a/src/workers/sync-engine/modules/folders/application/FolderMover.ts
+++ b/src/workers/sync-engine/modules/folders/application/FolderMover.ts
@@ -3,17 +3,21 @@ import { FolderPath } from '../domain/FolderPath';
 import { Folder } from '../domain/Folder';
 import { FolderRepository } from '../domain/FolderRepository';
 import { FolderFinder } from './FolderFinder';
+import { EventBus } from '../../shared/domain/EventBus';
 
 export class FolderMover {
   constructor(
     private readonly repository: FolderRepository,
-    private readonly folderFinder: FolderFinder
+    private readonly folderFinder: FolderFinder,
+    private readonly eventBus: EventBus
   ) {}
 
   private async move(folder: Folder, parentFolder: Folder) {
     folder.moveTo(parentFolder);
 
     await this.repository.updateParentDir(folder);
+
+    this.eventBus.publish(folder.pullDomainEvents());
   }
 
   async run(folder: Folder, destination: FolderPath): Promise<void> {

--- a/src/workers/sync-engine/modules/folders/application/FolderPathUpdater.ts
+++ b/src/workers/sync-engine/modules/folders/application/FolderPathUpdater.ts
@@ -62,6 +62,8 @@ export class FolderPathUpdater {
     });
 
     if (!folderMovedEvent) {
+      // When a folder with content is moved the update path its called twice
+      // it the folder has been moved there then ignore it
       throw new Error('No path change detected for folder path update');
     }
   }

--- a/src/workers/sync-engine/modules/folders/domain/Folder.ts
+++ b/src/workers/sync-engine/modules/folders/domain/Folder.ts
@@ -5,6 +5,7 @@ import { FolderStatus, FolderStatuses } from './FolderStatus';
 import { FolderUuid } from './FolderUuid';
 import { FolderCreatedDomainEvent } from './events/FolderCreatedDomainEvent';
 import { FolderRenamedDomainEvent } from './events/FolderRenamedDomainEvent';
+import { FolderMovedDomainEvent } from './events/FolderMovedDomainEvent';
 
 export type FolderAttributes = {
   id: number;
@@ -129,7 +130,12 @@ export class Folder extends AggregateRoot {
     this._path = this._path.changeFolder(folder.path.value);
     this._parentId = folder.id;
 
-    //TODO: record moved event
+    this.record(
+      new FolderMovedDomainEvent({
+        aggregateId: this.uuid,
+        resultPath: this._path,
+      })
+    );
   }
 
   rename(newPath: FolderPath) {

--- a/src/workers/sync-engine/modules/folders/domain/events/FolderMovedDomainEvent.ts
+++ b/src/workers/sync-engine/modules/folders/domain/events/FolderMovedDomainEvent.ts
@@ -1,0 +1,29 @@
+import { DomainEvent } from '../../../shared/domain/DomainEvent';
+import { FolderPath } from '../FolderPath';
+
+export class FolderMovedDomainEvent extends DomainEvent {
+  static readonly EVENT_NAME = 'folder.moved';
+
+  private resultPath: FolderPath;
+
+  constructor({
+    aggregateId,
+    resultPath,
+  }: {
+    aggregateId: string;
+    resultPath: FolderPath;
+  }) {
+    super({
+      eventName: FolderMovedDomainEvent.EVENT_NAME,
+      aggregateId,
+    });
+    this.resultPath = resultPath;
+  }
+
+  toPrimitives() {
+    return {
+      uuid: this.aggregateId,
+      resultPath: this.resultPath.value,
+    };
+  }
+}

--- a/src/workers/sync-engine/modules/folders/test/application/FolderMover.test.ts
+++ b/src/workers/sync-engine/modules/folders/test/application/FolderMover.test.ts
@@ -3,17 +3,20 @@ import { FolderMover } from '../../application/FolderMover';
 import { FolderMother } from '../domain/FolderMother';
 import { FolderRepositoryMock } from '../__mocks__/FolderRepositoryMock';
 import { FolderPath } from '../../domain/FolderPath';
+import { EventBusMock } from 'workers/sync-engine/modules/shared/test/__mock__/EventBusMock';
 
 describe('Folder Mover', () => {
   let repository: FolderRepositoryMock;
   let folderFinder: FolderFinder;
   let SUT: FolderMover;
+  let eventBus: EventBusMock;
 
   beforeEach(() => {
     repository = new FolderRepositoryMock();
     folderFinder = new FolderFinder(repository);
+    eventBus = new EventBusMock();
 
-    SUT = new FolderMover(repository, folderFinder);
+    SUT = new FolderMover(repository, folderFinder, eventBus);
   });
 
   it('Folders cannot be overwrite', async () => {


### PR DESCRIPTION
**Problem:**
When moving a folder with contents the update path for the folders gets called twice

**Solution proposed**
- Record the missing folder moved folder event
- Check if the folder was already moved to that destination

⚠️ There is still a problem with the files inside
![image](https://github.com/internxt/drive-desktop/assets/38570230/905ea92d-fc10-4668-86b2-cb0892985cff)
