### PR TITLE
Added Debounce to updateUsage to Prevent Multiple Calls

### DIFF
--- a/src/apps/main/main.ts
+++ b/src/apps/main/main.ts
@@ -1,7 +1,7 @@
 import { app, ipcMain, nativeTheme } from 'electron';
 import Logger from 'electron-log';
 
-app.whenReady().then(() => {
+void app.whenReady().then(() => {
   app.setAppUserModelId('com.internxt.app');
 });
 
@@ -86,9 +86,9 @@ Sentry.init({
 Sentry.captureMessage('Main process started');
 Logger.log('Sentry is ready for main process');
 
-function checkForUpdates() {
+async function checkForUpdates() {
   autoUpdater.logger = Logger;
-  autoUpdater.checkForUpdatesAndNotify();
+  await autoUpdater.checkForUpdatesAndNotify();
 }
 
 if (process.env.NODE_ENV === 'production') {
@@ -114,7 +114,7 @@ app
     await migrate();
 
     registerUsageHandlers();
-    setUpBackups();
+    await setUpBackups();
 
     await checkIfUserIsLoggedIn();
     const isLoggedIn = getIsLoggedIn();
@@ -130,7 +130,7 @@ app
       return nativeTheme.shouldUseDarkColors;
     });
 
-    checkForUpdates();
+    await checkForUpdates();
   })
   .catch(Logger.error);
 
@@ -180,7 +180,7 @@ eventBus.on('USER_LOGGED_OUT', async () => {
     widget.destroy();
   }
 
-  clearAntivirus();
+  await clearAntivirus();
   unregisterVirtualDrives({});
 
   await createAuthWindow();

--- a/src/apps/renderer/hooks/useUsage.tsx
+++ b/src/apps/renderer/hooks/useUsage.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Usage } from '../../main/usage/Usage';
+import { debounce } from 'lodash';
 
 export default function useUsage() {
   const [usage, setUsage] = useState<Usage>();
   const [status, setStatus] = useState<'loading' | 'error' | 'ready'>('loading');
-  async function updateUsage() {
+
+  const updateUsage = useCallback(async () => {
     try {
       const userIsLoggedIn = await window.electron.isUserLoggedIn();
 
@@ -18,14 +20,18 @@ export default function useUsage() {
     } catch (err) {
       setStatus('error');
     }
-  }
+  }, []);
+
+  const debouncedUpdateUsage = useCallback(debounce(updateUsage, 500), []);
 
   useEffect(() => {
     setStatus('loading');
-    updateUsage();
-    const listener = window.electron.onRemoteChanges(updateUsage);
+    // The 'void' operator explicitly ignores the Promise returned by this async function,
+    // preventing unhandled promise warnings and indicating we don't need to await its result
+    void debouncedUpdateUsage();
+    const listener = window.electron.onRemoteChanges(debouncedUpdateUsage);
     return listener;
-  }, []);
+  }, [updateUsage, debouncedUpdateUsage]);
 
-  return { usage, refreshUsage: updateUsage, status };
+  return { usage, refreshUsage: debouncedUpdateUsage, status };
 }

--- a/src/apps/renderer/pages/Settings/Account/index.tsx
+++ b/src/apps/renderer/pages/Settings/Account/index.tsx
@@ -13,11 +13,14 @@ export default function AccountSection({ active }: { active: boolean }) {
   const { usage, status, refreshUsage } = useUsage();
 
   useEffect(() => {
-    window.electron.getUser().then(setUser);
+    window.electron
+      .getUser()
+      .then(setUser)
+      .catch(() => setUser(null));
   }, []);
 
   useEffect(() => {
-    if (active) refreshUsage();
+    if (active) void refreshUsage();
   }, [active]);
 
   return (

--- a/src/apps/renderer/pages/Widget/Header.tsx
+++ b/src/apps/renderer/pages/Widget/Header.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { MouseEventHandler, useEffect, useState } from 'react';
 import { FolderSimple, Gear, Globe } from '@phosphor-icons/react';
 import { Menu, Transition } from '@headlessui/react';
 import bytes from 'bytes';
@@ -30,18 +30,12 @@ const Header: React.FC<HeadersProps> = ({ setIsLogoutModalOpen }) => {
 
   const numberOfIssuesDisplay = numberOfIssues > 99 ? '99+' : numberOfIssues;
 
-  /* Electron on MacOS kept focusing the first focusable
-  element on start so we had to create a dummy element
-  to get that focus, remove it and make itself
-  non-focusable */
-  const dummyRef = useRef<HTMLDivElement>(null);
-
   function onQuitClick() {
     window.electron.quit();
   }
 
-  async function onSyncClick() {
-    window.electron.syncManually();
+  function onSyncClick() {
+    void window.electron.syncManually();
   }
 
   const handleOpenURL = async (URL: string) => {
@@ -61,7 +55,12 @@ const Header: React.FC<HeadersProps> = ({ setIsLogoutModalOpen }) => {
     const [user, setUser] = useState<User | null>(null);
 
     useEffect(() => {
-      window.electron.getUser().then(setUser);
+      window.electron
+        .getUser()
+        .then(setUser)
+        .catch(() => {
+          setUser(null);
+        });
     }, []);
 
     const { usage, status } = useUsage();
@@ -104,7 +103,7 @@ const Header: React.FC<HeadersProps> = ({ setIsLogoutModalOpen }) => {
   }: {
     children: JSX.Element;
     active?: boolean;
-    onClick?: any;
+    onClick?: MouseEventHandler<HTMLDivElement>;
     disabled?: boolean;
   }) => {
     return (


### PR DESCRIPTION
This Pull Request introduces an efficiency improvement to the updateUsage method.

- Implementation of Debounce in updateUsage:
  - A debounce has been added to the updateUsage method. This means that if calls are made to this method quickly and consecutively, only the last call within a specified time period will be executed. This helps prevent multiple unnecessary calls to the service, optimizing performance and reducing the load on the system.