### PR TITLE
[_]: fea/add-process-errors-sync

### DIFF
--- a/src/apps/renderer/localize/locales/en.json
+++ b/src/apps/renderer/localize/locales/en.json
@@ -314,13 +314,14 @@
     },
     "short-error-messages": {
       "unknown": "Unknown error",
-      "empty-file": "File is empty",
+      "empty-file": "Empty files are not supported.",
       "bad-response": "Bad response from Internxt servers",
       "no-remote-connection": "Can't connect to Internxt servers",
       "no-internet-connection": "No internet connection",
       "no-permission": "Insufficient permissions",
       "file-does-not-exist": "File doesn't exist",
-      "file-too-big": "Max upload size is 20GB. Please try smaller files."
+      "file-too-big": "Max upload size is 20GB. Please try smaller files.",
+      "file-non-extension": "Files without extensions are not supported."
     },
     "error-messages": {
       "no-internet": "Looks like you are not connected to the internet, we'll try again later",
@@ -334,7 +335,8 @@
       "empty-file": "We don't support files with a size of 0 bytes because of our processes of sharding and encryption",
       "bad-response": "We got a bad response from our servers while processing this file. Please, try starting the sync process again.",
       "file-does-not-exist": "This file was present when we compared your local folder with your Internxt drive but dissapeared when we tried to access it. If you deleted this file, don't worry, this error should dissapear the next time the sync process starts.",
-      "file-too-big": "Max upload size is 20GB. Please try smaller files."
+      "file-too-big": "Max upload size is 20GB. Please try smaller files.",
+      "file-non-extension": "Files without extensions are not supported. Not synchronized."
     },
     "report-modal": {
       "actions": {

--- a/src/apps/renderer/localize/locales/es.json
+++ b/src/apps/renderer/localize/locales/es.json
@@ -313,13 +313,14 @@
     },
     "short-error-messages": {
       "unknown": "Error desconocido",
-      "emtpy-file": "El archivo está vacío",
+      "emtpy-file": "Archivos vacios no son soportados",
       "bad-response": "Error de los servidores de Internxt",
       "no-remote-connection": "No pudimos conectar con los servidores de Internxt",
       "no-internet-connection": "No hay conexión a Internet",
       "no-permission": "Permisos insuficientes",
       "file-does-not-exist": "El archivo no existe",
-      "file-too-big": "El tamaño máximo de carga es de 20GB. Por favor, intenta con archivos más pequeños."
+      "file-too-big": "El tamaño máximo de carga es de 20GB. Por favor, intenta con archivos más pequeños.",
+      "file-non-extension": "Archivos sin extensión no son soportados"
     },
     "error-messages": {
       "no-internet": "No estás conectado a Internet, lo intentaremos más tarde",
@@ -333,7 +334,8 @@
       "empty-file": "No admitimos archivos con un tamaño de 0 bytes debido a nuestros procesos de cifrado",
       "bad-response": "Error de servidor al procesar este archivo. Por favor, intente iniciar de nuevo el proceso de sincronización",
       "file-does-not-exist": "Este archivo estaba presente cuando comparamos su carpeta local con su unidad Internxt, pero desapareció cuando intentamos acceder a él. Si has eliminado este archivo, no te preocupes, este error debería desaparecer la próxima vez que se inicie el proceso de sincronización",
-      "file-too-big": "El tamaño máximo de carga es de 20GB. Por favor, intenta con archivos más pequeños."
+      "file-too-big": "El tamaño máximo de carga es de 20GB. Por favor, intenta con archivos más pequeños.",
+      "file-non-extension": "Los archivos sin extensiones no son soportados. No sincronizado"
     },
     "report-modal": {
       "actions": {

--- a/src/apps/renderer/localize/locales/fr.json
+++ b/src/apps/renderer/localize/locales/fr.json
@@ -308,7 +308,7 @@
     },
     "short-error-messages": {
       "unknown": "Erreur inconnue",
-      "empty-file": "Le fichier est vide",
+      "empty-file": "Les fichiers vides ne sont pas pris en charge",
       "bad-response": "Mauvaise réponse des serveurs Internxt",
       "no-remote-connection": "Impossible de se connecter aux serveurs Internxt",
       "no-internet-connection": "Pas de connexion internet",
@@ -328,7 +328,8 @@
       "empty-file": "Nous ne prenons pas en charge les fichiers d'une taille de 0 octet en raison de nos processus de  chiffrement",
       "bad-response": "Nous avons reçu une mauvaise réponse de nos serveurs lors du traitement de ce fichier. Veuillez essayer de relancer le processus de synchronisation.",
       "file-does-not-exist": "Ce fichier était présent lorsque nous avons comparé votre dossier local avec votre disque interne, mais il a disparu lorsque nous avons essayé d'y accéder. Si vous avez supprimé ce fichier, ne vous inquiétez pas, cette erreur devrait disparaître au prochain démarrage du processus de synchronisation.",
-      "file-too-big": "La taille maximale de téléchargement est de 20 GB. Veuillez essayer des fichiers plus petits."
+      "file-too-big": "La taille maximale de téléchargement est de 20 GB. Veuillez essayer des fichiers plus petits.",
+      "file-non-extension": "Les archives sans extensions ne sont pas supportées. Non synchronisées"
     },
     "report-modal": {
       "actions": {

--- a/src/apps/renderer/messages/process-error.ts
+++ b/src/apps/renderer/messages/process-error.ts
@@ -11,6 +11,7 @@ export const shortMessages: ProcessErrorMessages = {
   EMPTY_FILE: 'issues.short-error-messages.empty-file',
   UNKNOWN: 'issues.short-error-messages.unknown',
   FILE_TOO_BIG: 'issues.short-error-messages.file-too-big',
+  FILE_NON_EXTENSION: 'issues.short-error-messages.file-non-extension',
 };
 
 export const longMessages: ProcessErrorMessages = {
@@ -23,4 +24,5 @@ export const longMessages: ProcessErrorMessages = {
   EMPTY_FILE: 'issues.error-messages.empty-file',
   UNKNOWN: 'issues.error-messages.unknown',
   FILE_TOO_BIG: 'issues.error-messages.file-too-big',
+  FILE_NON_EXTENSION: 'issues.error-messages.file-non-extension',
 };

--- a/src/apps/shared/types.ts
+++ b/src/apps/shared/types.ts
@@ -145,6 +145,9 @@ export type ProcessErrorName =
   // The file is bigger than the current upload limit
   | 'FILE_TOO_BIG'
 
+  // The file don't have an extension
+  | 'FILE_NON_EXTENSION'
+
   // Unknown error
   | 'UNKNOWN';
 


### PR DESCRIPTION
Update: 
- Error adding files without extension because they are not supported.
 
Depends on: [node-win-pr-44](https://github.com/internxt/node-win/pull/44) 