### PR TITLE
[_] feat/debounce remote manager sync

### DIFF
--- a/src/apps/main/remote-sync/handlers.ts
+++ b/src/apps/main/remote-sync/handlers.ts
@@ -12,6 +12,8 @@ import { broadcastToWindows } from '../windows';
 import { updateSyncEngine } from '../background-processes/sync-engine';
 import { debounce } from 'lodash';
 
+const SYNC_DEBOUNCE_DELAY = 3_000;
+
 let initialSyncReady = false;
 const driveFilesCollection = new DriveFilesCollection();
 const driveFoldersCollection = new DriveFoldersCollection();
@@ -81,7 +83,7 @@ ipcMain.handle('get-remote-sync-status', () =>
 const debouncedSynchronization = debounce(async () => {
   await startRemoteSync();
   updateSyncEngine();
-}, 3_000);
+}, SYNC_DEBOUNCE_DELAY);
 
 eventBus.on('RECEIVED_REMOTE_CHANGES', async () => {
   // Wait before checking for updates, could be possible


### PR DESCRIPTION
Instead of delaying the synchronization after the first notification, it's delayed if more notifications arrive in a given threshold