### PR TITLE
[PB-1489] Fix: ignore nodes with same name

### DIFF
--- a/src/apps/main/background-processes/process-issues.ts
+++ b/src/apps/main/background-processes/process-issues.ts
@@ -72,6 +72,16 @@ ipcMain.on('SYNC_INFO_UPDATE', (_, payload: ProcessInfoUpdatePayload) => {
   }
 });
 
+ipcMain.on('SYNC_PROBLEM', (_, payload) => {
+  addProcessIssue({
+    action: 'GENERATE_TREE',
+    process: 'SYNC',
+    errorName: 'DUPLICATED_NODE',
+    kind: 'LOCAL',
+    name: payload.additionalData.name,
+  });
+});
+
 ipcMain.on('BACKUP_ISSUE', (_, issue: ProcessIssue) => {
   addProcessIssue(issue);
 });

--- a/src/apps/main/fordwardToWindows.ts
+++ b/src/apps/main/fordwardToWindows.ts
@@ -1,5 +1,6 @@
 import { broadcastToWindows } from './windows';
 import { ipcMainDrive } from './ipcs/mainDrive';
+import { ipcMainSyncEngine } from './ipcs/ipcMainSyncEngine';
 import { FileErrorInfo } from '../shared/IPC/events/drive';
 
 ipcMainDrive.on('FILE_DELETED', (_, payload) => {
@@ -128,5 +129,12 @@ ipcMainDrive.on('FILE_DELETION_ERROR', (_, payload: FileErrorInfo) => {
   broadcastToWindows('sync-info-update', {
     action: 'DELETE_ERROR',
     name: nameWithExtension,
+  });
+});
+
+ipcMainSyncEngine.on('SYNC_PROBLEM', (_, payload) => {
+  broadcastToWindows('sync-info-update', {
+    action: 'SYNC_PROBLEM',
+    name: payload.additionalData.name,
   });
 });

--- a/src/apps/renderer/localize/locales/en.json
+++ b/src/apps/renderer/localize/locales/en.json
@@ -322,7 +322,7 @@
       "file-does-not-exist": "File doesn't exist",
       "file-too-big": "Max upload size is 20GB. Please try smaller files.",
       "file-non-extension": "Files without extensions are not supported.",
-      "duplicated-node": "There is a conflict with the element"
+      "duplicated-node": "It appears that there are duplicate file or folder names in this directory. Please rename one of them to ensure synchronization"
     },
     "error-messages": {
       "no-internet": "Looks like you are not connected to the internet, we'll try again later",

--- a/src/apps/renderer/localize/locales/en.json
+++ b/src/apps/renderer/localize/locales/en.json
@@ -321,7 +321,8 @@
       "no-permission": "Insufficient permissions",
       "file-does-not-exist": "File doesn't exist",
       "file-too-big": "Max upload size is 20GB. Please try smaller files.",
-      "file-non-extension": "Files without extensions are not supported."
+      "file-non-extension": "Files without extensions are not supported.",
+      "duplicated-node": "There is a conflict with the element"
     },
     "error-messages": {
       "no-internet": "Looks like you are not connected to the internet, we'll try again later",
@@ -334,9 +335,10 @@
       "unknown": "An unknown error ocurred while trying to sync your files",
       "empty-file": "We don't support files with a size of 0 bytes because of our processes of sharding and encryption",
       "bad-response": "We got a bad response from our servers while processing this file. Please, try starting the sync process again.",
-      "file-does-not-exist": "This file was present when we compared your local folder with your Internxt drive but dissapeared when we tried to access it. If you deleted this file, don't worry, this error should dissapear the next time the sync process starts.",
+      "file-does-not-exist": "This file was present when we compared your local folder with your Internxt drive but disappeared when we tried to access it. If you deleted this file, don't worry, this error should dissapear the next time the sync process starts.",
       "file-too-big": "Max upload size is 20GB. Please try smaller files.",
-      "file-non-extension": "Files without extensions are not supported. Not synchronized."
+      "file-non-extension": "Files without extensions are not supported. Not synchronized.",
+      "duplicated-node": "There are two elements (file or folder) with the same name on a folder. Rename one of them to sync them both"
     },
     "report-modal": {
       "actions": {

--- a/src/apps/renderer/localize/locales/es.json
+++ b/src/apps/renderer/localize/locales/es.json
@@ -320,7 +320,8 @@
       "no-permission": "Permisos insuficientes",
       "file-does-not-exist": "El archivo no existe",
       "file-too-big": "El tamaño máximo de carga es de 20GB. Por favor, intenta con archivos más pequeños.",
-      "file-non-extension": "Archivos sin extensión no son soportados"
+      "file-non-extension": "Archivos sin extensión no son soportados",
+      "duplicated-node": "Hay un conflicto con el elemento"
     },
     "error-messages": {
       "no-internet": "No estás conectado a Internet, lo intentaremos más tarde",
@@ -335,7 +336,8 @@
       "bad-response": "Error de servidor al procesar este archivo. Por favor, intente iniciar de nuevo el proceso de sincronización",
       "file-does-not-exist": "Este archivo estaba presente cuando comparamos su carpeta local con su unidad Internxt, pero desapareció cuando intentamos acceder a él. Si has eliminado este archivo, no te preocupes, este error debería desaparecer la próxima vez que se inicie el proceso de sincronización",
       "file-too-big": "El tamaño máximo de carga es de 20GB. Por favor, intenta con archivos más pequeños.",
-      "file-non-extension": "Los archivos sin extensiones no son soportados. No sincronizado"
+      "file-non-extension": "Los archivos sin extensiones no son soportados. No sincronizado",
+      "duplicated-node": "Hay dos elementos (archivo o carpeta) con el mismo nombre en una carpeta. Cambia el nombre de uno de ellos para sincronizar ambos."
     },
     "report-modal": {
       "actions": {

--- a/src/apps/renderer/localize/locales/fr.json
+++ b/src/apps/renderer/localize/locales/fr.json
@@ -314,7 +314,8 @@
       "no-internet-connection": "Pas de connexion internet",
       "no-permission": "Permissions insuffisantes",
       "file-does-not-exist": "Le fichier n'existe pas",
-      "file-too-big": "La taille maximale de téléchargement est de 20 GB. Veuillez essayer des fichiers plus petits."
+      "file-too-big": "La taille maximale de téléchargement est de 20 GB. Veuillez essayer des fichiers plus petits.",
+      "duplicated-node": "Il y a un conflit avec l'élément."
     },
     "error-messages": {
       "no-internet": "Il semble que vous ne soyez pas connecté à l'internet, nous réessayerons plus tard",
@@ -329,7 +330,8 @@
       "bad-response": "Nous avons reçu une mauvaise réponse de nos serveurs lors du traitement de ce fichier. Veuillez essayer de relancer le processus de synchronisation.",
       "file-does-not-exist": "Ce fichier était présent lorsque nous avons comparé votre dossier local avec votre disque interne, mais il a disparu lorsque nous avons essayé d'y accéder. Si vous avez supprimé ce fichier, ne vous inquiétez pas, cette erreur devrait disparaître au prochain démarrage du processus de synchronisation.",
       "file-too-big": "La taille maximale de téléchargement est de 20 GB. Veuillez essayer des fichiers plus petits.",
-      "file-non-extension": "Les archives sans extensions ne sont pas supportées. Non synchronisées"
+      "file-non-extension": "Les archives sans extensions ne sont pas supportées. Non synchronisées",
+      "duplicated-node": "Il y a deux éléments (fichier ou dossier) avec le même nom dans un dossier. Renommez l'un d'eux pour les synchroniser tous les deux."
     },
     "report-modal": {
       "actions": {

--- a/src/apps/renderer/messages/process-error.ts
+++ b/src/apps/renderer/messages/process-error.ts
@@ -12,6 +12,7 @@ export const shortMessages: ProcessErrorMessages = {
   UNKNOWN: 'issues.short-error-messages.unknown',
   FILE_TOO_BIG: 'issues.short-error-messages.file-too-big',
   FILE_NON_EXTENSION: 'issues.short-error-messages.file-non-extension',
+  DUPLICATED_NODE: 'issues.short-error-messages.duplicated-node',
 };
 
 export const longMessages: ProcessErrorMessages = {
@@ -25,4 +26,5 @@ export const longMessages: ProcessErrorMessages = {
   UNKNOWN: 'issues.error-messages.unknown',
   FILE_TOO_BIG: 'issues.error-messages.file-too-big',
   FILE_NON_EXTENSION: 'issues.error-messages.file-non-extension',
+  DUPLICATED_NODE: 'issues.error-messages.duplicated-node',
 };

--- a/src/apps/renderer/pages/ProcessIssues/List.tsx
+++ b/src/apps/renderer/pages/ProcessIssues/List.tsx
@@ -202,7 +202,7 @@ function Item({
 
         <div className="flex flex-col space-y-1">
           <h1
-            className="flex flex-1 flex-col truncate text-base font-medium leading-5 text-gray-100"
+            className="flex flex-1 flex-col text-base font-medium leading-5 text-gray-100"
             data-test="sync-issue-name"
           >
             {translate(shortMessages[errorName])}

--- a/src/apps/renderer/pages/Widget/Item.tsx
+++ b/src/apps/renderer/pages/Widget/Item.tsx
@@ -68,7 +68,8 @@ export function Item({
                 action === 'DOWNLOAD_ERROR' ||
                 action === 'UPLOAD_ERROR' ||
                 action === 'RENAME_ERROR' ||
-                action === 'METADATA_READ_ERROR')
+                action === 'METADATA_READ_ERROR' ||
+                action === 'GENERATE_TREE')
                 ? 'text-red'
                 : undefined
             }`}
@@ -78,7 +79,8 @@ export function Item({
                 action === 'DOWNLOAD_ERROR' ||
                 action === 'UPLOAD_ERROR' ||
                 action === 'RENAME_ERROR' ||
-                action === 'METADATA_READ_ERROR')
+                action === 'METADATA_READ_ERROR' ||
+                action === 'GENERATE_TREE')
                 ? description
                 : undefined
             }
@@ -123,7 +125,8 @@ export function Item({
               action === 'DOWNLOAD_ERROR' ||
               action === 'UPLOAD_ERROR' ||
               action === 'RENAME_ERROR' ||
-              action === 'METADATA_READ_ERROR') && (
+              action === 'METADATA_READ_ERROR' ||
+              action === 'GENERATE_TREE') && (
               <WarningCircle size={24} className="text-red" weight="regular" />
             )}
         </div>

--- a/src/apps/shared/IPC/events/sync-engine.ts
+++ b/src/apps/shared/IPC/events/sync-engine.ts
@@ -128,6 +128,10 @@ export type SyncEngineInvocableFunctions = {
 // TODO: change how errors are reported to the ui
 export type ProcessInfoUpdate = {
   SYNC_INFO_UPDATE: (payload: ProcessInfoUpdatePayload) => void;
+  SYNC_PROBLEM: (payload: {
+    key: string;
+    additionalData: Record<string, any>;
+  }) => void;
 };
 
 export type FromProcess = FilesEvents &

--- a/src/apps/shared/types.ts
+++ b/src/apps/shared/types.ts
@@ -149,7 +149,10 @@ export type ProcessErrorName =
   | 'FILE_NON_EXTENSION'
 
   // Unknown error
-  | 'UNKNOWN';
+  | 'UNKNOWN'
+
+  // Duplicated node path
+  | 'DUPLICATED_NODE';
 
 export class ProcessError extends Error {
   details: ErrorDetails;
@@ -213,7 +216,8 @@ export type ProcessIssue = ProcessInfoBase & {
     | 'DOWNLOAD_ERROR'
     | 'RENAME_ERROR'
     | 'DELETE_ERROR'
-    | 'METADATA_READ_ERROR';
+    | 'METADATA_READ_ERROR'
+    | 'GENERATE_TREE';
 
   errorName: ProcessErrorName;
   process: 'SYNC' | 'BACKUPS';

--- a/src/apps/sync-engine/dependency-injection/common/traverser.ts
+++ b/src/apps/sync-engine/dependency-injection/common/traverser.ts
@@ -1,6 +1,7 @@
 import crypt from '../../../../context/shared/infrastructure/crypt';
 import { Traverser } from '../../../../context/virtual-drive/items/application/Traverser';
 import { DependencyInjectionUserProvider } from './user';
+import { ipcRendererSyncEngine } from '../../ipcRendererSyncEngine';
 
 export class DependencyInjectionTraverserProvider {
   private static traverser: Traverser;
@@ -12,7 +13,11 @@ export class DependencyInjectionTraverserProvider {
 
     const user = DependencyInjectionUserProvider.get();
 
-    const traverser = Traverser.existingItems(crypt, user.root_folder_id);
+    const traverser = Traverser.existingItems(
+      crypt,
+      ipcRendererSyncEngine,
+      user.root_folder_id
+    );
 
     DependencyInjectionTraverserProvider.traverser = traverser;
 

--- a/src/apps/sync-engine/dependency-injection/items/builder.ts
+++ b/src/apps/sync-engine/dependency-injection/items/builder.ts
@@ -19,10 +19,12 @@ export function buildItemsContainer(): ItemsContainer {
 
   const existingItemsTraverser = Traverser.existingItems(
     nameDecryptor,
+    ipcRendererSyncEngine,
     user.root_folder_id
   );
   const allStatusesTraverser = Traverser.allItems(
     nameDecryptor,
+    ipcRendererSyncEngine,
     user.root_folder_id
   );
   const treeBuilder = new TreeBuilder(

--- a/src/context/virtual-drive/items/application/Traverser.ts
+++ b/src/context/virtual-drive/items/application/Traverser.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/electron/renderer';
 import Logger from 'electron-log';
+import { SyncEngineIpc } from '../../../../apps/sync-engine/ipcRendererSyncEngine';
 import {
   ServerFile,
   ServerFileStatus,
@@ -27,22 +28,32 @@ type Items = {
 export class Traverser {
   constructor(
     private readonly decrypt: NameDecrypt,
+    private readonly ipc: SyncEngineIpc,
     private readonly baseFolderId: number,
     private readonly fileStatusesToFilter: Array<ServerFileStatus>,
     private readonly folderStatusesToFilter: Array<ServerFolderStatus>
   ) {}
 
-  static existingItems(decrypt: NameDecrypt, baseFolderId: number): Traverser {
+  static existingItems(
+    decrypt: NameDecrypt,
+    ipc: SyncEngineIpc,
+    baseFolderId: number
+  ): Traverser {
     return new Traverser(
       decrypt,
+      ipc,
       baseFolderId,
       [ServerFileStatus.EXISTS],
       [ServerFolderStatus.EXISTS]
     );
   }
 
-  static allItems(decrypt: NameDecrypt, baseFolderId: number): Traverser {
-    return new Traverser(decrypt, baseFolderId, [], []);
+  static allItems(
+    decrypt: NameDecrypt,
+    ipc: SyncEngineIpc,
+    baseFolderId: number
+  ): Traverser {
+    return new Traverser(decrypt, ipc, baseFolderId, [], []);
   }
 
   private createRootFolder(): Folder {
@@ -95,6 +106,12 @@ export class Traverser {
         (error): void => {
           Logger.warn('[Traverser] Error adding file:', error);
           Sentry.captureException(error);
+          this.ipc.send('SYNC_PROBLEM', {
+            key: 'node-duplicated',
+            additionalData: {
+              name: serverFile.plainName,
+            },
+          });
         },
         () => {
           //  no-op
@@ -128,6 +145,12 @@ export class Traverser {
         (error) => {
           Logger.warn(`[Traverser] Error adding folder:  ${error} `);
           Sentry.captureException(error);
+          this.ipc.send('SYNC_PROBLEM', {
+            key: 'node-duplicated',
+            additionalData: {
+              name,
+            },
+          });
         },
         (folder) => {
           if (folder.hasStatus(FolderStatuses.EXISTS)) {

--- a/src/context/virtual-drive/items/domain/FolderNode.ts
+++ b/src/context/virtual-drive/items/domain/FolderNode.ts
@@ -1,6 +1,7 @@
 import { Folder } from '../../folders/domain/Folder';
 import { FileNode } from './FileNode';
 import { Node } from './Node';
+
 export class FolderNode {
   private constructor(
     public readonly folder: Folder,
@@ -17,7 +18,7 @@ export class FolderNode {
 
   addChild(node: Node): void {
     if (this.children.has(node.id)) {
-      throw new Error('Child already exists');
+      throw new Error(`Duplicated node detected: ${node.id}`);
     }
 
     this.children.set(node.id, node);

--- a/tests/context/virtual-drive/items/application/Traverser.test.ts
+++ b/tests/context/virtual-drive/items/application/Traverser.test.ts
@@ -8,10 +8,12 @@ import {
 } from '../../../../../src/context/shared/domain/ServerFolder';
 import { Traverser } from '../../../../../src/context/virtual-drive/items/application/Traverser';
 import { ContentsIdMother } from '../../contents/domain/ContentsIdMother';
+import { IpcRendererSyncEngineMock } from '../../shared/__mock__/IpcRendererSyncEngineMock';
 import { FakeNameDecrypt } from '../infrastructure/FakeNameDecrypt';
 
 describe('Traverser', () => {
   const nameDecrypt = new FakeNameDecrypt();
+  const ipc = new IpcRendererSyncEngineMock();
 
   it('first level files starts with /', () => {
     const baseFolderId = 6;
@@ -29,6 +31,7 @@ describe('Traverser', () => {
     };
     const SUT = new Traverser(
       nameDecrypt,
+      ipc,
       baseFolderId,
       [ServerFileStatus.EXISTS, ServerFileStatus.TRASHED],
       [ServerFolderStatus.EXISTS]
@@ -64,6 +67,7 @@ describe('Traverser', () => {
     };
     const SUT = new Traverser(
       nameDecrypt,
+      ipc,
       baseFolderId,
       [ServerFileStatus.EXISTS, ServerFileStatus.TRASHED],
       [ServerFolderStatus.EXISTS]
@@ -91,6 +95,7 @@ describe('Traverser', () => {
     };
     const SUT = new Traverser(
       nameDecrypt,
+      ipc,
       baseFolderId,
       [ServerFileStatus.EXISTS, ServerFileStatus.TRASHED],
       [ServerFolderStatus.EXISTS]
@@ -124,6 +129,7 @@ describe('Traverser', () => {
     };
     const SUT = new Traverser(
       nameDecrypt,
+      ipc,
       baseFolderId,
       [ServerFileStatus.EXISTS, ServerFileStatus.TRASHED],
       [ServerFolderStatus.EXISTS]
@@ -157,6 +163,7 @@ describe('Traverser', () => {
     };
     const SUT = new Traverser(
       nameDecrypt,
+      ipc,
       baseFolderId,
       [ServerFileStatus.EXISTS, ServerFileStatus.TRASHED],
       [ServerFolderStatus.EXISTS]
@@ -197,6 +204,7 @@ describe('Traverser', () => {
     };
     const SUT = new Traverser(
       nameDecrypt,
+      ipc,
       baseFolderId,
       [ServerFileStatus.EXISTS, ServerFileStatus.TRASHED],
       [ServerFolderStatus.EXISTS]
@@ -224,6 +232,7 @@ describe('Traverser', () => {
     };
     const SUT = new Traverser(
       nameDecrypt,
+      ipc,
       baseFolderId,
       [ServerFileStatus.EXISTS, ServerFileStatus.TRASHED],
       [ServerFolderStatus.EXISTS]
@@ -259,6 +268,7 @@ describe('Traverser', () => {
     };
     const SUT = new Traverser(
       nameDecrypt,
+      ipc,
       baseFolderId,
       [ServerFileStatus.EXISTS, ServerFileStatus.TRASHED],
       [ServerFolderStatus.EXISTS]
@@ -294,6 +304,7 @@ describe('Traverser', () => {
     };
     const SUT = new Traverser(
       nameDecrypt,
+      ipc,
       baseFolderId,
       [ServerFileStatus.EXISTS, ServerFileStatus.TRASHED],
       [ServerFolderStatus.EXISTS]


### PR DESCRIPTION
**Why**
On web, we can create files and folders with the same name but on desktop, we cannot due how the OS File System does not allow it.

**Proposed solution**
Ignore one of the "duplicated" elements and notify the user that we cannot sync both of them.