### PR TITLE
Fix unregister workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "@iconscout/react-unicons": "^1.1.6",
     "@internxt/inxt-js": "2.1.0",
     "@internxt/lib": "1.1.6",
-    "@internxt/node-win": "1.0.4",
+    "@internxt/node-win": "1.0.5",
     "@internxt/scan": "1.0.2",
     "@internxt/sdk": "1.9.9",
     "@phosphor-icons/react": "2.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: 1.1.6
         version: 1.1.6
       '@internxt/node-win':
-        specifier: 1.0.4
-        version: 1.0.4
+        specifier: 1.0.5
+        version: 1.0.5
       '@internxt/scan':
         specifier: 1.0.2
         version: 1.0.2
@@ -1322,8 +1322,8 @@ packages:
   '@internxt/lib@1.1.6':
     resolution: {integrity: sha512-xpnSpDsWr+jemV2aI71B39LGfXnNCsyv2VKND0JAgrOeyHXjnChH+IHxGLq/8f73HT47mpkNXrK4nfpzH4OaaQ==, tarball: https://npm.pkg.github.com/download/@internxt/lib/1.1.6/ea931ba39aa0e715704400603beb8833c73c05e4}
 
-  '@internxt/node-win@1.0.4':
-    resolution: {integrity: sha512-NHFtn8Z8IBc4t57oij84S/Oh0HbrlQqbGb0Avz2zvQAKKvhxCIsCk/JXRqLNHhR76Rp/zqF+EUuxcel3tWmKxw==, tarball: https://npm.pkg.github.com/download/@internxt/node-win/1.0.4/ea4683b803dd4ceac75b31ec0ef8d1efc5f6cbc9}
+  '@internxt/node-win@1.0.5':
+    resolution: {integrity: sha512-q47f4hwvPGNaqeYI4iUG/iiiNL0ELSIVzxAU79m10CPWMpRlqg4eSboZgt2kshQFXXPYfk8Cql/1uxHLTON/yA==, tarball: https://npm.pkg.github.com/download/@internxt/node-win/1.0.5/7980d916a91c58246d9b7d4269f0fab314caba48}
 
   '@internxt/scan@1.0.2':
     resolution: {integrity: sha512-AZAPF+JywxfyEWJ9LPk+b3HHJG1c6fDq+x+YX5U5FKilfX43RgM6GdCME/RfuJPLuMy6B0r/W24NWIRs6sQUXQ==, tarball: https://npm.pkg.github.com/download/@internxt/scan/1.0.2/dc85bd75165ff50adfc8b9f607b233398898c60a}
@@ -8969,7 +8969,7 @@ snapshots:
 
   '@internxt/lib@1.1.6': {}
 
-  '@internxt/node-win@1.0.4':
+  '@internxt/node-win@1.0.5':
     dependencies:
       chokidar: 3.6.0
       lodash.chunk: 4.2.0

--- a/src/apps/main/database/collections/DriveFileCollection.ts
+++ b/src/apps/main/database/collections/DriveFileCollection.ts
@@ -199,22 +199,4 @@ export class DriveFilesCollection implements DatabaseCollectionAdapter<DriveFile
       };
     }
   }
-
-  async cleanWorkspace(workspaceId: string): Promise<{ success: boolean }> {
-    try {
-      await this.repository.delete({ workspaceId });
-      return {
-        success: true,
-      };
-    } catch (exc) {
-      logger.warn({
-        msg: 'Error cleaning workspace',
-        workspaceId,
-        exc,
-      });
-      return {
-        success: false,
-      };
-    }
-  }
 }

--- a/src/apps/main/database/collections/DriveFolderCollection.ts
+++ b/src/apps/main/database/collections/DriveFolderCollection.ts
@@ -162,22 +162,4 @@ export class DriveFoldersCollection implements DatabaseCollectionAdapter<DriveFo
       };
     }
   }
-
-  async cleanWorkspace(workspaceId: string): Promise<{ success: boolean }> {
-    try {
-      await this.repository.delete({ workspaceId });
-      return {
-        success: true,
-      };
-    } catch (exc) {
-      logger.warn({
-        msg: 'Error cleaning workspace',
-        workspaceId,
-        exc,
-      });
-      return {
-        success: false,
-      };
-    }
-  }
 }

--- a/src/apps/sync-engine/BindingManager.ts
+++ b/src/apps/sync-engine/BindingManager.ts
@@ -241,10 +241,6 @@ export class BindingsManager {
     await this.container.virtualDrive.unregisterSyncRoot();
   }
 
-  async unregisterSyncEngine({ providerId }: { providerId: string }) {
-    await this.container.virtualDrive.unRegisterSyncRootByProviderId({ providerId });
-  }
-
   async cleanQueue() {
     if (this.queueManager) {
       this.queueManager.clearQueue();

--- a/src/apps/sync-engine/index.ts
+++ b/src/apps/sync-engine/index.ts
@@ -7,7 +7,6 @@ import { iconPath } from '../utils/icon';
 import * as Sentry from '@sentry/electron/renderer';
 import { setConfig, Config, getConfig } from './config';
 import { FetchWorkspacesService } from '../main/remote-sync/workspace/fetch-workspaces.service';
-import { logger } from '../shared/logger/logger';
 import { INTERNXT_VERSION } from '@/core/utils/utils';
 
 Logger.log(`Running sync engine ${INTERNXT_VERSION}`);
@@ -97,12 +96,6 @@ async function setUp() {
       Sentry.captureException(error);
       event.sender.send('ERROR_ON_STOP_AND_CLEAR_SYNC_ENGINE_PROCESS');
     }
-  });
-
-  ipcRenderer.on('UNREGISTER_SYNC_ENGINE_PROCESS', async (_, providerId: string) => {
-    logger.debug({ msg: '[SYNC ENGINE] Unregistering sync engine', providerId });
-    await bindings.unregisterSyncEngine({ providerId });
-    logger.debug({ msg: '[SYNC ENGINE] sync engine unregistered successfully' });
   });
 
   await bindings.start(INTERNXT_VERSION);


### PR DESCRIPTION
## What

Fix unregister root folder of removed workspaces. Now we don't need to emit an event to the sync engine process, we can unregister it directly from main process.