### PR TITLE
 Removal of Sync Root Folder Deletion on Login and Renaming for Legacy Users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 /coverage
 /dist
 /node_modules
+
+# Testing temp files
+/test/temp-test/

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,4 @@
 /coverage
 /dist
 /node_modules
-
-# Testing temp files
 /test/temp-test/

--- a/src/apps/main/auth/handlers.ts
+++ b/src/apps/main/auth/handlers.ts
@@ -79,7 +79,7 @@ export function setupAuthIpcHandlers() {
       password: data.password,
     });
     if (!canHisConfigBeRestored(data.user.uuid)) {
-      await setupRootFolder();
+      await setupRootFolder(data.user);
     }
     await clearRootVirtualDrive();
 

--- a/src/apps/main/auth/handlers.ts
+++ b/src/apps/main/auth/handlers.ts
@@ -79,7 +79,7 @@ export function setupAuthIpcHandlers() {
       password: data.password,
     });
     if (!canHisConfigBeRestored(data.user.uuid)) {
-      await setupRootFolder(data.user);
+      setupRootFolder(data.user);
     }
     await clearRootVirtualDrive();
 

--- a/src/apps/main/config.ts
+++ b/src/apps/main/config.ts
@@ -36,7 +36,6 @@ export interface AppStore {
   deviceId: number;
   deviceUuid: string;
   backupList: Record<string, { enabled: boolean; folderId: number; folderUuid: string }>;
-
   workspacesPath: Record<string, string>;
   clientId: string;
   preferedLanguage?: string;

--- a/src/apps/main/database/data-source.ts
+++ b/src/apps/main/database/data-source.ts
@@ -20,10 +20,19 @@ logger.debug({
 });
 
 export const destroyDatabase = async () => {
-  AppDataSource.dropDatabase().catch((error) => {
-    reportError(error);
-  });
-  logger.debug({
-    msg: 'Database destroyed',
-  });
+  try {
+    // Clear all tables instead of dropping the database
+    await AppDataSource.getRepository(DriveFile).clear();
+    await AppDataSource.getRepository(DriveFolder).clear();
+    await AppDataSource.getRepository(DriveWorkspace).clear();
+
+    logger.debug({
+      msg: 'All table contents cleared',
+    });
+  } catch (error) {
+    logger.warn({
+      msg: 'Error clearing database',
+      exc: error,
+    });
+  }
 };

--- a/src/apps/main/virtual-root-folder/service.ts
+++ b/src/apps/main/virtual-root-folder/service.ts
@@ -43,10 +43,11 @@ export function setSyncRoot(pathname: string): void {
 export function getRootVirtualDrive(): string {
   const current = configStore.get('syncRoot');
   const user = getUser();
-  if (!user)
+  if (!user) {
     throw logger.error({
       msg: 'User not found when getting root virtual drive',
     });
+  }
 
   logger.debug({
     msg: 'Current root virtual drive',

--- a/src/apps/main/virtual-root-folder/services.test.ts
+++ b/src/apps/main/virtual-root-folder/services.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach, MockInstance } from 'vitest';
-import fsPromise from 'fs/promises';
 import fs from 'fs';
 import path from 'path';
 import configStore from '../config';
@@ -22,7 +21,7 @@ beforeEach(async () => {
     fs.mkdirSync(tempDir);
   }
 
-  renameSpy = vi.spyOn(fsPromise, 'rename').mockImplementation(async () => Promise.resolve());
+  renameSpy = vi.spyOn(fs, 'renameSync').mockImplementation(async () => Promise.resolve());
 });
 
 afterEach(() => {
@@ -44,7 +43,7 @@ describe('setupRootFolder', () => {
 
     configStore.get = vi.fn().mockReturnValue(syncRoot);
 
-    await setupRootFolder(user);
+    setupRootFolder(user);
 
     expect(renameSpy).toHaveBeenCalledWith(syncRoot, `${virtualDriveFolder} - ${user.email}`);
     expect(configStore.get).toHaveBeenCalledWith('syncRoot');
@@ -61,7 +60,7 @@ describe('setupRootFolder', () => {
 
     configStore.get = vi.fn().mockReturnValue(syncRoot);
 
-    await setupRootFolder(user);
+    setupRootFolder(user);
 
     expect(renameSpy).not.toHaveBeenCalled();
   });
@@ -70,7 +69,7 @@ describe('setupRootFolder', () => {
     const user: User = { email: 'test4@gmail.com', uuid: '101' } as User;
     configStore.get = vi.fn().mockReturnValue(undefined);
 
-    await setupRootFolder(user);
+    setupRootFolder(user);
 
     expect(renameSpy).not.toHaveBeenCalled();
   });

--- a/src/apps/main/virtual-root-folder/services.test.ts
+++ b/src/apps/main/virtual-root-folder/services.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach, MockInstance } from 'vitest';
+import fsPromise from 'fs/promises';
+import fs from 'fs';
+import path from 'path';
+import configStore from '../config';
+import { User } from '../types';
+import { getRootVirtualDrive, setupRootFolder } from './service';
+import { logger } from '@/apps/shared/logger/logger';
+
+vi.mock('./service', async () => {
+  const actual = await vi.importActual('./service');
+  return {
+    ...actual,
+    setSyncRoot: vi.fn(),
+  };
+});
+
+const tempDir = path.join(__dirname, '../../../../tests/temp-test');
+let renameSpy: MockInstance<(oldPath: string, newPath: string) => void>;
+
+beforeEach(async () => {
+  if (!fs.existsSync(tempDir)) {
+    fs.mkdirSync(tempDir);
+  }
+
+  renameSpy = vi.spyOn(fsPromise, 'rename').mockImplementation(async () => Promise.resolve());
+});
+
+afterEach(() => {
+  fs.rm(tempDir, { recursive: true }, () => {
+    return;
+  });
+  vi.restoreAllMocks();
+});
+
+describe('setupRootFolder', () => {
+  it('should rename the folder if the current syncRoot matches pathNameWithSepInTheEnd', async () => {
+    const user = { email: 'test@gmail.com', uuid: '123' } as User;
+    const virtualDriveFolder = path.join(tempDir, process.env.ROOT_FOLDER_NAME);
+    const syncRoot = virtualDriveFolder + path.sep;
+
+    if (!fs.existsSync(virtualDriveFolder)) {
+      fs.mkdirSync(virtualDriveFolder);
+    }
+
+    configStore.get = vi.fn().mockReturnValue(syncRoot);
+
+    await setupRootFolder(user);
+
+    expect(renameSpy).toHaveBeenCalledWith(syncRoot, `${virtualDriveFolder} - ${user.email}`);
+    expect(configStore.get).toHaveBeenCalledWith('syncRoot');
+  });
+
+  it('should set a new syncRoot when the user changes the root', async () => {
+    const user: User = { email: 'test2@gmail.com', uuid: '456' } as User;
+    const virtualDriveFolder = path.join(tempDir, 'virtual-drive');
+    const syncRoot = `${virtualDriveFolder} - test@gmail.com`;
+
+    if (!fs.existsSync(virtualDriveFolder)) {
+      fs.mkdirSync(virtualDriveFolder);
+    }
+
+    configStore.get = vi.fn().mockReturnValue(syncRoot);
+
+    await setupRootFolder(user);
+
+    expect(renameSpy).not.toHaveBeenCalled();
+  });
+
+  it('should handle a syncRoot belonging to another user and update it correctly', async () => {
+    const user: User = { email: 'test3@gmail.com', uuid: '789' } as User;
+    const virtualDriveFolder = path.join(tempDir, 'virtual-drive');
+    const syncRoot = `${virtualDriveFolder} - test@gmail.com`;
+
+    if (!fs.existsSync(virtualDriveFolder)) {
+      fs.mkdirSync(virtualDriveFolder);
+    }
+
+    configStore.get = vi.fn().mockReturnValue(syncRoot);
+
+    await setupRootFolder(user);
+
+    expect(renameSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not rename or setSyncRoot if syncRoot is undefined', async () => {
+    const user: User = { email: 'test4@gmail.com', uuid: '101' } as User;
+    configStore.get = vi.fn().mockReturnValue(undefined);
+
+    await setupRootFolder(user);
+
+    expect(renameSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('getRootVirtualDrive', () => {
+  it('should return the current syncRoot if it matches the user email', () => {
+    const userEmail = 'test@gmail.com';
+    vi.mock('@/apps/main/auth/service', () => {
+      return {
+        getUser: vi.fn(() => ({
+          email: 'test@gmail.com',
+          uuid: '123',
+          id: 21,
+        })),
+      };
+    });
+    const syncRoot = `/test/path - ${userEmail}`;
+    configStore.get = vi.fn().mockReturnValue(syncRoot);
+
+    const result = getRootVirtualDrive();
+    expect(result).toBe(syncRoot);
+  });
+
+  it('should call setupRootFolder and return a new syncRoot if the user email does not match', () => {
+    const user: User = { email: 'test2@gmail.com', uuid: '456' } as User;
+    vi.mock('@/apps/main/auth/service', () => {
+      return {
+        getUser: vi.fn(() => ({
+          email: 'test2@gmail.com',
+          uuid: '123',
+          id: 21,
+        })),
+      };
+    });
+    const oldSyncRoot = '/test/path - test1@gmail.com';
+    const newSyncRoot = `/test/path - ${user.email}`;
+    configStore.get = vi.fn().mockReturnValueOnce(oldSyncRoot).mockReturnValueOnce(oldSyncRoot).mockReturnValueOnce(newSyncRoot);
+
+    const result = getRootVirtualDrive();
+
+    expect(result).toBe(newSyncRoot);
+  });
+});

--- a/src/apps/main/virtual-root-folder/services.test.ts
+++ b/src/apps/main/virtual-root-folder/services.test.ts
@@ -5,7 +5,6 @@ import path from 'path';
 import configStore from '../config';
 import { User } from '../types';
 import { getRootVirtualDrive, setupRootFolder } from './service';
-import { logger } from '@/apps/shared/logger/logger';
 
 vi.mock('./service', async () => {
   const actual = await vi.importActual('./service');
@@ -15,7 +14,7 @@ vi.mock('./service', async () => {
   };
 });
 
-const tempDir = path.join(__dirname, '../../../../tests/temp-test');
+const tempDir = path.join(process.cwd(), 'tests/temp-test');
 let renameSpy: MockInstance<(oldPath: string, newPath: string) => void>;
 
 beforeEach(async () => {

--- a/src/apps/main/virtual-root-folder/services.test.ts
+++ b/src/apps/main/virtual-root-folder/services.test.ts
@@ -67,22 +67,6 @@ describe('setupRootFolder', () => {
     expect(renameSpy).not.toHaveBeenCalled();
   });
 
-  it('should handle a syncRoot belonging to another user and update it correctly', async () => {
-    const user: User = { email: 'test3@gmail.com', uuid: '789' } as User;
-    const virtualDriveFolder = path.join(tempDir, 'virtual-drive');
-    const syncRoot = `${virtualDriveFolder} - test@gmail.com`;
-
-    if (!fs.existsSync(virtualDriveFolder)) {
-      fs.mkdirSync(virtualDriveFolder);
-    }
-
-    configStore.get = vi.fn().mockReturnValue(syncRoot);
-
-    await setupRootFolder(user);
-
-    expect(renameSpy).not.toHaveBeenCalled();
-  });
-
   it('should not rename or setSyncRoot if syncRoot is undefined', async () => {
     const user: User = { email: 'test4@gmail.com', uuid: '101' } as User;
     configStore.get = vi.fn().mockReturnValue(undefined);

--- a/tests/vitest/setup.helper.test.ts
+++ b/tests/vitest/setup.helper.test.ts
@@ -1,5 +1,6 @@
 import { vi } from 'vitest';
 import dotenv from 'dotenv';
+import path from 'path';
 
 dotenv.config();
 
@@ -68,7 +69,12 @@ vi.mock('electron', async () => {
     ...actual,
     app: {
       ...actual.app,
-      getPath: vi.fn(() => '/mock/path'),
+      getPath: vi.fn((string) => {
+        if (string === 'home') {
+          return path.join(__dirname, '../temp-test');
+        }
+        return '/mock/logs';
+      }),
       on: vi.fn(),
     },
     ipcMain: {

--- a/tests/vitest/setup.helper.test.ts
+++ b/tests/vitest/setup.helper.test.ts
@@ -6,6 +6,8 @@ dotenv.config();
 
 process.env.NODE_ENV = 'development';
 
+process.env.ROOT_FOLDER_NAME = 'InternxtDrive';
+
 vi.mock('@/apps/main/auth/service', () => {
   const user = {
     email: 'jonathandanielarce9@gmail.com',

--- a/tests/vitest/setup.helper.test.ts
+++ b/tests/vitest/setup.helper.test.ts
@@ -54,7 +54,7 @@ vi.mock('@/apps/main/auth/service', () => {
 });
 
 vi.mock('../event-bus', () => {
-  const listeners: Record<string, ((...args: any[]) => void)[]> = {};
+  const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
 
   return {
     default: {
@@ -65,7 +65,7 @@ vi.mock('../event-bus', () => {
 });
 
 vi.mock('electron', async () => {
-  const ipcMainHandlers: Record<string, (...args: any[]) => void> = {};
+  const ipcMainHandlers: Record<string, (...args: unknown[]) => void> = {};
   const actual = await vi.importActual<typeof import('electron')>('electron');
   return {
     ...actual,
@@ -73,7 +73,7 @@ vi.mock('electron', async () => {
       ...actual.app,
       getPath: vi.fn((string) => {
         if (string === 'home') {
-          return path.join(__dirname, '../temp-test');
+          return path.join(process.cwd(), 'tests/temp-test');
         }
         return '/mock/logs';
       }),
@@ -101,7 +101,7 @@ vi.mock('electron', async () => {
     })),
     ipcRenderer: {
       on: vi.fn(
-        (event, callback) =>
+        (event) =>
           ipcMainHandlers[event] &&
           ipcMainHandlers[event]({
             sender: {
@@ -122,7 +122,7 @@ vi.mock('electron', async () => {
           ),
       ),
       handle: vi.fn(
-        (event, callback) =>
+        (event) =>
           ipcMainHandlers[event] &&
           ipcMainHandlers[event]({
             sender: {
@@ -131,7 +131,7 @@ vi.mock('electron', async () => {
           }),
       ),
       invoke: vi.fn(
-        (event, ...args) =>
+        (event) =>
           ipcMainHandlers[event] &&
           ipcMainHandlers[event]({
             sender: {


### PR DESCRIPTION
**This Pull Request focuses on fixing an issue that caused the loss of unsynchronized files on login, and on improving sync folder management for existing and new users.**

- Removal of sync root folder deletion on login:
  - The logic that deleted the user's sync root folder during login has been removed. This prevents the loss of files that have not yet been synchronized with the cloud.
- Implementation of unique user folders:
  - To prevent file mixing between multiple accounts, each user now has a unique sync folder named "InternxtDrive - {userEmail}".
- Folder renaming for legacy users:
  - Logic has been implemented to rename existing sync folders of legacy users to the new format.
- Addition of tests:
  - Unit tests have been added to ensure the correct functioning of the changes.

### Specific Changes:

- Removal of the sync root folder deletion logic on login.
- Implementation of the creation of unique sync folders for each user.
- Implementation of the sync folder renaming logic for legacy users.
- Addition of unit and integration tests.