### PR TITLE
Fix Duplicate Folder Creation, WorkspaceID in Events, and File Rename

### DIFF
--- a/src/apps/main/background-processes/sync-engine.ts
+++ b/src/apps/main/background-processes/sync-engine.ts
@@ -1,3 +1,4 @@
+import fs from 'fs/promises';
 import { BrowserWindow, ipcMain } from 'electron';
 import path from 'path';
 import Logger from 'electron-log';
@@ -7,7 +8,7 @@ import { monitorHealth } from './sync-engine/monitor-health';
 import { Config } from '../../sync-engine/config';
 import { getLoggersPaths, getRootVirtualDrive, getRootWorkspace } from '../virtual-root-folder/service';
 import { logger } from '../../../apps/shared/logger/logger';
-import { syncWorkspaceService } from '../remote-sync/handlers';
+import { driveFilesCollection, driveFoldersCollection, syncWorkspaceService } from '../remote-sync/handlers';
 import { getUser } from '../auth/service';
 import { FetchWorkspacesService } from '../remote-sync/workspace/fetch-workspaces.service';
 import { decryptMessageWithPrivateKey } from '@/apps/shared/crypto/service';
@@ -219,6 +220,15 @@ export const spawnAllSyncEngineWorker = async () => {
 
   await Promise.all(
     workspaces.map(async (workspace) => {
+      if (workspace.removed) {
+        const rootFolder = await getRootWorkspace(workspace.id);
+        await fs.rm(rootFolder, { recursive: true, force: true });
+        await driveFilesCollection.cleanWorkspace(workspace.id);
+        await driveFoldersCollection.cleanWorkspace(workspace.id);
+        ipcMain.emit('UNREGISTER_SYNC_ENGINE_PROCESS', `{${workspace.id}}`);
+        return;
+      }
+
       const workspaceCredential = await FetchWorkspacesService.getCredencials(workspace.id);
 
       const user = getUser();

--- a/src/apps/main/background-processes/sync-engine.ts
+++ b/src/apps/main/background-processes/sync-engine.ts
@@ -42,7 +42,7 @@ function scheduleSync(workspaceId: string) {
     workers[workspaceId].syncSchedule?.cancel(false);
   }
 
-  workers[workspaceId].syncSchedule = nodeSchedule.scheduleJob('0 0 */2 * * *', async () => {
+  workers[workspaceId].syncSchedule = nodeSchedule.scheduleJob('*/15 * * * *', async () => {
     eventBus.emit('RECEIVED_REMOTE_CHANGES', workspaceId);
   });
 }

--- a/src/apps/main/database/collections/DriveFileCollection.ts
+++ b/src/apps/main/database/collections/DriveFileCollection.ts
@@ -188,4 +188,18 @@ export class DriveFilesCollection implements DatabaseCollectionAdapter<DriveFile
       };
     }
   }
+
+  async cleanWorkspace(workspaceId: string): Promise<{ success: boolean }> {
+    try {
+      await this.repository.delete({ workspaceId });
+      return {
+        success: true,
+      };
+    } catch (error) {
+      Logger.error('Error cleaning workspace:', error);
+      return {
+        success: false,
+      };
+    }
+  }
 }

--- a/src/apps/main/database/collections/DriveFolderCollection.ts
+++ b/src/apps/main/database/collections/DriveFolderCollection.ts
@@ -153,4 +153,18 @@ export class DriveFoldersCollection implements DatabaseCollectionAdapter<DriveFo
       };
     }
   }
+
+  async cleanWorkspace(workspaceId: string): Promise<{ success: boolean }> {
+    try {
+      await this.repository.delete({ workspaceId });
+      return {
+        success: true,
+      };
+    } catch (error) {
+      Logger.error('Error cleaning workspace:', error);
+      return {
+        success: false,
+      };
+    }
+  }
 }

--- a/src/apps/main/database/entities/DriveWorkspace.ts
+++ b/src/apps/main/database/entities/DriveWorkspace.ts
@@ -20,6 +20,9 @@ export class DriveWorkspace {
   @Column({ type: 'boolean', default: false })
   setupCompleted!: boolean;
 
+  @Column({ type: 'boolean', default: false })
+  removed!: boolean;
+
   @Column({ type: 'varchar' })
   mnemonic!: string;
 

--- a/src/apps/main/fordwardToWindows.ts
+++ b/src/apps/main/fordwardToWindows.ts
@@ -28,12 +28,12 @@ ipcMainDrive.on('FILE_DOWNLOADING', (_, payload) => {
   });
 });
 
