### PR TITLE
patch: this awaits for files to download ?

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internxt-drive",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "author": "Internxt <hello@internxt.com>",
   "description": "Internxt Drive client UI",
   "license": "AGPL-3.0",

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internxt-drive",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Internxt Drive client UI",
   "main": "./dist/main/main.js",
   "author": "Internxt <hello@internxt.com>",

--- a/release/app/yarn.lock
+++ b/release/app/yarn.lock
@@ -30,6 +30,18 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
+"@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.3.0.tgz#8368869dcb735be2e7f5cb7647de78e167a251fb"
+  integrity sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==
+
+"@hapi/topo@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.1.0.tgz#dc448e332c6c6e37a4dc02fd84ba8d44b9afb012"
+  integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
 "@ioredis/commands@^1.1.1":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz"
@@ -90,6 +102,23 @@
   dependencies:
     component-type "^1.2.1"
     join-component "^1.1.0"
+
+"@sideway/address@^4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.5.tgz#4bc149a0076623ced99ca8208ba780d65a99b9d5"
+  integrity sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.1.tgz#80fcbcbaf7ce031e0ef2dd29b1bfc7c3f583611f"
+  integrity sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@sqltools/formatter@^1.2.5":
   version "1.2.5"
@@ -374,6 +403,11 @@ dotenv@^16.0.3:
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz"
   integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
 
+dotenv@^16.4.1:
+  version "16.4.4"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.4.tgz#a26e7bb95ebd36272ebb56edb80b826aecf224c1"
+  integrity sha512-XvPXc8XAQThSjAbY6cQ/9PcBXmFoWuw1sQ3b8HqUCR6ziGXjkTi//kB9SWa2UwqlgdAIuRqAa/9hVljzPehbYg==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
@@ -529,6 +563,17 @@ is-stream@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
+joi@^17.12.0:
+  version "17.12.1"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.12.1.tgz#3347ecf4cd3301962d42191c021b165eef1f395b"
+  integrity sha512-vtxmq+Lsc5SlfqotnfVjlViWfOL9nt/avKNbKYizwf6gsCfq9NYY/ceYRMFD8XDdrjJ9abJyScWmhmIiy+XRtQ==
+  dependencies:
+    "@hapi/hoek" "^9.3.0"
+    "@hapi/topo" "^5.1.0"
+    "@sideway/address" "^4.1.5"
+    "@sideway/formula" "^3.0.1"
+    "@sideway/pinpoint" "^2.0.0"
 
 join-component@^1.1.0:
   version "1.1.0"
@@ -1031,7 +1076,10 @@ uuid@^9.0.0:
 virtual-drive@../../../node-win:
   version "1.0.1"
   dependencies:
+    dotenv "^16.4.1"
+    joi "^17.12.0"
     tsconfig-paths "^4.2.0"
+    yargs "^17.7.2"
 
 winston-transport@^4.5.0:
   version "4.5.0"
@@ -1106,7 +1154,7 @@ yargs@^16.0.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.6.2:
+yargs@^17.6.2, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==

--- a/src/apps/main/fordwardToWindows.ts
+++ b/src/apps/main/fordwardToWindows.ts
@@ -22,6 +22,16 @@ ipcMainDrive.on('FILE_DOWNLOADING', (_, payload) => {
   });
 });
 
