### PR TITLE
[PB-1671] fix: catch errors from auto update

### DIFF
--- a/src/apps/main/main.ts
+++ b/src/apps/main/main.ts
@@ -69,8 +69,12 @@ if (process.env.SENTRY_DSN) {
 }
 
 function checkForUpdates() {
-  autoUpdater.logger = Logger;
-  autoUpdater.checkForUpdatesAndNotify();
+  try {
+    autoUpdater.logger = Logger;
+    autoUpdater.checkForUpdatesAndNotify();
+  } catch (err: unknown) {
+    Logger.error(err);
+  }
 }
 
 if (process.platform === 'darwin') {


### PR DESCRIPTION
Since Windows and Linux don't have the same version on production the app will try to get the latest yml for its platform on the latest version available in GitHub. If the latest version is not the one for that platform it will not be found and an error will thrown. That error was not being handled