### PR TITLE
[_]; fix/loading state while initializing antivirus

### DIFF
--- a/src/apps/renderer/hooks/antivirus/useAntivirus.tsx
+++ b/src/apps/renderer/hooks/antivirus/useAntivirus.tsx
@@ -56,6 +56,7 @@ export const useAntivirus = (): UseAntivirusReturn => {
 
   const isUserElegible = async () => {
     try {
+      setView('loading');
       const isAntivirusAvailable = await window.electron.antivirus.isAvailable();
 
       if (!isAntivirusAvailable) {


### PR DESCRIPTION
This PR implements a loading state while checking if the user van use the antivirus and initializing the clam av daemon.