### PR TITLE
Respawn sync engine worker

### DIFF
--- a/src/apps/main/background-processes/sync-engine/monitor-health.ts
+++ b/src/apps/main/background-processes/sync-engine/monitor-health.ts
@@ -1,0 +1,33 @@
+import { BrowserWindow } from 'electron';
+import Logger from 'electron-log';
+
+export const monitorHealth = async ({ worker, stopAndSpawn }: { worker: BrowserWindow, stopAndSpawn: () => Promise<void> }) => {
+  // If we keep this event, then when the process is closed, stopAndSpawn is called two times
+  // worker.on('closed', async () => {
+  //   Logger.error('[MAIN] Sync engine worker closed');
+  //   await stopAndSpawn();
+  // });
+
+  worker.webContents.on('render-process-gone', async () => {
+    Logger.error('[MAIN] Sync engine worker process gone');
+    await stopAndSpawn();
+  });
+
+  worker.webContents.on('unresponsive', async () => {
+    Logger.error('[MAIN] Sync engine worker unresponsive');
+    await checkWorkerHealth();
+  });
+
+  const checkWorkerHealth = async () => {
+    if (worker && worker.webContents.getOSProcessId()) {
+      const pid = worker.webContents.getOSProcessId();
+      try {
+        process.kill(pid, 0);
+        Logger.error('[MAIN] Sync engine worker is still running');
+      } catch (err) {
+        Logger.error('[MAIN] Sync engine worker is dead');
+        await stopAndSpawn();
+      }
+    }
+  };
+};

--- a/src/apps/main/main.ts
+++ b/src/apps/main/main.ts
@@ -48,7 +48,7 @@ import { getTray, setTrayStatus } from './tray/tray';
 import { openOnboardingWindow } from './windows/onboarding';
 import { reportError } from './bug-report/service';
 import { setCleanUpFunction } from './quit';
-import { stopSyncEngineWatcher } from './background-processes/sync-engine';
+import { stopAndClearSyncEngineWatcher } from './background-processes/sync-engine';
 import { Theme } from '../shared/types/Theme';
 import { setUpBackups } from './background-processes/backups/setUpBackups';
 import { clearDailyScan, scheduleDailyScan } from './antivirus/scanCronJob';
@@ -148,7 +148,7 @@ eventBus.on('USER_LOGGED_IN', async () => {
 
     scheduleDailyScan();
 
-    setCleanUpFunction(stopSyncEngineWatcher);
+    setCleanUpFunction(stopAndClearSyncEngineWatcher);
   } catch (error) {
     Logger.error(error);
     reportError(error as Error);


### PR DESCRIPTION
## What

Fix this bug #544.

## How

Instead of using ping and pong for checking the health of the process, we rely on events.
Benefits of this approach:
- We don't do many console logs just for the ping and pong.
- We achieve instant recovery, since we don't have to wait until ping and pong is done.

A new function monitorHealth is created that watches "render_process_gone" and "unresponsive". In case of unresponsive it checks if the process is still running or not, before spawning a new one.

This PR also removes a code duplication in stopWorker function. We had this two functions that were doing the same:
![image](https://github.com/user-attachments/assets/dcb259a9-37a8-4459-aa77-63e03dfec187)

## How has been tested?

Every time the process was spawn, I killed it in a 10 seconds timeout and check if it was respawning. I've killed it 4 times and the 4 times it respawned. For that, I needed to change event.once to event.on, otherwise it was just working on the first initialization.