### PR TITLE
[PB-1977] fix: SIGTRAP when calling safe storage methods

### DIFF
--- a/src/apps/main/auth/handlers.ts
+++ b/src/apps/main/auth/handlers.ts
@@ -58,13 +58,18 @@ export function onUserUnauthorized() {
 ipcMain.on('user-is-unauthorized', onUserUnauthorized);
 
 ipcMain.on('user-logged-in', async (_, data: AccessResponse) => {
-  setCredentials(data.user, data.user.mnemonic, data.token, data.newToken);
-  if (!canHisConfigBeRestored(data.user.uuid)) {
-    await setupRootFolder();
-  }
+  try {
+    setCredentials(data.user, data.user.mnemonic, data.token, data.newToken);
+    if (!canHisConfigBeRestored(data.user.uuid)) {
+      await setupRootFolder();
+    }
 
-  setIsLoggedIn(true);
-  eventBus.emit('USER_LOGGED_IN');
+    setIsLoggedIn(true);
+    eventBus.emit('USER_LOGGED_IN');
+  } catch (err) {
+    Logger.info('USER TOKENS:', data.token, data.newToken);
+    Logger.error(err);
+  }
 });
 
 ipcMain.on('user-logged-out', () => {

--- a/src/apps/main/auth/handlers.ts
+++ b/src/apps/main/auth/handlers.ts
@@ -67,7 +67,6 @@ ipcMain.on('user-logged-in', async (_, data: AccessResponse) => {
     setIsLoggedIn(true);
     eventBus.emit('USER_LOGGED_IN');
   } catch (err) {
-    Logger.info('USER TOKENS:', data.token, data.newToken);
     Logger.error(err);
   }
 });

--- a/src/apps/main/auth/handlers.ts
+++ b/src/apps/main/auth/handlers.ts
@@ -59,7 +59,12 @@ ipcMain.on('user-is-unauthorized', onUserUnauthorized);
 
 ipcMain.on('user-logged-in', async (_, data: AccessResponse) => {
   try {
-    setCredentials(data.user, data.user.mnemonic, data.token, data.newToken);
+    await setCredentials(
+      data.user,
+      data.user.mnemonic,
+      data.token,
+      data.newToken
+    );
     if (!canHisConfigBeRestored(data.user.uuid)) {
       await setupRootFolder();
     }

--- a/src/apps/main/auth/service.ts
+++ b/src/apps/main/auth/service.ts
@@ -4,6 +4,7 @@ import Logger from 'electron-log';
 import packageConfig from '../../../../package.json';
 import ConfigStore, { defaults, fieldsToSave } from '../config';
 import { User } from '../types';
+import { Delay } from '../../shared/Delay';
 
 const TOKEN_ENCODING = 'latin1';
 
@@ -39,7 +40,7 @@ function ecnryptToken(token: string): string {
   return buffer.toString(TOKEN_ENCODING);
 }
 
-export function setCredentials(
+export async function setCredentials(
   userData: User,
   mnemonic: string,
   bearerToken: string,
@@ -47,6 +48,11 @@ export function setCredentials(
 ) {
   ConfigStore.set('mnemonic', mnemonic);
   ConfigStore.set('userData', userData);
+
+  await Delay.ms(1_000);
+  // In the version of electron we are using calling
+  // isEncryptionAvailable or decryptString "too son" will crash the app
+  // we will be able to remove once we can update the electron version
 
   const isSafeStorageAvailable = safeStorage.isEncryptionAvailable();
 

--- a/src/apps/shared/Delay.ts
+++ b/src/apps/shared/Delay.ts
@@ -1,0 +1,7 @@
+export class Delay {
+  static ms(milliseconds: number): Promise<void> {
+    return new Promise((resolve) => {
+      setTimeout(resolve, milliseconds);
+    });
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12673,6 +12673,11 @@ unbox-primitive@^1.0.2:
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
 undici@^5.5.1:
   version "5.22.1"
   resolved "https://registry.yarnpkg.com/undici/-/undici-5.22.1.tgz#877d512effef2ac8be65e695f3586922e1a57d7b"


### PR DESCRIPTION
Adds 1-second delay as suggested by a comment for a workaround  on https://github.com/electron/electron/issues/32206 