### PR TITLE
[_] fix: ensure newer files are included

### DIFF
--- a/src/apps/main/analytics/user-handlers.ts
+++ b/src/apps/main/analytics/user-handlers.ts
@@ -6,7 +6,6 @@ import {
   userSignin,
   userSigninFailed,
 } from './service';
-import { clearRemoteSyncStore } from '../remote-sync/helpers';
 import { clearTempFolder } from '../app-info/helpers';
 
 eventBus.on('USER_LOGGED_IN', () => {
@@ -16,7 +15,6 @@ eventBus.on('USER_LOGGED_IN', () => {
 
 eventBus.on('USER_LOGGED_OUT', () => {
   userLogout();
-  clearRemoteSyncStore();
   clearTempFolder();
 });
 

--- a/src/apps/main/database/adapters/base.ts
+++ b/src/apps/main/database/adapters/base.ts
@@ -1,20 +1,20 @@
-export abstract class DatabaseCollectionAdapter<DatabaseItemType> {
+export interface DatabaseCollectionAdapter<DatabaseItemType> {
   /**
    * Used to initialize the database adapter
    */
-  abstract connect(): Promise<{ success: boolean }>;
+  connect(): Promise<{ success: boolean }>;
 
   /**
    * Gets an item from the database
    */
-  abstract get(
+  get(
     itemId: string
   ): Promise<{ success: boolean; result: DatabaseItemType | null }>;
 
   /**
    * Updates an item in the database
    */
-  abstract update(
+  update(
     itemId: string,
     updatePayload: Partial<DatabaseItemType>
   ): Promise<{
@@ -25,7 +25,7 @@ export abstract class DatabaseCollectionAdapter<DatabaseItemType> {
   /**
    * Creates an item in the database
    */
-  abstract create(creationPayload: DatabaseItemType): Promise<{
+  create(creationPayload: DatabaseItemType): Promise<{
     success: boolean;
     result: DatabaseItemType | null;
   }>;
@@ -33,7 +33,12 @@ export abstract class DatabaseCollectionAdapter<DatabaseItemType> {
   /**
    * Removes an item from the database
    */
-  abstract remove(itemId: string): Promise<{
+  remove(itemId: string): Promise<{
     success: boolean;
+  }>;
+
+  getLastUpdated(): Promise<{
+    success: boolean;
+    result: DatabaseItemType | null;
   }>;
 }

--- a/src/apps/main/database/collections/DriveFileCollection.ts
+++ b/src/apps/main/database/collections/DriveFileCollection.ts
@@ -78,11 +78,7 @@ export class DriveFilesCollection
     try {
       const queryResult = await this.repository
         .createQueryBuilder('drive_file')
-        .orderBy(
-          // eslint-disable-next-line quotes
-          "STR_TO_DATE(drive_file.updatedAt, '%Y-%m-%dT%H:%i:%sZ')",
-          'DESC'
-        )
+        .orderBy('datetime(drive_file.updatedAt)', 'DESC')
         .getOne();
 
       return {

--- a/src/apps/main/database/collections/DriveFolderCollection.ts
+++ b/src/apps/main/database/collections/DriveFolderCollection.ts
@@ -2,6 +2,9 @@ import { DatabaseCollectionAdapter } from '../adapters/base';
 import { AppDataSource } from '../data-source';
 import { DriveFolder } from '../entities/DriveFolder';
 import { Repository } from 'typeorm';
+import * as Sentry from '@sentry/electron/main';
+import Logger from 'electron-log';
+
 export class DriveFoldersCollection
   implements DatabaseCollectionAdapter<DriveFolder>
 {
@@ -65,5 +68,33 @@ export class DriveFoldersCollection
     return {
       success: result.affected ? true : false,
     };
+  }
+
+  async getLastUpdated(): Promise<{
+    success: boolean;
+    result: DriveFolder | null;
+  }> {
+    try {
+      const queryResult = await this.repository
+        .createQueryBuilder('drive_folder')
+        .orderBy(
+          // eslint-disable-next-line quotes
+          "STR_TO_DATE(drive_folder.updatedAt, '%Y-%m-%dT%H:%i:%sZ')",
+          'DESC'
+        )
+        .getOne();
+
+      return {
+        success: true,
+        result: queryResult,
+      };
+    } catch (error) {
+      Sentry.captureException(error);
+      Logger.error('Error fetching newest drive folder:', error);
+      return {
+        success: false,
+        result: null,
+      };
+    }
   }
 }

--- a/src/apps/main/database/collections/DriveFolderCollection.ts
+++ b/src/apps/main/database/collections/DriveFolderCollection.ts
@@ -77,11 +77,7 @@ export class DriveFoldersCollection
     try {
       const queryResult = await this.repository
         .createQueryBuilder('drive_folder')
-        .orderBy(
-          // eslint-disable-next-line quotes
-          "STR_TO_DATE(drive_folder.updatedAt, '%Y-%m-%dT%H:%i:%sZ')",
-          'DESC'
-        )
+        .orderBy('datetime(drive_folder.updatedAt)', 'DESC')
         .getOne();
 
       return {

--- a/src/apps/main/remote-sync/RemoteSyncManager.test.ts
+++ b/src/apps/main/remote-sync/RemoteSyncManager.test.ts
@@ -23,6 +23,7 @@ const inMemorySyncedFilesCollection: DatabaseCollectionAdapter<DriveFile> = {
   update: jest.fn(),
   create: jest.fn(),
   remove: jest.fn(),
+  getLastUpdated: jest.fn(),
 };
 
 const inMemorySyncedFoldersCollection: DatabaseCollectionAdapter<DriveFolder> =
@@ -32,6 +33,7 @@ const inMemorySyncedFoldersCollection: DatabaseCollectionAdapter<DriveFolder> =
     update: jest.fn(),
     create: jest.fn(),
     remove: jest.fn(),
+    getLastUpdated: jest.fn(),
   };
 
 const createRemoteSyncedFileFixture = (
@@ -94,6 +96,12 @@ describe('RemoteSyncManager', () => {
       syncFolders: true,
     }
   );
+
+  inMemorySyncedFilesCollection.getLastUpdated = () =>
+    Promise.resolve({ success: false, result: null });
+  inMemorySyncedFoldersCollection.getLastUpdated = () =>
+    Promise.resolve({ success: false, result: null });
+
   beforeEach(() => {
     sut = new RemoteSyncManager(
       {
@@ -249,6 +257,11 @@ describe('RemoteSyncManager', () => {
     });
 
     it('Should fail the sync if some files or folders cannot be retrieved', async () => {
+      inMemorySyncedFilesCollection.getLastUpdated = () =>
+        Promise.resolve({ success: false, result: null });
+      inMemorySyncedFoldersCollection.getLastUpdated = () =>
+        Promise.resolve({ success: false, result: null });
+
       const sut = new RemoteSyncManager(
         {
           folders: inMemorySyncedFoldersCollection,

--- a/src/apps/main/remote-sync/RemoteSyncManager.ts
+++ b/src/apps/main/remote-sync/RemoteSyncManager.ts
@@ -6,7 +6,7 @@ import {
   RemoteSyncedFile,
   SyncConfig,
   SYNC_OFFSET_MS,
-  WAITING_AFTER_SYNCING
+  WAITING_AFTER_SYNCING,
 } from './helpers';
 import { reportError } from '../bug-report/service';
 
@@ -26,6 +26,8 @@ export class RemoteSyncManager {
   private totalFilesSynced = 0;
   private totalFoldersSynced = 0;
   private lastSyncingFinishedTimestamp: Date | null = null;
+
+  private static SIX_HOURS = 6 * 60 * 60 * 1000;
 
   constructor(
     private db: {
@@ -74,7 +76,9 @@ export class RemoteSyncManager {
    * @returns False if the RemoteSyncManager was not syncing recently
    */
   recentlyWasSyncing() {
-    const passedTime = Date.now() - ( this.getLastSyncingFinishedTimestamp()?.getTime() ?? Date.now() );
+    const passedTime =
+      Date.now() -
+      (this.getLastSyncingFinishedTimestamp()?.getTime() ?? Date.now());
     return passedTime < WAITING_AFTER_SYNCING;
   }
 
@@ -359,6 +363,12 @@ export class RemoteSyncManager {
     hasMore: boolean;
     result: RemoteSyncedFile[];
   }> {
+    if (updatedAtCheckpoint) {
+      updatedAtCheckpoint.setTime(
+        updatedAtCheckpoint.getTime() - RemoteSyncManager.SIX_HOURS
+      );
+    }
+
     const params = {
       limit: this.config.fetchFilesLimitPerRequest,
       offset: 0,
@@ -428,6 +438,12 @@ export class RemoteSyncManager {
     hasMore: boolean;
     result: RemoteSyncedFolder[];
   }> {
+    if (updatedAtCheckpoint) {
+      updatedAtCheckpoint.setTime(
+        updatedAtCheckpoint.getTime() - RemoteSyncManager.SIX_HOURS
+      );
+    }
+
     const params = {
       limit: this.config.fetchFilesLimitPerRequest,
       offset: 0,

--- a/src/apps/main/remote-sync/handlers.ts
+++ b/src/apps/main/remote-sync/handlers.ts
@@ -2,7 +2,7 @@ import eventBus from '../event-bus';
 import { RemoteSyncManager } from './RemoteSyncManager';
 import { DriveFilesCollection } from '../database/collections/DriveFileCollection';
 import { DriveFoldersCollection } from '../database/collections/DriveFolderCollection';
-import { clearRemoteSyncStore, RemoteSyncStatus } from './helpers';
+import { RemoteSyncStatus } from './helpers';
 import { getNewTokenClient } from '../../shared/HttpClient/main-process-client';
 import Logger from 'electron-log';
 import { ipcMain } from 'electron';
@@ -99,7 +99,6 @@ eventBus.on('USER_LOGGED_IN', async () => {
 eventBus.on('USER_LOGGED_OUT', () => {
   initialSyncReady = false;
   remoteSyncManager.resetRemoteSync();
-  clearRemoteSyncStore();
 });
 
 ipcMain.on('CHECK_SYNC', (event) => {

--- a/src/apps/main/remote-sync/helpers.ts
+++ b/src/apps/main/remote-sync/helpers.ts
@@ -1,70 +1,5 @@
-import Store from 'electron-store';
-
-const SIX_HOURS_IN_MILLISECONDS = 6 * 60 * 60 * 1000;
-
-let store: Store<{
-  lastFilesSyncAt?: string;
-  lastFoldersSyncAt?: string;
-}> | null = null;
-export const getRemoteSyncStore = () => {
-  if (!store) {
-    store = new Store<{
-      lastFilesSyncAt?: string;
-      lastFoldersSyncAt?: string;
-    }>({
-      defaults: {
-        lastFilesSyncAt: undefined,
-        lastFoldersSyncAt: undefined,
-      },
-    });
-
-    return store;
-  }
-
-  return store;
-};
-
-export const clearRemoteSyncStore = () => getRemoteSyncStore().clear();
-
-export function getLastFilesSyncAt(): Date | undefined {
-  const value = getRemoteSyncStore().get('lastFilesSyncAt');
-
-  if (!value) return undefined;
-
-  const date = new Date(value);
-
-  date.setTime(date.getTime() - SIX_HOURS_IN_MILLISECONDS);
-
-  return date;
-}
-
-export function saveLastFilesSyncAt(date: Date, offsetMs: number): Date {
-  getRemoteSyncStore().set(
-    'lastFilesSyncAt',
-    new Date(date.getTime() - offsetMs).toISOString()
-  );
-  return date;
-}
-
-export function getLastFoldersSyncAt(): Date | undefined {
-  const value = getRemoteSyncStore().get('lastFoldersSyncAt');
-
-  if (!value) return undefined;
-
-  const date = new Date(value);
-
-  date.setTime(date.getTime() - SIX_HOURS_IN_MILLISECONDS);
-
-  return date;
-}
-
-export function saveLastFoldersSyncAt(date: Date, offsetMs: number): Date {
-  getRemoteSyncStore().set(
-    'lastFoldersSyncAt',
-    new Date(date.getTime() - offsetMs).toISOString()
-  );
-  return date;
-}
+export const WAITING_AFTER_SYNCING = 1000 * 60 * 3; // 5 minutes
+export const SIX_HOURS_IN_MILLISECONDS = 6 * 60 * 60 * 1000;
 
 export type RemoteSyncedFile = {
   id: number;
@@ -109,9 +44,6 @@ export type SyncConfig = {
   maxRetries: number;
 };
 
-export const SYNC_OFFSET_MS = 0;
-export const WAITING_AFTER_SYNCING = 1000 * 60 * 3; // 5 minutes
-
 export const lastSyncedAtIsNewer = (
   itemUpdatedAt: Date,
   lastItemsSyncAt: Date,
@@ -119,3 +51,11 @@ export const lastSyncedAtIsNewer = (
 ) => {
   return itemUpdatedAt.getTime() - offset > lastItemsSyncAt.getTime();
 };
+
+export function rewind(original: Date, milliseconds: number): Date {
+  const shallowCopy = new Date(original.getTime());
+
+  shallowCopy.setTime(shallowCopy.getTime() - milliseconds);
+
+  return shallowCopy;
+}

--- a/src/apps/main/remote-sync/helpers.ts
+++ b/src/apps/main/remote-sync/helpers.ts
@@ -1,5 +1,7 @@
 import Store from 'electron-store';
 
+const SIX_HOURS_IN_MILLISECONDS = 6 * 60 * 60 * 1000;
+
 let store: Store<{
   lastFilesSyncAt?: string;
   lastFoldersSyncAt?: string;
@@ -23,12 +25,17 @@ export const getRemoteSyncStore = () => {
 };
 
 export const clearRemoteSyncStore = () => getRemoteSyncStore().clear();
+
 export function getLastFilesSyncAt(): Date | undefined {
   const value = getRemoteSyncStore().get('lastFilesSyncAt');
 
   if (!value) return undefined;
 
-  return new Date(value);
+  const date = new Date(value);
+
+  date.setTime(date.getTime() - SIX_HOURS_IN_MILLISECONDS);
+
+  return date;
 }
 
 export function saveLastFilesSyncAt(date: Date, offsetMs: number): Date {
@@ -44,7 +51,11 @@ export function getLastFoldersSyncAt(): Date | undefined {
 
   if (!value) return undefined;
 
-  return new Date(value);
+  const date = new Date(value);
+
+  date.setTime(date.getTime() - SIX_HOURS_IN_MILLISECONDS);
+
+  return date;
 }
 
 export function saveLastFoldersSyncAt(date: Date, offsetMs: number): Date {


### PR DESCRIPTION
To avoid prs that depend on other prs. This one removes the StorageApp for the `RemoteSyncManager` and changes the checkpoint of files and folders to be 6 hours before the last updated item.

The StorageApp has been deleted and instead of managing the `lastFilesSyncAt` and `lastFoldersSyncAt`, we take advantage of the local database to query those values. This avoids showing the onboarding window on every login, the reset of the selected language, and the creation of new devices after logging out and back in.

When fetching the items we check for items 6 hours previous to the latest one saved to avoid missing some items when the backend does not return them on the synchronization.