### PR TITLE
Global Configuration Refactoring and Root Folder Renaming

### DIFF
--- a/src/apps/main/main.ts
+++ b/src/apps/main/main.ts
@@ -55,6 +55,7 @@ import { setUpBackups } from './background-processes/backups/setUpBackups';
 import { clearAntivirusIfAvailable, initializeAntivirusIfAvailable } from './antivirus/utils/initializeAntivirus';
 import { registerUsageHandlers } from './usage/handlers';
 import { setupQuitHandlers } from './quit';
+import { setDefaultConfig } from '../sync-engine/config';
 
 const gotTheLock = app.requestSingleInstanceLock();
 
@@ -115,6 +116,8 @@ app
       await createAuthWindow();
       setTrayStatus('IDLE');
     }
+
+    setDefaultConfig({});
 
     ipcMain.handle('is-dark-mode-active', () => {
       return nativeTheme.shouldUseDarkColors;

--- a/src/apps/main/virtual-root-folder/service.ts
+++ b/src/apps/main/virtual-root-folder/service.ts
@@ -44,7 +44,7 @@ export function getRootVirtualDrive(): string {
     current,
   });
 
-  if (!current.includes(user.email)) {
+  if (!current.includes(user.uuid)) {
     logger.debug({
       msg: 'Root virtual drive not found for user',
     });
@@ -110,7 +110,7 @@ export function setupRootFolder(user: User): void {
   const current = configStore.get('syncRoot');
 
   const pathNameWithSepInTheEnd = VIRTUAL_DRIVE_FOLDER + path.sep;
-  const syncFolderPath = `${VIRTUAL_DRIVE_FOLDER} - ${user.email}`;
+  const syncFolderPath = `${VIRTUAL_DRIVE_FOLDER} - ${user.uuid}`;
 
   logger.debug({
     msg: 'Virtual drive folder',
@@ -124,8 +124,8 @@ export function setupRootFolder(user: User): void {
    * Previously, the drive name in Explorer was "Internxt Drive" and when you logged out and logged in,
    * you would delete the folder and recreate it. However, if some files weren't synced, deleting the folder
    * would cause them to be lost. Now, we won't delete the folder; instead, we'll create a new drive for each
-   * login called "Internxt Drive - {user.email}."
-   * So, we need to rename "Internxt Drive" to "Internxt Drive - {user.email}".
+   * login called "Internxt Drive - { user.uuid}."
+   * So, we need to rename "Internxt Drive" to "Internxt Drive - { user.uuid}".
    */
   if (current === pathNameWithSepInTheEnd) {
     if (fs.existsSync(syncFolderPath)) {

--- a/src/apps/main/virtual-root-folder/service.ts
+++ b/src/apps/main/virtual-root-folder/service.ts
@@ -124,7 +124,7 @@ export function setupRootFolder(user: User): void {
    * Previously, the drive name in Explorer was "Internxt Drive" and when you logged out and logged in,
    * you would delete the folder and recreate it. However, if some files weren't synced, deleting the folder
    * would cause them to be lost. Now, we won't delete the folder; instead, we'll create a new drive for each
-   * login called "Internxt Drive - { user.uuid}."
+   * login called "Internxt Drive - {user.uuid}."
    * So, we need to rename "Internxt Drive" to "Internxt Drive - { user.uuid}".
    */
   if (current === pathNameWithSepInTheEnd) {

--- a/src/apps/main/virtual-root-folder/services.test.ts
+++ b/src/apps/main/virtual-root-folder/services.test.ts
@@ -45,7 +45,7 @@ describe('setupRootFolder', () => {
 
     setupRootFolder(user);
 
-    expect(renameSpy).toHaveBeenCalledWith(syncRoot, `${virtualDriveFolder} - ${user.email}`);
+    expect(renameSpy).toHaveBeenCalledWith(syncRoot, `${virtualDriveFolder} - ${user.uuid}`);
     expect(configStore.get).toHaveBeenCalledWith('syncRoot');
   });
 
@@ -106,7 +106,7 @@ describe('getRootVirtualDrive', () => {
       };
     });
     const oldSyncRoot = '/test/path - test1@gmail.com';
-    const newSyncRoot = `/test/path - ${user.email}`;
+    const newSyncRoot = `/test/path - ${user.uuid}`;
     configStore.get = vi.fn().mockReturnValueOnce(oldSyncRoot).mockReturnValueOnce(oldSyncRoot).mockReturnValueOnce(newSyncRoot);
 
     const result = getRootVirtualDrive();


### PR DESCRIPTION
### This Pull Request includes minor changes focused on improving global configuration management and the consistency of root folder names.

- Initialization of global configuration in main:

The global configuration has been initialized in the main file to ensure that all global values, including the mnemonic and other relevant values, are accessible by default.

- Root folder renaming:

At Luis's request, the key for root folders has been changed from "internxtDrive - user.email" to "InternxtDrive - user.uuid". This improves consistency and uniqueness of folder names.

- Test updates:

The corresponding unit and integration tests have been updated to reflect the changes made.

### Specific Changes:

1. Initialization of global configuration in the main file.
2. Modification of the root folder key to "InternxtDrive - user.uuid".
3. Updating of unit and integration tests.