-ipcMainDrive.on('SYNCING', () => {
-  setIsProcessing(true);
+ipcMainDrive.on('SYNCING', (_, workspacesId) => {
+  setIsProcessing(true, workspacesId);
 });
 
-ipcMainDrive.on('SYNCED', () => {
-  setIsProcessing(false);
+ipcMainDrive.on('SYNCED', (_, workspacesId) => {
+  setIsProcessing(false, workspacesId);
 });
 
 ipcMainDrive.on('FILE_PREPARING', (_, payload) => {

--- a/src/apps/main/realtime.ts
+++ b/src/apps/main/realtime.ts
@@ -4,7 +4,7 @@ import { getUser, obtainToken } from './auth/service';
 import eventBus from './event-bus';
 import { broadcastToWindows } from './windows';
 import { logger } from '../shared/logger/logger';
-import { updateRemoteSync } from './remote-sync/handlers';
+import { debouncedSynchronization } from './remote-sync/handlers';
 
 type XHRRequest = {
   getResponseHeader: (headerName: string) => string[] | null;
@@ -76,7 +76,7 @@ function cleanAndStartRemoteNotifications() {
 
     if (data.payload.bucket !== user?.backupsBucket) {
       logger.debug({ msg: 'Notification received', data });
-      await updateRemoteSync();
+      await debouncedSynchronization();
       return;
     }
 

--- a/src/apps/main/remote-sync/handlers.ts
+++ b/src/apps/main/remote-sync/handlers.ts
@@ -30,8 +30,8 @@ import Queue from '@/apps/shared/Queue/Queue';
 const SYNC_DEBOUNCE_DELAY = 500;
 
 let initialSyncReady = false;
-const driveFilesCollection = new DriveFilesCollection();
-const driveFoldersCollection = new DriveFoldersCollection();
+export const driveFilesCollection = new DriveFilesCollection();
+export const driveFoldersCollection = new DriveFoldersCollection();
 const driveWorkspaceCollection = new DriveWorkspaceCollection();
 const remoteSyncManagers = new Map<string, RemoteSyncManager>();
 export const syncWorkspaceService = new SyncRemoteWorkspaceService(driveWorkspaceCollection, driveFoldersCollection);

--- a/src/apps/main/remote-sync/handlers.ts
+++ b/src/apps/main/remote-sync/handlers.ts
@@ -330,7 +330,7 @@ ipcMain.handle('SYNC_MANUALLY', async (_, workspaceId = '') => {
   Logger.info('[Manual Sync] Received manual sync event');
   const isSyncing = await checkSyncEngineInProcess(5000, workspaceId);
   if (isSyncing) return;
-  await updateRemoteSync();
+  await debouncedSynchronization();
   await fallbackRemoteSync(workspaceId);
 });
 
@@ -356,7 +356,7 @@ ipcMain.on('UPDATE_UNSYNC_FILE_IN_SYNC_ENGINE', async (_: unknown, filesPath: st
   manager.setUnsyncFiles(filesPath);
 });
 
-const debouncedSynchronization = lodashDebounce(async () => {
+export const debouncedSynchronization = lodashDebounce(async () => {
   await updateRemoteSync();
 }, SYNC_DEBOUNCE_DELAY);
 

--- a/src/apps/main/remote-sync/workspace/sync-remote-workspace.ts
+++ b/src/apps/main/remote-sync/workspace/sync-remote-workspace.ts
@@ -12,13 +12,31 @@ export class SyncRemoteWorkspaceService {
 
   private async createOrUpdate(workspaces: DriveWorkspace[]): Promise<DriveWorkspace[]> {
     try {
+      const existingWorkspaces = await this.workspaceCollection.getAll();
+      const incomingWorkspaceIds = new Set(workspaces.map((ws) => ws.id));
+
+      const workspacesToDelete = existingWorkspaces.result.filter((ws) => !incomingWorkspaceIds.has(ws.id));
+      await Promise.all(
+        workspacesToDelete.map(async (ws) => {
+          return await this.workspaceCollection.update(ws.id, {
+            removed: true,
+          });
+        }),
+      );
+
       const updateOrCreateWorkspace = async (workspace: DriveWorkspace) => {
         const existingWorkspace = await this.workspaceCollection.get(workspace.id);
         let response;
         if (existingWorkspace.result) {
-          response = await this.workspaceCollection.update(workspace.id, workspace);
+          response = await this.workspaceCollection.update(workspace.id, {
+            ...workspace,
+            removed: false,
+          });
         } else {
-          response = await this.workspaceCollection.create(workspace);
+          response = await this.workspaceCollection.create({
+            ...workspace,
+            removed: false,
+          });
         }
         return response.result;
       };
@@ -27,7 +45,7 @@ export class SyncRemoteWorkspaceService {
 
       return result.filter(Boolean) as DriveWorkspace[];
     } catch (error) {
-      logger.error({ msg: 'Error creating or updating workspace', error });
+      logger.error({ msg: 'Error creating, updating, or deleting workspace', error });
       throw error;
     }
   }
@@ -48,6 +66,7 @@ export class SyncRemoteWorkspaceService {
             mnemonic: workspaceUser.key,
             createdAt: workspace.createdAt,
             updatedAt: workspace.updatedAt,
+            removed: false,
           };
         }),
       );

--- a/src/apps/main/virtual-root-folder/service.ts
+++ b/src/apps/main/virtual-root-folder/service.ts
@@ -5,6 +5,7 @@ import path from 'path';
 
 import configStore from '../config';
 import eventBus from '../event-bus';
+import { getUser } from '../auth/service';
 
 const ROOT_FOLDER_NAME = process.env.ROOT_FOLDER_NAME;
 const HOME_FOLDER_PATH = app.getPath('home');
@@ -47,13 +48,20 @@ export function getRootVirtualDrive(): string {
 }
 
 export function getRootWorkspace(workspaceId: string): string {
+  const user = getUser();
+  if (!user) {
+    throw new Error('User not found');
+  }
+
+  const key = `${user.uuid}-${workspaceId}`;
+
   const current = configStore.get('workspacesPath');
-  if (!current[workspaceId]) {
-    const pathName = path.join(HOME_FOLDER_PATH, `${ROOT_FOLDER_NAME} - ${workspaceId}`);
-    configStore.set('workspacesPath', { ...current, [workspaceId]: pathName });
+  if (!current[key]) {
+    const pathName = path.join(HOME_FOLDER_PATH, `${ROOT_FOLDER_NAME} - ${key}`);
+    configStore.set('workspacesPath', { ...current, [key]: pathName });
     return pathName;
   }
-  return current[workspaceId];
+  return current[key];
 }
 
 export interface LoggersPaths {

--- a/src/apps/renderer/pages/Widget/Header.tsx
+++ b/src/apps/renderer/pages/Widget/Header.tsx
@@ -81,7 +81,7 @@ const Header: React.FC<HeadersProps> = ({ setIsLogoutModalOpen }) => {
     } else if (status === 'error') {
       displayUsage = '';
     } else if (usage) {
-      displayUsage = `${bytes.format(usage.usageInBytes)} ${translate(
+      displayUsage = `${bytes.format(usage?.usageInBytes || 0)} ${translate(
         'widget.header.usage.of',
       )} ${usage.isInfinite ? '∞' : bytes.format(usage.limitInBytes)}`;
     } else {

--- a/src/apps/shared/HttpClient/HttpClient.ts
+++ b/src/apps/shared/HttpClient/HttpClient.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 import Logger from 'electron-log';
 
 export type HeadersProvider = () => Promise<Record<string, string>>;
@@ -23,10 +23,10 @@ export class AuthorizedHttpClient {
     return Promise.reject(error);
   }
 
-  private async addApplicationHeaders(config: AxiosRequestConfig) {
+  private async addApplicationHeaders(config: AxiosRequestConfig): Promise<InternalAxiosRequestConfig> {
     config.headers = await this.headersProvider();
 
-    return config;
+    return config as InternalAxiosRequestConfig;
   }
 
   constructor(

--- a/src/apps/shared/IPC/events/drive.ts
+++ b/src/apps/shared/IPC/events/drive.ts
@@ -65,8 +65,8 @@ type MoveEvents = {
 };
 
 type SyncEvents = {
-  SYNCING: () => void;
-  SYNCED: () => void;
+  SYNCING: (workspacesId: string) => void;
+  SYNCED: (workspacesId: string) => void;
 };
 
 type CloneEvents = {

--- a/src/apps/shared/IPC/events/sync-engine.ts
+++ b/src/apps/shared/IPC/events/sync-engine.ts
@@ -89,8 +89,8 @@ export type SyncEngineInvocableFunctions = {
 export type ProcessInfoUpdate = {
   SYNC_INFO_UPDATE: (payload: ProcessInfoUpdatePayload) => void;
   SYNC_PROBLEM: (payload: { key: string; additionalData: Record<string, any> }) => void;
-  SYNCING: () => void;
-  SYNCED: () => void;
+  SYNCING: (workspacesId: string) => void;
+  SYNCED: (workspacesId: string) => void;
 };
 
 export type FromProcess = FilesEvents & FolderEvents & SyncEngineInvocableFunctions & ProcessInfoUpdate;

--- a/src/apps/shared/fs/PathTypeChecker .ts
+++ b/src/apps/shared/fs/PathTypeChecker .ts
@@ -1,4 +1,5 @@
 import fs from 'fs/promises';
+import { logger } from '../logger/logger';
 
 export class PathTypeChecker {
   static async isFolder(path: string): Promise<boolean> {
@@ -6,7 +7,11 @@ export class PathTypeChecker {
       const stats = await fs.stat(path);
       return stats.isDirectory();
     } catch (error) {
-      return false;
+      throw logger.error({
+        msg: 'Error checking if path is a folder',
+        path,
+        exc: error,
+      });
     }
   }
 

--- a/src/apps/sync-engine/BindingManager.ts
+++ b/src/apps/sync-engine/BindingManager.ts
@@ -19,6 +19,7 @@ import { HandleDehydrateService } from './callbacks/handleDehydrate.service';
 import { HandleAddService } from './callbacks/handleAdd.service';
 import { HandleChangeSizeService } from './callbacks/handleChangeSize.service';
 import { DangledFilesManager, PushAndCleanInput } from '@/context/virtual-drive/shared/domain/DangledFilesManager';
+import { getConfig } from './config';
 
 export type CallbackDownload = (data: boolean, path: string, errorHandler?: () => void) => Promise<{ finished: boolean; progress: number }>;
 
@@ -75,7 +76,7 @@ export class BindingsManager {
   }
 
   async start(version: string) {
-    ipcRendererSyncEngine.send('SYNCING');
+    ipcRendererSyncEngine.send('SYNCING', getConfig().workspaceId);
     await this.stop();
     await this.pollingStart();
 
@@ -129,7 +130,7 @@ export class BindingsManager {
         } catch (error) {
           Logger.error('Error during rename or move operation', error);
         }
-        ipcRendererSyncEngine.send('SYNCED');
+        ipcRendererSyncEngine.send('SYNCED', getConfig().workspaceId);
         ipcRenderer.send('CHECK_SYNC');
       },
       notifyFileAddedCallback: async (absolutePath: string) => {
@@ -205,7 +206,7 @@ export class BindingsManager {
 
     await this.load();
     await this.polling();
-    ipcRendererSyncEngine.send('SYNCED');
+    ipcRendererSyncEngine.send('SYNCED', getConfig().workspaceId);
   }
 
   async watch() {
@@ -217,8 +218,8 @@ export class BindingsManager {
     };
 
     const notify = {
-      onTaskSuccess: async () => ipcRendererSyncEngine.send('SYNCED'),
-      onTaskProcessing: async () => ipcRendererSyncEngine.send('SYNCING'),
+      onTaskSuccess: async () => ipcRendererSyncEngine.send('SYNCED', getConfig().workspaceId),
+      onTaskProcessing: async () => ipcRendererSyncEngine.send('SYNCING', getConfig().workspaceId),
     };
 
     const persistQueueManager: string = configStore.get('persistQueueManagerPath');
@@ -249,7 +250,7 @@ export class BindingsManager {
 
   async update() {
     Logger.info('[SYNC ENGINE]: Updating placeholders');
-    ipcRendererSyncEngine.send('SYNCING');
+    ipcRendererSyncEngine.send('SYNCING', getConfig().workspaceId);
 
     try {
       const tree = await this.container.existingItemsTreeBuilder.run();
@@ -262,7 +263,7 @@ export class BindingsManager {
         this.container.folderPlaceholderUpdater.run(tree.folders),
         this.container.filesPlaceholderUpdater.run(tree.files),
       ]);
-      ipcRendererSyncEngine.send('SYNCED');
+      ipcRendererSyncEngine.send('SYNCED', getConfig().workspaceId);
     } catch (error) {
       Logger.error('[SYNC ENGINE] ', error);
       Sentry.captureException(error);
@@ -276,7 +277,7 @@ export class BindingsManager {
 
   async polling(): Promise<void> {
     try {
-      ipcRendererSyncEngine.send('SYNCING');
+      ipcRendererSyncEngine.send('SYNCING', getConfig().workspaceId);
       Logger.info('[SYNC ENGINE] Monitoring polling...');
       const fileInPendingPaths = (await this.container.virtualDrive.getPlaceholderWithStatePending()) as Array<string>;
       Logger.info('[SYNC ENGINE] fileInPendingPaths', fileInPendingPaths);
@@ -287,7 +288,7 @@ export class BindingsManager {
       Logger.error('[SYNC ENGINE] Polling', error);
       Sentry.captureException(error);
     }
-    ipcRendererSyncEngine.send('SYNCED');
+    ipcRendererSyncEngine.send('SYNCED', getConfig().workspaceId);
 
     Logger.debug('[SYNC ENGINE] Polling finished');
 

--- a/src/apps/sync-engine/BindingManager.ts
+++ b/src/apps/sync-engine/BindingManager.ts
@@ -242,8 +242,8 @@ export class BindingsManager {
     await this.container.virtualDrive.unregisterSyncRoot();
   }
 
-  async unregisterSyncEngine(providerId: string) {
-    await this.container.virtualDrive.unRegisterSyncRootByProviderId(providerId);
+  async unregisterSyncEngine({ providerId }: { providerId: string }) {
+    await this.container.virtualDrive.unRegisterSyncRootByProviderId({ providerId });
   }
 
   async cleanQueue() {

--- a/src/apps/sync-engine/BindingManager.ts
+++ b/src/apps/sync-engine/BindingManager.ts
@@ -242,6 +242,10 @@ export class BindingsManager {
     await this.container.virtualDrive.unregisterSyncRoot();
   }
 
+  async unregisterSyncEngine(providerId: string) {
+    await this.container.virtualDrive.unRegisterSyncRootByProviderId(providerId);
+  }
+
   async cleanQueue() {
     if (this.queueManager) {
       this.queueManager.clearQueue();

--- a/src/apps/sync-engine/callbacks/fetchData.service.ts
+++ b/src/apps/sync-engine/callbacks/fetchData.service.ts
@@ -8,6 +8,7 @@ import { FilePath } from '../../../context/virtual-drive/files/domain/FilePath';
 import * as fs from 'fs';
 import { SyncEngineIpc } from '../ipcRendererSyncEngine';
 import { dirname } from 'path';
+import { getConfig } from '../config';
 
 type TProps = {
   self: BindingsManager;
@@ -108,7 +109,7 @@ export class FetchDataService {
       Logger.error(error);
       Sentry.captureException(error);
       await callback(false, '');
-      ipcRendererSyncEngine.send('SYNCED');
+      ipcRendererSyncEngine.send('SYNCED', getConfig().workspaceId);
     }
   }
 

--- a/src/apps/sync-engine/callbacks/handleAdd.service.ts
+++ b/src/apps/sync-engine/callbacks/handleAdd.service.ts
@@ -1,8 +1,7 @@
-import Logger from 'electron-log';
-import * as Sentry from '@sentry/electron/renderer';
 import { QueueItem, VirtualDrive } from 'virtual-drive/dist';
 import { BindingsManager } from '../BindingManager';
 import { isTemporaryFile } from '../../../apps/utils/isTemporalFile';
+import { logger } from '@/apps/shared/logger/logger';
 
 type TProps = {
   self: BindingsManager;
@@ -13,29 +12,39 @@ type TProps = {
 export class HandleAddService {
   async run({ self, task, drive }: TProps) {
     try {
-      Logger.debug('Path received from handle add', task.path);
+      logger.debug({
+        msg: 'Path received from handle add',
+        path: task.path,
+      });
 
       const tempFile = await isTemporaryFile(task.path);
 
-      Logger.debug('[isTemporaryFile]', tempFile);
+      logger.debug({
+        msg: '[isTemporaryFile]',
+        tempFile,
+      });
 
       if (tempFile && !task.isFolder) {
-        Logger.debug('File is temporary, skipping');
+        logger.debug({ msg: 'File is temporary, skipping' });
         return;
       }
 
       const itemId = await self.controllers.addFile.execute(task.path);
       if (!itemId) {
-        Logger.error('Error adding file' + task.path);
+        logger.warn({
+          msg: 'Error adding file',
+          path: task.path,
+        });
         return;
       }
 
       await drive.convertToPlaceholder(task.path, itemId);
       await drive.updateSyncStatus(task.path, task.isFolder, true);
     } catch (error) {
-      Logger.error(`error adding file ${task.path}`);
-      Logger.error(error);
-      Sentry.captureException(error);
+      throw logger.error({
+        msg: `Error adding file ${task.path}`,
+        exc: error,
+      });
     }
   }
 }

--- a/src/apps/sync-engine/index.ts
+++ b/src/apps/sync-engine/index.ts
@@ -104,7 +104,7 @@ async function setUp() {
 
   ipcRenderer.on('UNREGISTER_SYNC_ENGINE_PROCESS', async (_, providerId: string) => {
     Logger.info('[SYNC ENGINE] Unregistering sync engine');
-    await bindings.unregisterSyncEngine(providerId);
+    await bindings.unregisterSyncEngine({ providerId });
     Logger.info('[SYNC ENGINE] sync engine unregistered successfully');
   });
 

--- a/src/apps/sync-engine/index.ts
+++ b/src/apps/sync-engine/index.ts
@@ -102,6 +102,12 @@ async function setUp() {
     }
   });
 
+  ipcRenderer.on('UNREGISTER_SYNC_ENGINE_PROCESS', async (_, providerId: string) => {
+    Logger.info('[SYNC ENGINE] Unregistering sync engine');
+    await bindings.unregisterSyncEngine(providerId);
+    Logger.info('[SYNC ENGINE] sync engine unregistered successfully');
+  });
+
   await bindings.start(packageJson.version);
 
   await bindings.watch();

--- a/src/context/virtual-drive/files/domain/File.ts
+++ b/src/context/virtual-drive/files/domain/File.ts
@@ -173,10 +173,6 @@ export class File extends AggregateRoot {
   }
 
   moveTo(folder: Folder, trackerId: string): void {
-    if (Number(this.folderId) === Number(folder.id)) {
-      throw new FileCannotBeMovedToTheOriginalFolderError(this.path);
-    }
-
     this._folderId = new FileFolderId(folder.id);
     this._folderUuid = new FolderUuid(folder.uuid);
     this._path = this._path.changeFolder(folder.path);

--- a/src/context/virtual-drive/folders/application/FolderContainerDetector.ts
+++ b/src/context/virtual-drive/folders/application/FolderContainerDetector.ts
@@ -4,15 +4,15 @@ import { FolderRepository } from '../domain/FolderRepository';
 export class FolderContainerDetector {
   constructor(private readonly repository: FolderRepository) {}
 
-  run(fodlerContentId: Folder['uuid'], parentFolderContentId: Folder['uuid']): boolean {
-    const folder = this.repository.searchByPartial({ uuid: fodlerContentId });
+  run(folderContentId: Folder['uuid'], parentFolderContentId: Folder['uuid']): boolean {
+    const folder = this.repository.searchByPartial({ uuid: folderContentId });
 
     if (!folder) {
       throw new Error('Folder not found');
     }
 
     const parent = this.repository.searchByPartial({
-      id: folder.parentId as number,
+      uuid: folder.parentUuid as string,
     });
 
     if (!parent) {

--- a/src/context/virtual-drive/folders/application/FolderFinder.ts
+++ b/src/context/virtual-drive/folders/application/FolderFinder.ts
@@ -33,4 +33,11 @@ export class FolderFinder {
     }
     return folder;
   }
+  findFromUuid(uuid: Folder['uuid']): Folder {
+    const folder = this.repository.searchByPartial({ uuid });
+    if (!folder) {
+      throw new Error('Folder not found');
+    }
+    return folder;
+  }
 }

--- a/src/context/virtual-drive/folders/application/FolderPathUpdater.ts
+++ b/src/context/virtual-drive/folders/application/FolderPathUpdater.ts
@@ -1,4 +1,3 @@
-import Logger from 'electron-log';
 import { Folder } from '../domain/Folder';
 import { FolderPath } from '../domain/FolderPath';
 import { FolderRepository } from '../domain/FolderRepository';
@@ -6,6 +5,7 @@ import { ActionNotPermittedError } from '../domain/errors/ActionNotPermittedErro
 import { FolderNotFoundError } from '../domain/errors/FolderNotFoundError';
 import { FolderMover } from './FolderMover';
 import { FolderRenamer } from './FolderRenamer';
+import { logger } from '@/apps/shared/logger/logger';
 
 export class FolderPathUpdater {
   constructor(
@@ -17,20 +17,15 @@ export class FolderPathUpdater {
   async run(uuid: Folder['uuid'], posixRelativePath: string) {
     const folder = this.repository.searchByPartial({ uuid });
 
+    logger.debug({
+      msg: 'FolderPathUpdater.run',
+    });
+
     if (!folder) {
       throw new FolderNotFoundError(uuid);
     }
 
     const desiredPath = new FolderPath(posixRelativePath);
-
-    Logger.debug('desired path', desiredPath);
-    Logger.debug('folder', folder.attributes());
-
-    Logger.debug('desired path dirname', desiredPath.dirname());
-    Logger.debug('folder dirname', folder.dirname.value);
-
-    Logger.debug('desired path name', desiredPath.name());
-    Logger.debug('folder name', folder.name);
 
     const dirnameChanged = folder.dirname.value !== desiredPath.dirname();
     const nameChanged = folder.name !== desiredPath.name();

--- a/tests/context/virtual-drive/files/application/FilePathUpdater.test.ts
+++ b/tests/context/virtual-drive/files/application/FilePathUpdater.test.ts
@@ -38,7 +38,13 @@ describe('File path updater', () => {
     const fileToRename = FileMother.any();
     const fileWithDestinationPath = undefined;
 
+    const folderFather = FolderMother.fromPartial({
+      path: fileToRename.dirname,
+    });
+
     repository.searchByPartial.mockReturnValueOnce(fileToRename).mockReturnValueOnce(fileWithDestinationPath);
+
+    folderFinder.findFromUuid.mockReturnValueOnce(folderFather);
 
     const destination = new FilePath(`${fileToRename.dirname}/_${fileToRename.nameWithExtension}`);
 
@@ -65,6 +71,12 @@ describe('File path updater', () => {
     const fileToMove = FileMother.any();
     const fileInDestination = undefined;
     const localFileId = '1-2';
+
+    const folderFather = FolderMother.fromPartial({
+      path: fileToMove.dirname,
+    });
+
+    folderFinder.findFromUuid.mockReturnValueOnce(folderFather);
 
     repository.searchByPartial.mockReturnValueOnce(fileToMove).mockReturnValueOnce(fileInDestination);
 


### PR DESCRIPTION
**This Pull Request addresses several issues and improvements in folder and file management:**

- Fix Duplicate Folder Creation:
The error causing duplicate creation of the "New Folder" folder when creating a new folder has been fixed. Now, the handlerAdd returns an error, skipping the queue task and preventing duplication.

- Add WorkspaceID in SYNCED and SYNCING Events:
The WorkspaceID has been added to the synced and syncing events to provide information about the sync status of each individual drive.

- Fix File Rename:
The issue preventing correct file renaming after renaming the parent folder has been fixed.

- Fix Folder Delete in Workspaces:
The issue preventing correct folder deletion within workspaces has been fixed.

- Fix Workspace Entry/Exit Inconsistency:
The inconsistency occurring when entering and exiting workspaces has been fixed, ensuring a smooth and error-free transition.