### PR TITLE
Simplify download and fix types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
     },
   ],
   rules: {
-    'no-await-in-loop': 'warn',
+    'no-await-in-loop': 'off',
     'no-use-before-define': 'warn',
     'array-callback-return': 'warn',
     'no-empty': 'off',

--- a/src/apps/backups/Backups.ts
+++ b/src/apps/backups/Backups.ts
@@ -156,7 +156,6 @@ export class Backup {
         if (abortController.signal.aborted) {
           return;
         }
-        // eslint-disable-next-line no-await-in-loop
         await this.fileBatchUploader.run(localRootPath, tree, batch, abortController.signal, async () => {
           this.backed += 1;
           await BackupsIPCRenderer.send('backups.progress-update', this.backed);
@@ -189,7 +188,6 @@ export class Backup {
         return;
       }
       try {
-        // eslint-disable-next-line no-await-in-loop
         await this.fileBatchUpdater.run(localTree.root, remoteTree, Array.from(batch.keys()), abortController.signal);
       } catch (error) {
         logger.warn({
@@ -214,7 +212,6 @@ export class Backup {
         return;
       }
       try {
-        // eslint-disable-next-line no-await-in-loop
         await this.remoteFileDeleter.run(file);
       } catch (error) {
         logger.warn({
@@ -238,7 +235,6 @@ export class Backup {
       }
 
       try {
-        // eslint-disable-next-line no-await-in-loop
         await this.remoteFolderDeleter.run(folder);
       } catch (error) {
         logger.warn({

--- a/src/apps/main/background-processes/backups/launchBackupProcesses.ts
+++ b/src/apps/main/background-processes/backups/launchBackupProcesses.ts
@@ -74,7 +74,6 @@ export async function launchBackupProcesses(
       continue;
     }
 
-    // eslint-disable-next-line no-await-in-loop
     const endReason = await executeBackupWorker(backupInfo, stopController);
 
     if (isSyncError(endReason)) {

--- a/src/apps/main/device/service.ts
+++ b/src/apps/main/device/service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable no-use-before-define */
 import { aes } from '@internxt/lib';

--- a/src/apps/main/network/NetworkFacade.ts
+++ b/src/apps/main/network/NetworkFacade.ts
@@ -65,7 +65,7 @@ export class NetworkFacade {
         }
       },
       async (_, key, iv, fileSize) => {
-        const decryptedStream = getDecryptedStream(encryptedContentStreams, createDecipheriv('aes-256-ctr', key, iv));
+        const decryptedStream = getDecryptedStream(encryptedContentStreams, createDecipheriv('aes-256-ctr', key as Buffer, iv as Buffer));
 
         fileStream = buildProgressStream(decryptedStream, (readBytes) => {
           // options.notifyProgress(readBytes / fileSize, readBytes, fileSize);

--- a/src/apps/main/network/download.ts
+++ b/src/apps/main/network/download.ts
@@ -1,11 +1,10 @@
-/* eslint-disable no-await-in-loop */
 import { FileVersionOneError } from '@internxt/sdk/dist/network/download';
 import { items } from '@internxt/lib';
 import fs, { PathLike } from 'fs';
-import { FileInfo, getFileInfoWithAuth, getFileInfoWithToken, getMirrors, Mirror, NetworkCredentials } from './requests';
+import { FileInfo, getFileInfoWithAuth, getMirrors, Mirror, NetworkCredentials } from './requests';
 import { GenerateFileKey } from '@internxt/inxt-js/build/lib/utils/crypto';
 import { createDecipheriv, Decipher } from 'crypto';
-import downloadFileV2 from './downloadv2';
+import { downloadFileV2 } from './downloadv2';
 import { fetchArrayFolderTree } from '../device/service';
 import { ReadableStream } from 'node:stream/web';
 import { Readable } from 'node:stream';
@@ -15,6 +14,7 @@ import { convertToReadableStream } from './NetworkFacade';
 import Logger from 'electron-log';
 import path from 'path';
 import { logger } from '@/apps/shared/logger/logger';
+import { IDownloadParams } from './download.types';
 
 async function writeReadableStreamToFile(readableStream: ReadableStream<Uint8Array>, filePath: string): Promise<void> {
   const writer = fs.createWriteStream(filePath);
@@ -58,7 +58,7 @@ export async function downloadFolder(
   },
   opts: {
     abortController?: AbortController;
-    updateProgress?: (progress: number) => void;
+    updateProgress: (progress: number) => void;
   },
 ) {
   Logger.info('Downloading folder to directory');
@@ -67,7 +67,7 @@ export async function downloadFolder(
   const { bridgeUser, bridgePass, encryptionKey } = environment;
 
   // Obtener información del árbol de carpetas y archivos
-  updateProgress && updateProgress(1);
+  updateProgress(1);
 
   const { tree, folderDecryptedNames, fileDecryptedNames, totalItems } = await fetchArrayFolderTree(foldersUuid);
 
@@ -127,6 +127,7 @@ export async function downloadFolder(
               mnemonic: encryptionKey,
               options: {
                 abortController: opts.abortController,
+                notifyProgress: updateProgress,
               },
             });
 
@@ -137,7 +138,7 @@ export async function downloadFolder(
             const progress = (downloadedItems / totalItems) * 100;
             Logger.info('totalItems:', totalItems, 'downloadedItems:', downloadedItems);
             Logger.info('Download progress:', progress);
-            updateProgress && updateProgress(Math.max(progress, 1));
+            updateProgress(Math.max(progress, 1));
           } catch (error) {
             throw logger.error({ msg: '[Downloader] Error downloading file:', file, error });
           }
@@ -153,39 +154,12 @@ export async function downloadFolder(
   }
 
   Logger.info('Download complete:', targetPath);
-  updateProgress && updateProgress(100);
-}
-
-export type DownloadProgressCallback = (totalBytes: number, downloadedBytes: number) => void;
-export interface IDownloadParams {
-  networkApiUrl: string;
-  bucketId: string;
-  fileId: string;
-  creds?: NetworkCredentials;
-  mnemonic?: string;
-  encryptionKey?: Buffer;
-  token?: string;
-  options?: {
-    notifyProgress?: DownloadProgressCallback;
-    abortController?: AbortController;
-  };
+  updateProgress(100);
 }
 
 interface MetadataRequiredForDownload {
   mirrors: Mirror[];
   fileMeta: FileInfo;
-}
-
-async function getRequiredFileMetadataWithToken(
-  networkApiUrl: string,
-  bucketId: string,
-  fileId: string,
-  token: string,
-): Promise<MetadataRequiredForDownload> {
-  const fileMeta: FileInfo = await getFileInfoWithToken(networkApiUrl, bucketId, fileId, token);
-  const mirrors: Mirror[] = await getMirrors(networkApiUrl, bucketId, fileId, null, token);
-
-  return { fileMeta, mirrors };
 }
 
 async function getRequiredFileMetadataWithAuth(
@@ -201,7 +175,7 @@ async function getRequiredFileMetadataWithAuth(
 }
 
 async function downloadFile(params: IDownloadParams): Promise<ReadableStream<Uint8Array>> {
-  const downloadFileV2Promise = downloadFileV2(params as any);
+  const downloadFileV2Promise = downloadFileV2(params);
 
   return downloadFileV2Promise.catch((err: Error) => {
     if (err instanceof FileVersionOneError) {
@@ -213,14 +187,12 @@ async function downloadFile(params: IDownloadParams): Promise<ReadableStream<Uin
 }
 
 async function _downloadFile(params: IDownloadParams): Promise<ReadableStream<Uint8Array>> {
-  const { networkApiUrl, bucketId, fileId, token, creds } = params;
+  const { networkApiUrl, bucketId, fileId, creds } = params;
 
   let metadata: MetadataRequiredForDownload;
 
   if (creds) {
     metadata = await getRequiredFileMetadataWithAuth(networkApiUrl, bucketId, fileId, creds);
-  } else if (token) {
-    metadata = await getRequiredFileMetadataWithToken(networkApiUrl, bucketId, fileId, token);
   } else {
     throw new Error('Download error 1');
   }
@@ -232,9 +204,7 @@ async function _downloadFile(params: IDownloadParams): Promise<ReadableStream<Ui
   const iv = index.slice(0, 16);
   let key: Buffer;
 
-  if (params.encryptionKey) {
-    key = params.encryptionKey;
-  } else if (params.mnemonic) {
+  if (params.mnemonic) {
     key = await GenerateFileKey(params.mnemonic, bucketId, index);
   } else {
     throw new Error('Download error code 1');
@@ -247,7 +217,7 @@ async function _downloadFile(params: IDownloadParams): Promise<ReadableStream<Ui
   );
 
   return buildProgressStream(downloadStream, (readBytes) => {
-    params.options?.notifyProgress?.(fileMeta.size, readBytes);
+    // params.options.notifyProgress(readBytes / fileMeta.size, readBytes, fileMeta.size);
   });
 }
 

--- a/src/apps/main/network/download.types.ts
+++ b/src/apps/main/network/download.types.ts
@@ -1,0 +1,14 @@
+import { DownloadProgressCallback } from '@internxt/inxt-js/build/lib/core';
+import { NetworkCredentials } from './requests';
+
+export interface IDownloadParams {
+  networkApiUrl: string;
+  bucketId: string;
+  fileId: string;
+  creds: NetworkCredentials;
+  mnemonic: string;
+  options: {
+    abortController?: AbortController;
+    notifyProgress: DownloadProgressCallback;
+  };
+}

--- a/src/apps/main/network/downloadv2.ts
+++ b/src/apps/main/network/downloadv2.ts
@@ -1,67 +1,8 @@
 import { Network } from '@internxt/sdk/dist/network';
-import { sha256 } from './requests';
+import { NetworkCredentials, sha256 } from './requests';
 import { NetworkFacade } from './NetworkFacade';
-import { ReadableStream } from 'node:stream/web';
 import { appInfo } from '../app-info/app-info';
-import { logger } from '@/apps/shared/logger/logger';
-
-type DownloadProgressCallback = (totalBytes: number, downloadedBytes: number) => void;
-type FileStream = ReadableStream<Uint8Array>;
-type DownloadFileResponse = Promise<FileStream>;
-type DownloadFileOptions = { notifyProgress: DownloadProgressCallback; abortController?: AbortController };
-interface NetworkCredentials {
-  user: string;
-  pass: string;
-}
-
-interface DownloadFileParams {
-  bucketId: string;
-  fileId: string;
-  options?: DownloadFileOptions;
-}
-
-export interface DownloadOwnFileParams extends DownloadFileParams {
-  creds: NetworkCredentials;
-  mnemonic: string;
-  token?: never;
-  encryptionKey?: never;
-}
-
-interface DownloadSharedFileParams extends DownloadFileParams {
-  creds?: never;
-  mnemonic?: never;
-  token: string;
-  encryptionKey: string;
-}
-
-type DownloadSharedFileFunction = (params: DownloadSharedFileParams) => DownloadFileResponse;
-type DownloadOwnFileFunction = (params: DownloadOwnFileParams) => DownloadFileResponse;
-type DownloadFileFunction = (params: DownloadSharedFileParams | DownloadOwnFileParams) => DownloadFileResponse;
-
-const downloadSharedFile: DownloadSharedFileFunction = (params) => {
-  const { bucketId, fileId, encryptionKey, token, options } = params;
-  const { name: clientName, version: clientVersion } = appInfo;
-
-  return new NetworkFacade(
-    Network.client(
-      process.env.DRIVE_URL,
-      {
-        clientName,
-        clientVersion,
-        desktopHeader: process.env.DESKTOP_HEADER,
-      },
-      {
-        bridgeUser: '',
-        userId: '',
-      },
-    ),
-  ).download(bucketId, fileId, '', {
-    key: Buffer.from(encryptionKey, 'hex'),
-    token,
-    downloadingCallback: options?.notifyProgress,
-    abortController: options?.abortController,
-  });
-};
+import { IDownloadParams } from './download.types';
 
 function getAuthFromCredentials(creds: NetworkCredentials): { username: string; password: string } {
   return {
@@ -70,7 +11,7 @@ function getAuthFromCredentials(creds: NetworkCredentials): { username: string; 
   };
 }
 
-const downloadOwnFile: DownloadOwnFileFunction = (params) => {
+function downloadOwnFile(params: IDownloadParams) {
   const { bucketId, fileId, mnemonic, options } = params;
   const { name: clientName, version: clientVersion } = appInfo;
   const auth = getAuthFromCredentials(params.creds);
@@ -89,24 +30,15 @@ const downloadOwnFile: DownloadOwnFileFunction = (params) => {
       },
     ),
   ).download(bucketId, fileId, mnemonic, {
-    downloadingCallback: options?.notifyProgress,
-    abortController: options?.abortController,
+    notifyProgress: options.notifyProgress,
+    abortController: options.abortController,
   });
-};
+}
 
-const downloadFileV2: DownloadFileFunction = (params) => {
-  if (params.token && params.encryptionKey) {
-    return downloadSharedFile(params);
-  } else if (params.creds && params.mnemonic) {
+export function downloadFileV2(params: IDownloadParams) {
+  if (params.creds && params.mnemonic) {
     return downloadOwnFile(params);
   } else {
-    // TODO: this log should be removed when the code is stable
-    logger.debug({
-      msg: 'Download file params are missing',
-      params,
-    });
     throw new Error('DOWNLOAD ERRNO. 0');
   }
-};
-
-export default downloadFileV2;
+}

--- a/src/apps/main/remote-sync/files/sync-remote-files.service.ts
+++ b/src/apps/main/remote-sync/files/sync-remote-files.service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import { RemoteSyncedFile } from '../helpers';
 import { RemoteSyncManager } from '../RemoteSyncManager';
 import { FetchRemoteFilesService } from './fetch-remote-files.service';

--- a/src/apps/main/remote-sync/folders/sync-remote-folders.service.ts
+++ b/src/apps/main/remote-sync/folders/sync-remote-folders.service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import { RemoteSyncedFolder } from '../helpers';
 import { RemoteSyncManager } from '../RemoteSyncManager';
 import { FetchRemoteFoldersService } from './fetch-remote-folders.service';

--- a/src/apps/sync-engine/callbacks/fetchData.service.ts
+++ b/src/apps/sync-engine/callbacks/fetchData.service.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-await-in-loop */
-
 import Logger from 'electron-log';
 import * as Sentry from '@sentry/electron/renderer';
 import { BindingsManager, CallbackDownload } from '../BindingManager';
@@ -8,7 +6,6 @@ import { FilePath } from '../../../context/virtual-drive/files/domain/FilePath';
 import * as fs from 'fs';
 import { SyncEngineIpc } from '../ipcRendererSyncEngine';
 import { dirname } from 'path';
-import { getConfig } from '../config';
 
 type TProps = {
   self: BindingsManager;

--- a/src/context/local/localFile/application/update/FileBatchUpdater.ts
+++ b/src/context/local/localFile/application/update/FileBatchUpdater.ts
@@ -15,7 +15,6 @@ export class FileBatchUpdater {
 
   async run(localRoot: LocalFolder, remoteTree: RemoteTree, batch: Array<LocalFile>, signal: AbortSignal): Promise<void> {
     for (const localFile of batch) {
-      // eslint-disable-next-line no-await-in-loop
       const upload = await this.uploader.upload(localFile.path, localFile.size, signal);
 
       if (upload.isLeft()) {
@@ -32,7 +31,6 @@ export class FileBatchUpdater {
         throw new Error(`Expected file, found folder on ${file.path}`);
       }
 
-      // eslint-disable-next-line no-await-in-loop
       await this.simpleFileOverrider.run(file, contentsId, localFile.size);
     }
   }

--- a/src/context/local/localFile/application/upload/FileBatchUploader.ts
+++ b/src/context/local/localFile/application/upload/FileBatchUploader.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable no-await-in-loop */
 import { Service } from 'diod';
 import { LocalFile } from '../../domain/LocalFile';
 import { SimpleFileCreator } from '../../../../virtual-drive/files/application/create/SimpleFileCreator';

--- a/src/context/local/localTree/application/LocalTreeBuilder.ts
+++ b/src/context/local/localTree/application/LocalTreeBuilder.ts
@@ -29,7 +29,6 @@ export default class LocalTreeBuilder {
 
         tree.addFolder(currentFolder, folder);
 
-        // eslint-disable-next-line no-await-in-loop
         await this.traverse(tree, folder);
       }
 

--- a/src/context/virtual-drive/files/infrastructure/HttpRemoteFileSystem.ts
+++ b/src/context/virtual-drive/files/infrastructure/HttpRemoteFileSystem.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import { EncryptionVersion } from '@internxt/sdk/dist/drive/storage/types';
 import { Crypt } from '../../shared/domain/Crypt';
 import { File, FileAttributes } from '../domain/File';

--- a/src/migrations/migrate.ts
+++ b/src/migrations/migrate.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-await-in-loop */
-
 import { logger } from '@/apps/shared/logger/logger';
 import { AddUserUuidToDatabase } from './v2.5.1/add-user-uuid-to-database';
 import Store from 'electron-store';


### PR DESCRIPTION
## What

1. Simplify download methods and types.
2. Also remove the download for shares since we don't have that feature implemented yet and probably we will need to do some refactoring before applying it.
3. Remove `no-await-in-loop` in eslint.