+ipcMainDrive.on('FILE_PREPARING', (_, payload) => {
+  const { nameWithExtension, processInfo } = payload;
+
+  broadcastToWindows('sync-info-update', {
+    action: 'PREPARING',
+    name: nameWithExtension,
+    progress: processInfo.progress,
+  });
+});
+
 ipcMainDrive.on('FILE_DOWNLOADED', (_, payload) => {
   const { nameWithExtension } = payload;
 

--- a/src/apps/main/tray/handlers.ts
+++ b/src/apps/main/tray/handlers.ts
@@ -28,6 +28,10 @@ ipcMainDrive.on('FILE_DOWNLOADING', () => {
   setTrayStatus('SYNCING');
 });
 
+ipcMainDrive.on('FILE_PREPARING', () => {
+  setTrayStatus('SYNCING');
+});
+
 ipcMainDrive.on('FILE_DOWNLOADED', () => {
   setTrayStatus('IDLE');
 });

--- a/src/apps/renderer/localize/locales/en.json
+++ b/src/apps/renderer/localize/locales/en.json
@@ -141,6 +141,7 @@
       "activity": {
         "operation": {
           "downloading": "Downloading",
+          "preparing": "Preparing",
           "decrypting": "Decrypting",
           "uploading": "Uploading",
           "encrypting": "Encrypting",

--- a/src/apps/renderer/localize/locales/es.json
+++ b/src/apps/renderer/localize/locales/es.json
@@ -141,6 +141,7 @@
       "activity": {
         "operation": {
           "downloading": "Descargando",
+          "preparing": "Preparando",
           "decrypting": "Desencriptando",
           "uploading": "Subiendo",
           "encrypting": "Encriptando",

--- a/src/apps/renderer/localize/locales/fr.json
+++ b/src/apps/renderer/localize/locales/fr.json
@@ -140,6 +140,7 @@
       "activity": {
         "operation": {
           "downloading": "Téléchargement",
+          "preparing": "Préparation",
           "decrypting": "Décryptage",
           "uploading": "téléchargement",
           "encrypting": "Encryptage",

--- a/src/apps/renderer/pages/Widget/Item.tsx
+++ b/src/apps/renderer/pages/Widget/Item.tsx
@@ -27,6 +27,8 @@ export function Item({
     description = progress
       ? translate('widget.body.activity.operation.downloading')
       : translate('widget.body.activity.operation.decrypting');
+  } else if (action === 'PREPARING') {
+    description = translate('widget.body.activity.operation.preparing');
   } else if (action === 'UPLOADING') {
     description = progress
       ? translate('widget.body.activity.operation.uploading')
@@ -94,6 +96,7 @@ export function Item({
           {action &&
             (action === 'UPLOADING' ||
               action === 'DOWNLOADING' ||
+              action === 'PREPARING' ||
               action === 'RENAMING' ||
               action === 'DELETING') && (
               <CircularProgressbar

--- a/src/apps/shared/IPC/events/drive.ts
+++ b/src/apps/shared/IPC/events/drive.ts
@@ -35,6 +35,7 @@ type UploadEvents = {
 
 type DownloadEvents = {
   FILE_DOWNLOADING: (payload: FileProgressInfo) => void;
+  FILE_PREPARING: (payload: FileProgressInfo) => void;
   FILE_DOWNLOADED: (payload: FileProgressInfo) => void;
   FILE_DOWNLOAD_ERROR: (payload: FileErrorInfo) => void;
 };

--- a/src/apps/shared/IPC/events/sync-engine.ts
+++ b/src/apps/shared/IPC/events/sync-engine.ts
@@ -66,6 +66,7 @@ export type FilesEvents = {
   }) => void;
 
   FILE_DOWNLOADING: (payload: FileUpdatePayload) => void;
+  FILE_PREPARING: (payload: FileUpdatePayload) => void;
   FILE_DOWNLOADED: (payload: FileUpdatePayload) => void;
   FILE_UPLOAD_ERROR: (payload: {
     name: string;

--- a/src/apps/shared/fs/write-readable-to-file.ts
+++ b/src/apps/shared/fs/write-readable-to-file.ts
@@ -21,7 +21,7 @@ export class WriteReadableToFile {
           return;
         }
         if (size !== expectedSize) {
-          reject('Wried file does not have expected size');
+          reject(new Error('Wried file does not have expected size'));
           return;
         }
 

--- a/src/apps/shared/fs/write-readable-to-file.ts
+++ b/src/apps/shared/fs/write-readable-to-file.ts
@@ -1,14 +1,33 @@
 import fs, { PathLike } from 'fs';
+import { stat } from 'fs/promises';
 import { Readable } from 'stream';
 
 export class WriteReadableToFile {
-  static write(readable: Readable, path: PathLike): Promise<void> {
+  static write(
+    readable: Readable,
+    path: PathLike,
+    expectedSize?: number
+  ): Promise<void> {
     const writableStream = fs.createWriteStream(path);
 
     readable.pipe(writableStream);
 
     return new Promise<void>((resolve, reject) => {
-      writableStream.on('finish', resolve);
+      writableStream.on('finish', async () => {
+        const { size } = await stat(path);
+
+        if (!expectedSize) {
+          resolve();
+          return;
+        }
+        if (size !== expectedSize) {
+          reject('Wried file does not have expected size');
+          return;
+        }
+
+        resolve();
+      });
+
       writableStream.on('error', reject);
     });
   }

--- a/src/apps/shared/types.ts
+++ b/src/apps/shared/types.ts
@@ -227,7 +227,12 @@ export type ProcessInfoUpdatePayload =
   | (ProcessInfoBase &
       (
         | {
-            action: 'UPLOADING' | 'DOWNLOADING' | 'RENAMING' | 'DELETING';
+            action:
+              | 'UPLOADING'
+              | 'DOWNLOADING'
+              | 'PREPARING'
+              | 'RENAMING'
+              | 'DELETING';
             progress: number;
           }
         | {

--- a/src/apps/sync-engine/BindingManager.ts
+++ b/src/apps/sync-engine/BindingManager.ts
@@ -96,11 +96,8 @@ export class BindingsManager {
         callback: CallbackDownload
       ) => {
         try {
-          const path = await controllers.downloadFile.execute(
-            contentsId,
-            callback
-          );
-          Logger.debug('Execute Fetch Data Callback, sending path:', path);
+          Logger.debug('[Fetch Data Callback] Donwloading begins');
+          const path = await controllers.downloadFile.execute(contentsId);
           const file = controllers.downloadFile.fileFinderByContentsId(
             contentsId
               .replace(
@@ -110,35 +107,43 @@ export class BindingsManager {
               )
               .split(':')[1]
           );
+          Logger.debug('[Fetch Data Callback] Preparing begins', path);
           let finished = false;
-          while (!finished) {
-            const result = await callback(true, path);
-            finished = result.finished;
-            if (this.progressBuffer == result.progress) {
-              break;
-            } else {
-              this.progressBuffer = result.progress;
-            }
-            Logger.debug('condition', finished);
-            ipcRendererSyncEngine.send('FILE_DOWNLOADING', {
-              name: file.name,
-              extension: file.type,
-              nameWithExtension: file.nameWithExtension,
-              size: file.size,
-              processInfo: {
-                elapsedTime: 0,
-                progress: result.progress,
-              },
-            });
-          }
-
-          this.progressBuffer = 0;
           try {
+            while (!finished) {
+              const result = await callback(true, path);
+              finished = result.finished;
+              Logger.debug('callback result', result);
+
+              if (finished && result.progress === 0) {
+                throw new Error('Result progress is 0');
+              } else if (this.progressBuffer == result.progress) {
+                break;
+              } else {
+                this.progressBuffer = result.progress;
+              }
+              Logger.debug('condition', finished);
+              ipcRendererSyncEngine.send('FILE_PREPARING', {
+                name: file.name,
+                extension: file.type,
+                nameWithExtension: file.nameWithExtension,
+                size: file.size,
+                processInfo: {
+                  elapsedTime: 0,
+                  progress: result.progress,
+                },
+              });
+            }
+            this.progressBuffer = 0;
+
             await controllers.notifyPlaceholderHydrationFinished.execute(
               contentsId
             );
+
+            await this.container.virtualDrive.closeDownloadMutex();
           } catch (error) {
             Logger.error('notify: ', error);
+            await this.container.virtualDrive.closeDownloadMutex();
           }
 
           // Esperar hasta que la ejecución de fetchDataCallback esté completa antes de continuar

--- a/src/apps/sync-engine/callbacks-controllers/controllers/DownloadFileController.ts
+++ b/src/apps/sync-engine/callbacks-controllers/controllers/DownloadFileController.ts
@@ -2,7 +2,6 @@ import Logger from 'electron-log';
 import { ContentsDownloader } from '../../../../context/virtual-drive/contents/application/ContentsDownloader';
 import { FileFinderByContentsId } from '../../../../context/virtual-drive/files/application/FileFinderByContentsId';
 import { FilePlaceholderId } from '../../../../context/virtual-drive/files/domain/PlaceholderId';
-import { CallbackDownload } from '../../BindingManager';
 import { CallbackController } from './CallbackController';
 
 export class DownloadFileController extends CallbackController {
@@ -13,25 +12,21 @@ export class DownloadFileController extends CallbackController {
     super();
   }
 
-  private async action(id: string, cb: CallbackDownload): Promise<string> {
+  private async action(id: string): Promise<string> {
     const file = this.fileFinder.run(id);
-
-    return await this.downloader.run(file, cb);
+    return await this.downloader.run(file);
   }
 
   fileFinderByContentsId(contentsId: string) {
     return this.fileFinder.run(contentsId);
   }
 
-  async execute(
-    filePlaceholderId: FilePlaceholderId,
-    cb: CallbackDownload
-  ): Promise<string> {
+  async execute(filePlaceholderId: FilePlaceholderId): Promise<string> {
     const trimmedId = this.trim(filePlaceholderId);
 
     try {
       const [_, contentsId] = trimmedId.split(':');
-      return await this.action(contentsId, cb);
+      return await this.action(contentsId);
     } catch (error: unknown) {
       Logger.error(
         'Error downloading a file, going to refresh and retry: ',
@@ -42,8 +37,7 @@ export class DownloadFileController extends CallbackController {
         setTimeout(async () => {
           try {
             const [_, contentsId] = trimmedId.split(':');
-            Logger.debug('cb: ', cb);
-            const result = await this.action(contentsId, cb);
+            const result = await this.action(contentsId);
             resolve(result);
           } catch (error) {
             reject(error);

--- a/src/context/virtual-drive/contents/application/ContentsDownloader.ts
+++ b/src/context/virtual-drive/contents/application/ContentsDownloader.ts
@@ -2,7 +2,6 @@ import Logger from 'electron-log';
 import path from 'path';
 import { Readable } from 'stream';
 import { ensureFolderExists } from '../../../../apps/shared/fs/ensure-folder-exists';
-import { CallbackDownload } from '../../../../apps/sync-engine/BindingManager';
 import { SyncEngineIpc } from '../../../../apps/sync-engine/ipcRendererSyncEngine';
 import { File } from '../../files/domain/File';
 import { EventBus } from '../../shared/domain/EventBus';

--- a/src/context/virtual-drive/contents/domain/contentHandlers/ContentFileDownloader.ts
+++ b/src/context/virtual-drive/contents/domain/contentHandlers/ContentFileDownloader.ts
@@ -19,4 +19,6 @@ export interface ContentFileDownloader {
   ): void;
 
   elapsedTime(): number;
+
+  removeListeners(): void;
 }

--- a/src/context/virtual-drive/contents/infrastructure/FSLocalFileWriter.ts
+++ b/src/context/virtual-drive/contents/infrastructure/FSLocalFileWriter.ts
@@ -16,7 +16,7 @@ export class FSLocalFileWriter implements LocalFileWriter {
 
     const filePath = path.join(location, contents.nameWithExtension);
 
-    await WriteReadableToFile.write(contents.stream, filePath);
+    await WriteReadableToFile.write(contents.stream, filePath, contents.size);
 
     return filePath;
   }

--- a/tests/context/virtual-drive/contents/__mocks__/ContentFileDownloaderMock.ts
+++ b/tests/context/virtual-drive/contents/__mocks__/ContentFileDownloaderMock.ts
@@ -9,6 +9,10 @@ export class ContentFileDownloaderMock implements ContentFileDownloader {
   onMock = jest.fn();
   elapsedTimeMock = jest.fn();
 
+  removeListeners(): void {
+    return;
+  }
+
   download(): Promise<Readable> {
     return this.mock();
   }

--- a/tests/context/virtual-drive/contents/application/ContentsDownloader._test.ts
+++ b/tests/context/virtual-drive/contents/application/ContentsDownloader._test.ts
@@ -40,10 +40,7 @@ describe.skip('Contents Downloader', () => {
         new ReadableHelloWorld()
       );
 
-      await SUT.run(FileMother.any(), async () => {
-        /* do nothing */
-        return { finished: true, progress: 100 };
-      });
+      await SUT.run(FileMother.any());
 
       expect(factory.mockDownloader.onMock).toBeCalledWith(
         event,
@@ -56,10 +53,7 @@ describe.skip('Contents Downloader', () => {
     factory.mockDownloader.mock.mockResolvedValueOnce(new ReadableHelloWorld());
 
     const file = FileMother.any();
-    await SUT.run(file, async () => {
-      /* do nothing */
-      return { finished: true, progress: 100 };
-    });
+    await SUT.run(file);
 
     expect(localWriter.writeMock).toBeCalledWith(
       expect.objectContaining({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1285,10 +1285,19 @@
   resolved "https://npm.pkg.github.com/download/@internxt/lib/1.2.0/172d7929abb3dc34fda044ad9977875791f7a471#172d7929abb3dc34fda044ad9977875791f7a471"
   integrity sha512-14byNxSU0S0KSc3g+BWiJb7/fcHUfqxkHQRz9fwJhAHNmgOo+Bhx13xXk07KKUzeNX1JymSGEZkVCk0AOQiM+Q==
 
-"@internxt/sdk@^1.4.27", "@internxt/sdk@^1.4.33":
+"@internxt/sdk@^1.4.27":
   version "1.4.35"
   resolved "https://npm.pkg.github.com/download/@internxt/sdk/1.4.35/d947a5608ce9c16dbf22984f3b4ae3a0c4bd87cb#d947a5608ce9c16dbf22984f3b4ae3a0c4bd87cb"
   integrity sha512-WX5cJiRoj8buRobAq+zRPKNavZ09vbCNdw9PVtEG6A5okK4wYIaGqbWBTldffgrO4JgtyNbMqxUCDD0i0UUSCQ==
+  dependencies:
+    axios "^0.24.0"
+    query-string "^7.1.0"
+    uuid "^8.3.2"
+
+"@internxt/sdk@^1.4.68":
+  version "1.4.71"
+  resolved "https://npm.pkg.github.com/download/@internxt/sdk/1.4.71/eb6f1cd524f2a861afdb1f14483848910bc0d0a7#eb6f1cd524f2a861afdb1f14483848910bc0d0a7"
+  integrity sha512-pirbb8odDDdqJxXwpNapVdLlhSw9di2emklzVza81JuWzXeyOlwpgvu65JU0RFZ+AjSl+0mJR4fmdfbh3evTEA==
   dependencies:
     axios "^0.24.0"
     query-string "^7.1.0"


### PR DESCRIPTION
- Removed the force download as @cg27shokworks mentioned it was not being used to simplify the callback
- Moved the tracker record for download after the await of the await of the write, just to simplify too

- Added a check when the writer ends writing the stream, so if the downloaded file does not have the expected size it fails. After that I could not get any errors in the download (I don't think the change made it work but could not test it).

