### PR TITLE
Migrate backups to use UUIDs

### DIFF
--- a/src/apps/backups/Backups.ts
+++ b/src/apps/backups/Backups.ts
@@ -39,11 +39,7 @@ export class Backup {
   private backed = 0;
 
   async run(info: BackupInfo, abortController: AbortController): Promise<DriveDesktopError | undefined> {
-    Logger.info('[BACKUPS] Local tree built 1');
-
     const localTreeEither = await this.localTreeBuilder.run(info.pathname as AbsolutePath);
-
-    Logger.info('[BACKUPS] Local tree built 2');
 
     if (localTreeEither.isLeft()) {
       Logger.error('[BACKUPS] Error building local tree');
@@ -51,11 +47,9 @@ export class Backup {
       return localTreeEither.getLeft();
     }
 
-    Logger.info('[BACKUPS] Local tree built 3');
-
     const local = localTreeEither.getRight();
 
-    const remote = await this.remoteTreeBuilder.run(info.folderId, true);
+    const remote = await this.remoteTreeBuilder.run(info.folderUuid, true);
 
     const foldersDiff = FoldersDiffCalculator.calculate(local, remote);
 

--- a/src/apps/backups/dependency-injection/virtual-drive/registerRemoteTreeServices.ts
+++ b/src/apps/backups/dependency-injection/virtual-drive/registerRemoteTreeServices.ts
@@ -21,5 +21,10 @@ export async function registerRemoteTreeServices(builder: ContainerBuilder) {
     .private();
 
   // Services
-  builder.registerAndUse(RemoteTreeBuilder);
+  builder
+    .register(RemoteTreeBuilder)
+    .useFactory((container) => new RemoteTreeBuilder(container.get(RemoteItemsGenerator),
+      container.get(Traverser))
+    )
+    .private();
 }

--- a/src/apps/backups/index.ts
+++ b/src/apps/backups/index.ts
@@ -5,6 +5,7 @@ import { BackupsDependencyContainerFactory } from './dependency-injection/Backup
 import { DriveDesktopError } from '../../context/shared/domain/errors/DriveDesktopError';
 import { BackupsIPCRenderer } from './BackupsIPCRenderer';
 import { setDefaultConfig } from '../sync-engine/config';
+import { logger } from '../shared/logger/logger';
 
 async function obtainBackup(): Promise<BackupInfo> {
   try {
@@ -24,8 +25,15 @@ async function obtainBackup(): Promise<BackupInfo> {
 
 async function backupFolder() {
   const data = await obtainBackup();
+
+  logger.debug({
+    msg: 'Backup folder',
+    data,
+  });
+
   setDefaultConfig({
     providerId: 'BACKUPS_PROVIDER_ID',
+    rootUuid: data.folderUuid,
   });
 
   try {

--- a/src/apps/backups/index.ts
+++ b/src/apps/backups/index.ts
@@ -5,7 +5,9 @@ import { BackupsDependencyContainerFactory } from './dependency-injection/Backup
 import { DriveDesktopError } from '../../context/shared/domain/errors/DriveDesktopError';
 import { BackupsIPCRenderer } from './BackupsIPCRenderer';
 import { setDefaultConfig } from '../sync-engine/config';
-setDefaultConfig();
+setDefaultConfig({
+  providerId: 'BACKUPS_PROVIDER_ID',
+});
 
 async function obtainBackup(): Promise<BackupInfo> {
   try {
@@ -57,7 +59,7 @@ async function backupFolder() {
       Logger.info('[BACKUPS] done');
       BackupsIPCRenderer.send('backups.backup-completed', data.folderId);
     }
-  } catch (error: any) {
+  } catch (error: unknown) {
     Logger.error('[BACKUPS] ', error);
     if (error instanceof DriveDesktopError) {
       Logger.error('[BACKUPS] ', { cause: error.cause });

--- a/src/apps/main/background-processes/backups/launchBackupProcesses.ts
+++ b/src/apps/main/background-processes/backups/launchBackupProcesses.ts
@@ -1,6 +1,5 @@
 import { ipcMain, powerSaveBlocker } from 'electron';
 import Logger from 'electron-log';
-// import { clearBackupsIssues } from '../../issues/virtual-drive';
 import { executeBackupWorker } from './BackukpWorker/executeBackupWorker';
 import { backupsConfig } from './BackupConfiguration/BackupConfiguration';
 import { BackupFatalErrors } from './BackupFatalErrors/BackupFatalErrors';
@@ -9,7 +8,6 @@ import { BackupsProcessTracker } from './BackupsProcessTracker/BackupsProcessTra
 import { BackupsStopController } from './BackupsStopController/BackupsStopController';
 import { isSyncError } from '../../../shared/issues/SyncErrorCause';
 import { isAvailableBackups } from '../../ipcs/ipcMainAntivirus';
-import { logger } from '@/apps/shared/logger/logger';
 
 function backupsCanRun(status: BackupsProcessStatus) {
   return status.isIn('STANDBY') && backupsConfig.enabled;

--- a/src/apps/main/device/service.test.ts
+++ b/src/apps/main/device/service.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import configStore from '../config';
+import { ensureBackupUuidExists, getBackupFolderUuid } from './service';
+import { client } from '@/apps/shared/HttpClient/client';
+
+// Mock dependencies
+vi.mock('../config', () => ({
+  default: {
+    get: vi.fn(),
+    set: vi.fn(),
+  },
+}));
+
+vi.mock('../auth/service', () => ({
+  getUser: vi.fn(),
+  setUser: vi.fn(),
+}));
+
+describe('ensureBackupUuidExists', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should handle empty backup list', async () => {
+    const emptyBackupsList = {};
+    await ensureBackupUuidExists(emptyBackupsList);
+
+    expect(configStore.set).toHaveBeenCalledWith('backupList', emptyBackupsList);
+    expect(configStore.set).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fetch UUIDs for enabled backups without UUIDs', async () => {
+    const backupsList: Record<
+      string,
+      {
+        enabled: boolean;
+        folderId: number;
+        folderUuid?: string;
+      }
+    > = {
+      '/path/to/backup1': {
+        enabled: true,
+        folderId: 123,
+      },
+      '/path/to/backup1.5': {
+        enabled: true,
+        folderId: 124,
+      },
+      '/path/to/backup2': {
+        enabled: false,
+        folderId: 456,
+      },
+      '/path/to/backup3': {
+        enabled: true,
+        folderId: 789,
+        folderUuid: 'existing-uuid',
+      },
+    };
+
+    vi.spyOn(client, 'GET').mockResolvedValue({ data: { uuid: 'new-uuid-123' }, error: null });
+
+    await ensureBackupUuidExists(backupsList);
+
+    // Check that UUIDs were properly updated
+    expect(backupsList['/path/to/backup1'].folderUuid).toBe('new-uuid-123');
+    expect(backupsList['/path/to/backup1.5'].folderUuid).toBe('new-uuid-123');
+    expect(backupsList['/path/to/backup2'].folderUuid).toBeUndefined();
+    expect(backupsList['/path/to/backup3'].folderUuid).toBe('existing-uuid');
+
+    expect(configStore.set).toHaveBeenCalledWith('backupList', backupsList);
+  });
+});

--- a/src/apps/main/device/service.test.ts
+++ b/src/apps/main/device/service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import configStore from '../config';
-import { ensureBackupUuidExists, getBackupFolderUuid } from './service';
+import { ensureBackupUuidExists } from './service';
 import { client } from '@/apps/shared/HttpClient/client';
 
 // Mock dependencies

--- a/src/apps/main/remote-sync/files/fetch-remote-files.service.ts
+++ b/src/apps/main/remote-sync/files/fetch-remote-files.service.ts
@@ -30,7 +30,7 @@ export class FetchRemoteFilesService implements FetchFilesService {
       return { hasMore, result: result.data };
     }
 
-    throw logger.error({ msg: 'Fetch files response not ok', exc: result.error });
+    throw logger.error({ msg: 'Fetch files response not ok', exc: result.error, folderUuid });
   }
 
   private getFiles({ query }: { query: QueryFiles }) {

--- a/src/apps/shared/HttpClient/schema.d.ts
+++ b/src/apps/shared/HttpClient/schema.d.ts
@@ -4563,7 +4563,9 @@ export interface operations {
     parameters: {
       query?: never;
       header?: never;
-      path?: never;
+      path: {
+        id: number;
+      };
       cookie?: never;
     };
     requestBody?: never;
@@ -4572,7 +4574,9 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['FolderDto'];
+        };
       };
     };
   };

--- a/src/apps/shared/IPC/events/sync-engine.ts
+++ b/src/apps/shared/IPC/events/sync-engine.ts
@@ -71,14 +71,14 @@ export type SyncEngineInvocableFunctions = {
     folders: DriveFolder[];
   }>;
   GET_UPDATED_REMOTE_ITEMS_BY_FOLDER: (
-    folderId: number,
+    folderUuid: string,
     workspaceId: string,
   ) => Promise<{
     files: DriveFile[];
     folders: DriveFolder[];
   }>;
   START_REMOTE_SYNC: () => Promise<void>;
-  FORCE_REFRESH_BACKUPS: (folderId: number) => Promise<void>;
+  FORCE_REFRESH_BACKUPS: (folderUuid: string) => Promise<void>;
 
   GET_HEADERS: () => Promise<Record<string, string>>;
 

--- a/src/apps/sync-engine/config.ts
+++ b/src/apps/sync-engine/config.ts
@@ -53,8 +53,8 @@ export function setConfig(newConfig: Config) {
   config = { ...defaultValues(), ...newConfig };
 }
 
-export function setDefaultConfig() {
-  config = defaultValues();
+export function setDefaultConfig(newConfig: Partial<Config>) {
+  config = { ...defaultValues(), ...newConfig };
 }
 export function getConfig(): Config {
   return config;

--- a/src/context/local/localFile/application/upload/FileBatchUploader.ts
+++ b/src/context/local/localFile/application/upload/FileBatchUploader.ts
@@ -10,6 +10,7 @@ import Logger from 'electron-log';
 import { ipcRenderer } from 'electron';
 import { RendererIpcLocalFileMessenger } from '../../infrastructure/RendererIpcLocalFileMessenger';
 import { EnvironmentLocalFileUploader } from '../../infrastructure/EnvironmentLocalFileUploader';
+import { logger } from '@/apps/shared/logger/logger';
 
 @Service()
 export class FileBatchUploader {
@@ -57,6 +58,8 @@ export class FileBatchUploader {
 
             const remotePath = relativeV2(localRootPath, localFile.path);
             const parent = remoteTree.getParent(remotePath);
+
+            logger.debug({ msg: 'Uploading file', remotePath, parent });
 
             const either = await this.creator.run({
               contentsId,

--- a/src/context/virtual-drive/files/infrastructure/HttpRemoteFileSystem.ts
+++ b/src/context/virtual-drive/files/infrastructure/HttpRemoteFileSystem.ts
@@ -28,7 +28,7 @@ export class HttpRemoteFileSystem {
 
       logger.debug({
         msg: `Creating file ${offline.name} in folder ${offline.folderId}`,
-        encryptedName: offline.path,
+        offline,
       });
 
       const body: PersistFileDto = {
@@ -40,6 +40,12 @@ export class HttpRemoteFileSystem {
         size: offline.size,
         type: offline.type,
       };
+
+      logger.debug({
+        msg: `Creating file ${offline.name} in folder ${offline.folderId}`,
+        offline,
+        body,
+      });
 
       const result = this.workspaceId ? await this.createFileInWorkspace(body, this.workspaceId) : await this.createFile(body);
 
@@ -110,16 +116,16 @@ export class HttpRemoteFileSystem {
 
       if (response.error) {
         logger.error({
-          msg: 'Error creating file entry',
+          msg: 'Error creating file entry in workspaces',
           error: response,
         });
-        throw new Error('Error creating file entry');
+        throw new Error('Error creating file entry in workspaces');
       }
 
       return response.data;
     } catch (error) {
       logger.error({
-        msg: 'Error creating file entry',
+        msg: 'Error creating file entry in workspaces',
         exc: error,
       });
       throw new Error('Failed to create file and no existing file found');

--- a/src/context/virtual-drive/items/application/RemoteItemsGenerator.ts
+++ b/src/context/virtual-drive/items/application/RemoteItemsGenerator.ts
@@ -57,8 +57,8 @@ export class RemoteItemsGenerator {
     return { files, folders };
   }
 
-  async getAllItemsByFolderId(folderId: number): Promise<{ files: ServerFile[]; folders: ServerFolder[] }> {
-    const updatedRemoteItems = await this.ipc.invoke('GET_UPDATED_REMOTE_ITEMS_BY_FOLDER', folderId, getConfig().workspaceId ?? '');
+  async getAllItemsByFolderId(folderUuid: string): Promise<{ files: ServerFile[]; folders: ServerFolder[] }> {
+    const updatedRemoteItems = await this.ipc.invoke('GET_UPDATED_REMOTE_ITEMS_BY_FOLDER', folderUuid, getConfig().workspaceId ?? '');
 
     const files = updatedRemoteItems.files.map<ServerFile>(this.mapFile);
 
@@ -67,7 +67,7 @@ export class RemoteItemsGenerator {
     return { files, folders };
   }
 
-  async forceRefresh(folderId: number): Promise<void> {
-    await this.ipc.invoke('FORCE_REFRESH_BACKUPS', folderId);
+  async forceRefresh(folderUuid: string): Promise<void> {
+    await this.ipc.invoke('FORCE_REFRESH_BACKUPS', folderUuid);
   }
 }

--- a/src/context/virtual-drive/remoteTree/application/RemoteTreeBuilder.ts
+++ b/src/context/virtual-drive/remoteTree/application/RemoteTreeBuilder.ts
@@ -11,14 +11,14 @@ export class RemoteTreeBuilder {
     private readonly traverser: Traverser,
   ) {}
 
-  async run(rootFolderId: number, refresh = false): Promise<RemoteTree> {
+  async run(rootFolderUuid: string, refresh = false): Promise<RemoteTree> {
     if (refresh) {
       Logger.debug('[REMOTE TREE BUILDER] Force refresh');
-      await this.remoteItemsGenerator.forceRefresh(rootFolderId);
+      await this.remoteItemsGenerator.forceRefresh(rootFolderUuid);
     }
 
-    const items = await this.remoteItemsGenerator.getAllItemsByFolderId(rootFolderId);
+    const items = await this.remoteItemsGenerator.getAllItemsByFolderId(rootFolderUuid);
 
-    return this.traverser.run(rootFolderId, items);
+    return this.traverser.run(rootFolderUuid, items);
   }
 }

--- a/src/context/virtual-drive/remoteTree/application/Traverser.ts
+++ b/src/context/virtual-drive/remoteTree/application/Traverser.ts
@@ -119,8 +119,6 @@ export class Traverser {
   public run(rootFolderId: number, items: Items): RemoteTree {
     const rootFolder = this.createRootFolder(rootFolderId);
 
-    Logger.debug('[Traverser] Root folder', rootFolder);
-
     const tree = new RemoteTree(rootFolder);
 
     this.traverse(tree, items, rootFolder);

--- a/src/context/virtual-drive/remoteTree/application/Traverser.ts
+++ b/src/context/virtual-drive/remoteTree/application/Traverser.ts
@@ -31,12 +31,12 @@ export class Traverser {
     return new Traverser(decrypt, [], []);
   }
 
-  private createRootFolder(id: number): Folder {
-    const rootFolderUuid = '43711926-15c2-5ebf-8c24-5099fa9af3c3';
+  private createRootFolder(uuid: string): Folder {
+    const id = 1;
 
     return Folder.from({
-      id: id,
-      uuid: rootFolderUuid,
+      id,
+      uuid,
       parentId: null,
       parentUuid: null,
       updatedAt: new Date().toISOString(),
@@ -116,7 +116,7 @@ export class Traverser {
     });
   }
 
-  public run(rootFolderId: number, items: Items): RemoteTree {
+  public run(rootFolderId: string, items: Items): RemoteTree {
     const rootFolder = this.createRootFolder(rootFolderId);
 
     const tree = new RemoteTree(rootFolder);

--- a/src/context/virtual-drive/remoteTree/domain/RemoteItemsGenerator.ts
+++ b/src/context/virtual-drive/remoteTree/domain/RemoteItemsGenerator.ts
@@ -4,7 +4,7 @@ import { ServerFolder } from '../../../shared/domain/ServerFolder';
 export abstract class RemoteItemsGenerator {
   abstract getAll(): Promise<{ files: ServerFile[]; folders: ServerFolder[] }>;
 
-  abstract getAllItemsByFolderId(folderId: number): Promise<{ files: ServerFile[]; folders: ServerFolder[] }>;
+  abstract getAllItemsByFolderId(folderUuid: string): Promise<{ files: ServerFile[]; folders: ServerFolder[] }>;
 
-  abstract forceRefresh(folderId: number): Promise<void>;
+  abstract forceRefresh(folderUuid: string): Promise<void>;
 }

--- a/tests/vitest/setup.helper.test.ts
+++ b/tests/vitest/setup.helper.test.ts
@@ -148,3 +148,13 @@ vi.mock('@/apps/main/virtual-root-folder/service.ts', () => {
     })),
   };
 });
+
+vi.mock('@/apps/main/windows/widget.ts', () => {
+  return {
+    getWidget: vi.fn(() => ({
+      webContents: {
+        send: vi.fn(),
+      },
+    })),
+  };
+});


### PR DESCRIPTION
**This Pull Request focuses on improving data consistency in the backup system. The following migration has been performed:**

Migration of Backup IDs to buckUuid: Backup identifiers have been migrated from numeric IDs to buckUuid. This ensures greater consistency and reduces the risk of conflicts, especially in distributed systems.

### Specific Changes:

- Modification of backup logic to use buckUuid instead of IDs.
- Update the models to reflect the change.
- Updating of unit and integration tests to verify the correct migration.