### PR TITLE
Removal of FILE_PREPARING Event and Exclusive Use of FILE_DOWNLOADING

### DIFF
--- a/src/apps/main/fordwardToWindows.ts
+++ b/src/apps/main/fordwardToWindows.ts
@@ -36,16 +36,6 @@ ipcMainDrive.on('SYNCED', (_, workspacesId) => {
   setIsProcessing(false, workspacesId);
 });
 
-ipcMainDrive.on('FILE_PREPARING', (_, payload) => {
-  const { nameWithExtension, processInfo } = payload;
-  setIsProcessing(true);
-  broadcastToWindows('sync-info-update', {
-    action: 'PREPARING',
-    name: nameWithExtension,
-    progress: processInfo.progress,
-  });
-});
-
 ipcMainDrive.on('FILE_DOWNLOADED', (_, payload) => {
   setIsProcessing(false);
   const { nameWithExtension } = payload;

--- a/src/apps/main/tray/handlers.ts
+++ b/src/apps/main/tray/handlers.ts
@@ -36,10 +36,6 @@ ipcMainDrive.on('SYNCED', () => {
   setTrayStatus('IDLE');
 });
 
-ipcMainDrive.on('FILE_PREPARING', () => {
-  setTrayStatus('SYNCING');
-});
-
 ipcMainDrive.on('FILE_DOWNLOADED', () => {
   setTrayStatus('IDLE');
 });

--- a/src/apps/shared/IPC/events/drive.ts
+++ b/src/apps/shared/IPC/events/drive.ts
@@ -38,7 +38,6 @@ type UploadEvents = {
 
 type DownloadEvents = {
   FILE_DOWNLOADING: (payload: FileProgressInfo) => void;
-  FILE_PREPARING: (payload: FileProgressInfo) => void;
   FILE_DOWNLOADED: (payload: FileProgressInfo) => void;
   FILE_DOWNLOAD_CANCEL: (payload: Partial<FileProgressInfo>) => void;
   FILE_DOWNLOAD_ERROR: (payload: Partial<FileErrorInfo>) => void;

--- a/src/apps/shared/IPC/events/sync-engine.ts
+++ b/src/apps/shared/IPC/events/sync-engine.ts
@@ -46,7 +46,6 @@ export type FilesEvents = {
   FILE_DOWNLOAD_ERROR: (payload: { name: string; extension: string; nameWithExtension: string; error: string }) => void;
 
   FILE_DOWNLOADING: (payload: FileUpdatePayload) => void;
-  FILE_PREPARING: (payload: FileUpdatePayload) => void;
   FILE_DOWNLOADED: (payload: FileUpdatePayload) => void;
   FILE_DOWNLOAD_CANCEL: (payload: Partial<FileUpdatePayload>) => void;
   FILE_UPLOAD_ERROR: (payload: { name?: string; extension?: string; nameWithExtension: string; error: string }) => void;

--- a/src/apps/sync-engine/callbacks/fetchData.service.ts
+++ b/src/apps/sync-engine/callbacks/fetchData.service.ts
@@ -53,7 +53,7 @@ export class FetchDataService {
             self.progressBuffer = result.progress;
           }
 
-          ipcRendererSyncEngine.send('FILE_PREPARING', {
+          ipcRendererSyncEngine.send('FILE_DOWNLOADING', {
             name: file.name,
             extension: file.type,
             nameWithExtension: file.nameWithExtension,

--- a/src/context/virtual-drive/contents/application/ContentsDownloader.ts
+++ b/src/context/virtual-drive/contents/application/ContentsDownloader.ts
@@ -4,17 +4,16 @@ import { ensureFolderExists } from '../../../../apps/shared/fs/ensure-folder-exi
 import { SyncEngineIpc } from '../../../../apps/sync-engine/ipcRendererSyncEngine';
 import { File } from '../../files/domain/File';
 import { EventBus } from '../../shared/domain/EventBus';
-import { ContentsManagersFactory } from '../domain/ContentsManagersFactory';
 import { LocalFileContents } from '../domain/LocalFileContents';
 import { LocalFileWriter } from '../domain/LocalFileWriter';
 import { ContentFileDownloader } from '../domain/contentHandlers/ContentFileDownloader';
 import { TemporalFolderProvider } from './temporalFolderProvider';
-import * as fs from 'fs';
 import { CallbackDownload } from '../../../../apps/sync-engine/BindingManager';
+import { EnvironmentRemoteFileContentsManagersFactory } from '../infrastructure/EnvironmentRemoteFileContentsManagersFactory';
 
 export class ContentsDownloader {
   constructor(
-    private readonly managerFactory: ContentsManagersFactory,
+    private readonly managerFactory: EnvironmentRemoteFileContentsManagersFactory,
     private readonly localWriter: LocalFileWriter,
     private readonly ipc: SyncEngineIpc,
     private readonly temporalFolderProvider: TemporalFolderProvider,

--- a/src/context/virtual-drive/contents/application/ContentsDownloader.ts
+++ b/src/context/virtual-drive/contents/application/ContentsDownloader.ts
@@ -42,22 +42,7 @@ export class ContentsDownloader {
     });
 
     downloader.on('progress', async () => {
-      const stats = fs.statSync(filePath);
-      const fileSizeInBytes = stats.size;
-      const progress = fileSizeInBytes / file.size;
-
       await callback(true, filePath);
-
-      this.ipc.send('FILE_DOWNLOADING', {
-        name: file.name,
-        extension: file.type,
-        nameWithExtension: file.nameWithExtension,
-        size: file.size,
-        processInfo: {
-          elapsedTime: downloader.elapsedTime(),
-          progress,
-        },
-      });
     });
 
     downloader.on('error', (error: Error) => {

--- a/src/context/virtual-drive/contents/application/ContentsUploader.ts
+++ b/src/context/virtual-drive/contents/application/ContentsUploader.ts
@@ -1,5 +1,4 @@
 import { ContentFileUploader } from '../domain/contentHandlers/ContentFileUploader';
-import { ContentsManagersFactory } from '../domain/ContentsManagersFactory';
 import { LocalContentsProvider } from '../domain/LocalFileProvider';
 import { RemoteFileContents } from '../domain/RemoteFileContents';
 import { LocalFileContents } from '../domain/LocalFileContents';
@@ -8,9 +7,10 @@ import { RelativePathToAbsoluteConverter } from '../../shared/application/Relati
 import { SyncEngineIpc } from '../../../../apps/sync-engine/ipcRendererSyncEngine';
 import { ipcRenderer } from 'electron';
 import Logger from 'electron-log';
+import { EnvironmentRemoteFileContentsManagersFactory } from '../infrastructure/EnvironmentRemoteFileContentsManagersFactory';
 export class ContentsUploader {
   constructor(
-    private readonly remoteContentsManagersFactory: ContentsManagersFactory,
+    private readonly remoteContentsManagersFactory: EnvironmentRemoteFileContentsManagersFactory,
     private readonly contentProvider: LocalContentsProvider,
     private readonly ipc: SyncEngineIpc,
     private readonly relativePathToAbsoluteConverter: RelativePathToAbsoluteConverter,

--- a/src/context/virtual-drive/contents/domain/ContentsManagersFactory.ts
+++ b/src/context/virtual-drive/contents/domain/ContentsManagersFactory.ts
@@ -1,9 +1,0 @@
-import { ContentFileDownloader } from './contentHandlers/ContentFileDownloader';
-import { ContentFileUploader } from './contentHandlers/ContentFileUploader';
-import { LocalFileContents } from './LocalFileContents';
-
-export interface ContentsManagersFactory {
-  downloader(): ContentFileDownloader;
-
-  uploader(contents: LocalFileContents, abortSignal?: AbortSignal): ContentFileUploader;
-}

--- a/src/context/virtual-drive/contents/infrastructure/EnvironmentRemoteFileContentsManagersFactory.ts
+++ b/src/context/virtual-drive/contents/infrastructure/EnvironmentRemoteFileContentsManagersFactory.ts
@@ -1,12 +1,11 @@
 import { Environment } from '@internxt/inxt-js';
 import { ContentFileDownloader } from '../domain/contentHandlers/ContentFileDownloader';
 import { ContentFileUploader } from '../domain/contentHandlers/ContentFileUploader';
-import { ContentsManagersFactory } from '../domain/ContentsManagersFactory';
 import { EnvironmentContentFileDownloader } from './download/EnvironmentContentFileDownloader';
 import { EnvironmentContentFileUploader } from './upload/EnvironmentContentFileUploader';
 import { LocalFileContents } from '../domain/LocalFileContents';
 
-export class EnvironmentRemoteFileContentsManagersFactory implements ContentsManagersFactory {
+export class EnvironmentRemoteFileContentsManagersFactory {
   private static MULTIPART_UPLOAD_SIZE_THRESHOLD = 5 * 1024 * 1024 * 1024;
 
   constructor(

--- a/tests/context/virtual-drive/contents/application/ContentsDownloader.test.ts
+++ b/tests/context/virtual-drive/contents/application/ContentsDownloader.test.ts
@@ -6,10 +6,10 @@ import {
 } from '../../../../../src/context/virtual-drive/contents/domain/contentHandlers/ContentFileDownloader';
 import { FileMother } from '../../files/domain/FileMother';
 import { LocalFileWriter } from '@/context/virtual-drive/contents/domain/LocalFileWriter';
-import { ContentsManagersFactory } from '@/context/virtual-drive/contents/domain/ContentsManagersFactory';
 import { SyncEngineIpc } from '@/apps/sync-engine/ipcRendererSyncEngine';
 import { EventBus } from '@/context/virtual-drive/shared/domain/EventBus';
 import { EventEmitter, Readable } from 'stream';
+import { EnvironmentRemoteFileContentsManagersFactory } from '@/context/virtual-drive/contents/infrastructure/EnvironmentRemoteFileContentsManagersFactory';
 
 // Creamos un EventEmitter real
 
@@ -19,7 +19,7 @@ describe('Contents Downloader', () => {
   };
 
   const localWriter = mockDeep<LocalFileWriter>();
-  const factory = mockDeep<ContentsManagersFactory>();
+  const factory = mockDeep<EnvironmentRemoteFileContentsManagersFactory>();
   const ipc = mockDeep<SyncEngineIpc>();
   const eventBus = mockDeep<EventBus>();
 


### PR DESCRIPTION
This Pull Request focuses on simplifying the handling of file download-related events.

- Removal of the FILE_PREPARING event:
  - The FILE_PREPARING event has been removed. Now, all download operations exclusively use the FILE_DOWNLOADING event. This simplifies the logic and reduces complexity in handling download events.