### PR TITLE
[_]: fix/use basename insted of name to create folders

### DIFF
--- a/src/context/virtual-drive/folders/application/FolderCreator.ts
+++ b/src/context/virtual-drive/folders/application/FolderCreator.ts
@@ -15,7 +15,7 @@ export class FolderCreator {
 
   async run(offlineFolder: OfflineFolder): Promise<Folder> {
     this.ipc.send('FOLDER_CREATING', {
-      name: offlineFolder.name,
+      name: offlineFolder.basename,
     });
 
     const attributes = await this.remote.persist(offlineFolder);

--- a/src/context/virtual-drive/folders/domain/FolderPath.ts
+++ b/src/context/virtual-drive/folders/domain/FolderPath.ts
@@ -20,6 +20,10 @@ export class FolderPath extends Path {
     return super.name();
   }
 
+  basename(): string {
+    return super.basename();
+  }
+
   updateName(name: string): FolderPath {
     return FolderPath.fromParts(this.dirname(), name);
   }

--- a/src/context/virtual-drive/folders/domain/OfflineFolder.ts
+++ b/src/context/virtual-drive/folders/domain/OfflineFolder.ts
@@ -38,6 +38,10 @@ export class OfflineFolder extends AggregateRoot {
     return this._path.name();
   }
 
+  public get basename() {
+    return this._path.basename();
+  }
+
   public get dirname() {
     return this._path.dirname();
   }

--- a/src/context/virtual-drive/folders/infrastructure/HttpRemoteFileSystem.ts
+++ b/src/context/virtual-drive/folders/infrastructure/HttpRemoteFileSystem.ts
@@ -18,12 +18,12 @@ export class HttpRemoteFileSystem implements RemoteFileSystem {
   ) {}
 
   async persist(offline: OfflineFolder): Promise<FolderAttributes> {
-    if (!offline.name) {
+    if (!offline.name || !offline.basename) {
       throw new Error('Bad folder name');
     }
 
     const body: CreateFolderDTO = {
-      folderName: offline.name,
+      folderName: offline.basename,
       parentFolderId: offline.parentId,
       uuid: offline.uuid, // TODO: Maybe we can avoid errors sending the uuid, because it's optional
     };

--- a/src/context/virtual-drive/shared/domain/Path.ts
+++ b/src/context/virtual-drive/shared/domain/Path.ts
@@ -44,6 +44,10 @@ export abstract class Path extends ValueObject<string> {
     return name;
   }
 
+  basename(): string {
+    return path.posix.basename(this.value);
+  }
+
   dirname(): string {
     const dirname = path.posix.dirname(this.value);
     if (dirname === '.') {


### PR DESCRIPTION
Context:
In the creation of folders, we have been using the name provided by` path.posix.parse(folderPath`). However, for folders, it seems better to use basename since it provides the base name of the folders. Only use name in the case of files, as we want it without an extension