### PR TITLE
Create placeholders as we fetch

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -34,13 +34,13 @@ main (electron/main)
 
 https://github.com/internxt/drive-desktop/issues/545
 
-```typescript
+```ts
 // old way
 function connect(host: string, port: number) {}
 // new way
-function connect({ host, port }: { host: string, port: number }) {}
+function connect({ host, port }: { host: string; port: number }) {}
 // default parameters
-function connect({ host, port = 5432 }: { host: string, port?: number }) {}
+function connect({ host, port = 5432 }: { host: string; port?: number }) {}
 ```
 
 ### Use explicit return types in functions just for primitive types
@@ -50,12 +50,12 @@ function connect({ host, port = 5432 }: { host: string, port?: number }) {}
 - Using return types for primitive types can help in code reviews to check whether, for example, something can be undefined or not.
 - Using return types for complex objects introduces the problem of naming elements and maintaining those types, and it also doesn't help in code reviews, since the return type can be anything (it's not a common type).
 
-```typescript
+```ts
 // Good
 function getAccessToken(): Promise<string | undefined> {
   return new Promise((resolve, reject) => {
-    resolve("");
-  })
+    resolve('');
+  });
 }
 ```
 
@@ -78,3 +78,17 @@ We are going to start open telemetry and store the logs in S3 has a cost. That's
 
 - Use logger.debug and logger.warn for anything that shouldn't be stored in S3 (most logs).
 - Use logger.info, logger.error, and logger.fatal for a small number of logs (only the most important ones).
+
+### Comments
+
+---
+
+```ts
+/**
+ * vX.X.X Author
+ * Explain why it's done that way, not what it does.
+ * We should be able to understand what it does by reading the code, but not why we did it that way; that's the point of the comment.
+ * Also, don't delete these comments. The plan is for it to function as an Architecture Decision Record.
+ * Whenever we change something, we should retain the comments from the previous version to see the history of the decision.
+ */
+```

--- a/src/apps/backups/Backups.ts
+++ b/src/apps/backups/Backups.ts
@@ -63,19 +63,10 @@ export class Backup {
     this.backed = alreadyBacked;
 
     logger.info({
-      msg: '[BACKUPS] Total items to backup',
+      tag: 'BACKUPS',
+      msg: 'Total items to backup',
       total: filesDiff.total + foldersDiff.total,
-      attributes: {
-        tag: 'BACKUPS',
-      },
-    });
-
-    logger.info({
-      msg: '[BACKUPS] Total items already backed',
-      total: alreadyBacked,
-      attributes: {
-        tag: 'BACKUPS',
-      },
+      alreadyBacked,
     });
 
     BackupsIPCRenderer.send('backups.total-items-calculated', filesDiff.total + foldersDiff.total, alreadyBacked);
@@ -89,11 +80,9 @@ export class Backup {
 
   private async backupFolders(diff: FoldersDiff, local: LocalTree, remote: RemoteTree, abortController: AbortController) {
     logger.info({
-      msg: '[BACKUPS] Backing folders',
+      tag: 'BACKUPS',
+      msg: 'Backing folders',
       total: diff.total,
-      attributes: {
-        tag: 'BACKUPS',
-      },
     });
 
     const { added, deleted } = diff;
@@ -125,20 +114,16 @@ export class Backup {
     await this.uploadAndCreateFile(local.root.path, added, remote, abortController);
 
     logger.debug({
-      msg: '[BACKUPS] Files modified',
+      tag: 'BACKUPS',
+      msg: 'Files modified',
       modified: modified.size,
-      attributes: {
-        tag: 'BACKUPS',
-      },
     });
     await this.uploadAndUpdate(modified, local, remote, abortController);
 
     logger.debug({
-      msg: '[BACKUPS] Files deleted',
+      tag: 'BACKUPS',
+      msg: 'Files deleted',
       deleted: deleted.length,
-      attributes: {
-        tag: 'BACKUPS',
-      },
     });
     await this.deleteRemoteFiles(deleted, abortController);
   }

--- a/src/apps/main/background-processes/sync-engine.ts
+++ b/src/apps/main/background-processes/sync-engine.ts
@@ -12,6 +12,7 @@ import { spawnWorkspace } from './sync-engine/services/spawn-workspace';
 import { getWorkspaces } from './sync-engine/services/get-workspaces';
 import { PATHS } from '@/core/electron/paths';
 import { join } from 'path';
+import { FolderStore } from '../remote-sync/folders/folder-store';
 
 ipcMain.on('SYNC_ENGINE_PROCESS_SETUP_SUCCESSFUL', (event, workspaceId = '') => {
   Logger.debug(`[MAIN] SYNC ENGINE RUNNING for workspace ${workspaceId}`);
@@ -70,6 +71,12 @@ export const spawnAllSyncEngineWorker = async () => {
     workspaceToken: undefined,
   };
 
+  FolderStore.addWorkspace({
+    workspaceId: '',
+    rootId: user.root_folder_id,
+    rootUuid: user.rootFolderId,
+  });
+
   const workspaces = await getWorkspaces({});
   const workspaceProviderIds = workspaces.map((workspace) => workspace.providerId);
 
@@ -78,6 +85,12 @@ export const spawnAllSyncEngineWorker = async () => {
   unregisterVirtualDrives({ currentProviderIds });
 
   const spawnWorkspaces = workspaces.forEach(async (workspace) => {
+    FolderStore.addWorkspace({
+      workspaceId: workspace.id,
+      rootId: null,
+      rootUuid: workspace.rootFolderId,
+    });
+
     await spawnWorkspace({ workspace });
   });
 

--- a/src/apps/main/remote-sync/files/sync-remote-file.ts
+++ b/src/apps/main/remote-sync/files/sync-remote-file.ts
@@ -3,6 +3,8 @@ import { RemoteSyncedFile } from '../helpers';
 import { RemoteSyncManager } from '../RemoteSyncManager';
 import { driveFilesCollection } from '../store';
 import { logger } from '@/apps/shared/logger/logger';
+import { File, FileAttributes } from '@/context/virtual-drive/files/domain/File';
+import { FolderStore } from '../folders/folder-store';
 
 type TProps = {
   self: RemoteSyncManager;
@@ -20,6 +22,39 @@ export async function syncRemoteFile({ self, user, remoteFile }: TProps) {
     });
 
     self.totalFilesSynced++;
+
+    if (remoteFile.status === 'EXISTS') {
+      try {
+        const plainName = File.decryptName({
+          name: remoteFile.name,
+          parentId: remoteFile.folderId,
+          type: remoteFile.type,
+          plainName: remoteFile.plainName,
+        });
+
+        const { relativePath } = FolderStore.getFolderPath({
+          workspaceId: self.workspaceId ?? '',
+          parentId: remoteFile.folderId,
+          parentUuid: remoteFile.folderUuid,
+          plainName,
+        });
+
+        const fileAttributes: FileAttributes = {
+          uuid: remoteFile.uuid,
+          id: remoteFile.id,
+          contentsId: remoteFile.fileId,
+          folderId: remoteFile.folderId,
+          createdAt: remoteFile.createdAt,
+          updatedAt: remoteFile.updatedAt,
+          status: remoteFile.status,
+          modificationTime: remoteFile.modificationTime,
+          size: remoteFile.size,
+          path: relativePath,
+        };
+
+        self.worker.worker?.webContents.send('UPDATE_FILE_PLACEHOLDER', fileAttributes);
+      } catch {}
+    }
   } catch (exc) {
     logger.error({
       msg: 'Error creating remote file in sqlite',

--- a/src/apps/main/remote-sync/folders/folder-store.test.ts
+++ b/src/apps/main/remote-sync/folders/folder-store.test.ts
@@ -1,0 +1,83 @@
+import { Folder } from '@/context/virtual-drive/folders/domain/Folder';
+import { FolderStore } from './folder-store';
+
+vi.mock(import('@/context/virtual-drive/folders/domain/Folder'));
+
+describe('folder-store', () => {
+  const FolderMock = vi.mocked(Folder);
+
+  const workspaceId = '';
+  const plainName = 'file.png';
+
+  beforeAll(() => {
+    FolderMock.decryptName.mockImplementation(({ name }) => name);
+  });
+
+  beforeEach(() => {
+    FolderStore.clear();
+  });
+
+  it('Should return path if all folders exist using parentId', () => {
+    FolderStore.addWorkspace({ workspaceId, rootId: 109862695, rootUuid: 'c133cad4-4bf4-4b03-86eb-794aeed82302' });
+    FolderStore.addFolder({ folderId: 110355389, parentId: 109862695, parentUuid: null, name: 'folder', workspaceId });
+    FolderStore.addFolder({ folderId: 110750590, parentId: 110355389, parentUuid: null, name: 'folder2', workspaceId });
+
+    const path1 = FolderStore.getFolderPath({ workspaceId, parentId: 109862695, parentUuid: null, plainName });
+    expect(path1.relativePath).toBe('/file.png');
+
+    const path2 = FolderStore.getFolderPath({ workspaceId, parentId: 110355389, parentUuid: null, plainName });
+    expect(path2.relativePath).toBe('/folder/file.png');
+
+    const path3 = FolderStore.getFolderPath({ workspaceId, parentId: 110750590, parentUuid: null, plainName });
+    expect(path3.relativePath).toBe('/folder/folder2/file.png');
+  });
+
+  it.only('Should return path if all folders exist using parentUuid', () => {
+    FolderStore.addWorkspace({ workspaceId, rootId: null, rootUuid: 'c133cad4-4bf4-4b03-86eb-794aeed82302' });
+
+    FolderStore.addFolder({
+      folderId: 110355389,
+      parentId: 109862695,
+      parentUuid: 'c133cad4-4bf4-4b03-86eb-794aeed82302',
+      name: 'folder',
+      workspaceId,
+    });
+
+    FolderStore.addFolder({
+      folderId: 110750590,
+      parentId: 110355389,
+      parentUuid: 'c909c709-6d05-4b67-906e-2aa2dd0379bb',
+      name: 'folder2',
+      workspaceId,
+    });
+
+    const path1 = FolderStore.getFolderPath({
+      workspaceId,
+      parentId: 109862695,
+      parentUuid: 'c133cad4-4bf4-4b03-86eb-794aeed82302',
+      plainName,
+    });
+    expect(path1.relativePath).toBe('/file.png');
+
+    const path2 = FolderStore.getFolderPath({ workspaceId, parentId: 110355389, parentUuid: null, plainName });
+    expect(path2.relativePath).toBe('/folder/file.png');
+
+    const path3 = FolderStore.getFolderPath({ workspaceId, parentId: 110750590, parentUuid: null, plainName });
+    expect(path3.relativePath).toBe('/folder/folder2/file.png');
+  });
+
+  it('Should throw error if folder not found', () => {
+    FolderStore.addWorkspace({ workspaceId, rootId: 109862695, rootUuid: 'c133cad4-4bf4-4b03-86eb-794aeed82302' });
+
+    FolderStore.addFolder({
+      folderId: 110753145,
+      parentId: 0,
+      parentUuid: null,
+      name: 'wrong_parent_id',
+      workspaceId,
+    });
+
+    expect(() => FolderStore.getFolderPath({ workspaceId, parentId: 0, parentUuid: null, plainName })).toThrowError();
+    expect(() => FolderStore.getFolderPath({ workspaceId, parentId: 110753145, parentUuid: null, plainName })).toThrowError();
+  });
+});

--- a/src/apps/main/remote-sync/folders/folder-store.test.ts
+++ b/src/apps/main/remote-sync/folders/folder-store.test.ts
@@ -32,7 +32,7 @@ describe('folder-store', () => {
     expect(path3.relativePath).toBe('/folder/folder2/file.png');
   });
 
-  it.only('Should return path if all folders exist using parentUuid', () => {
+  it('Should return path if all folders exist using parentUuid', () => {
     FolderStore.addWorkspace({ workspaceId, rootId: null, rootUuid: 'c133cad4-4bf4-4b03-86eb-794aeed82302' });
 
     FolderStore.addFolder({

--- a/src/apps/main/remote-sync/folders/folder-store.ts
+++ b/src/apps/main/remote-sync/folders/folder-store.ts
@@ -1,0 +1,90 @@
+import { logger } from '@/apps/shared/logger/logger';
+import { Folder } from '@/context/virtual-drive/folders/domain/Folder';
+import { posix } from 'path';
+
+export let folderStore: Record<
+  string,
+  {
+    rootId: number | null;
+    rootUuid: string;
+    folders: Record<
+      number,
+      {
+        parentId: number;
+        parentUuid: string | null;
+        plainName: string;
+      }
+    >;
+  }
+> = {};
+
+export class FolderStore {
+  static clear() {
+    folderStore = {};
+  }
+
+  static addWorkspace({ workspaceId, rootId, rootUuid }: { workspaceId: string; rootId: number | null; rootUuid: string }) {
+    folderStore[workspaceId] = { rootId, rootUuid, folders: {} };
+    console.log('🚀 ~ FolderStore ~ addWorkspace ~ folderStore:', folderStore);
+    logger.debug({
+      msg: 'Add workspace to the folder store',
+      workspaceId,
+      rootId,
+      rootUuid,
+    });
+  }
+
+  static addFolder({
+    workspaceId,
+    folderId,
+    parentId,
+    parentUuid,
+    name,
+    plainName,
+  }: {
+    workspaceId: string;
+    folderId: number;
+    parentId: number;
+    parentUuid: string | null;
+    name: string;
+    plainName?: string;
+  }) {
+    const decryptedName = Folder.decryptName({ plainName, name, parentId });
+    folderStore[workspaceId].folders[folderId] = { parentId, parentUuid, plainName: decryptedName };
+  }
+
+  static getFolderPath({
+    workspaceId,
+    parentId,
+    parentUuid,
+    plainName,
+  }: {
+    workspaceId: string;
+    parentId: number;
+    parentUuid: string | null;
+    plainName: string;
+  }) {
+    const paths: string[] = [];
+    const workspace = folderStore[workspaceId];
+
+    let folder = workspace.folders[parentId];
+
+    while (parentUuid !== workspace.rootUuid && parentId !== workspace.rootId) {
+      folder = workspace.folders[parentId];
+
+      if (!folder) {
+        throw new Error(`Folder not found for workspaceId "${workspaceId}" and parentId "${parentId}"`);
+      }
+
+      paths.unshift(folder.plainName);
+      parentId = folder.parentId;
+      parentUuid = folder.parentUuid;
+    }
+
+    const relativePath = posix.join(...paths, plainName);
+
+    return {
+      relativePath: posix.sep + relativePath,
+    };
+  }
+}

--- a/src/apps/main/remote-sync/folders/folder-store.ts
+++ b/src/apps/main/remote-sync/folders/folder-store.ts
@@ -25,7 +25,6 @@ export class FolderStore {
 
   static addWorkspace({ workspaceId, rootId, rootUuid }: { workspaceId: string; rootId: number | null; rootUuid: string }) {
     folderStore[workspaceId] = { rootId, rootUuid, folders: {} };
-    console.log('🚀 ~ FolderStore ~ addWorkspace ~ folderStore:', folderStore);
     logger.debug({
       msg: 'Add workspace to the folder store',
       workspaceId,

--- a/src/apps/main/remote-sync/folders/folder-store.ts
+++ b/src/apps/main/remote-sync/folders/folder-store.ts
@@ -2,29 +2,29 @@ import { logger } from '@/apps/shared/logger/logger';
 import { Folder } from '@/context/virtual-drive/folders/domain/Folder';
 import { posix } from 'path';
 
-export let folderStore: Record<
-  string,
-  {
-    rootId: number | null;
-    rootUuid: string;
-    folders: Record<
-      number,
-      {
-        parentId: number;
-        parentUuid: string | null;
-        plainName: string;
-      }
-    >;
-  }
-> = {};
-
 export class FolderStore {
+  private static store: Record<
+    string,
+    {
+      rootId: number | null;
+      rootUuid: string;
+      folders: Record<
+        number,
+        {
+          parentId: number;
+          parentUuid: string | null;
+          plainName: string;
+        }
+      >;
+    }
+  > = {};
+
   static clear() {
-    folderStore = {};
+    FolderStore.store = {};
   }
 
   static addWorkspace({ workspaceId, rootId, rootUuid }: { workspaceId: string; rootId: number | null; rootUuid: string }) {
-    folderStore[workspaceId] = { rootId, rootUuid, folders: {} };
+    FolderStore.store[workspaceId] = { rootId, rootUuid, folders: {} };
     logger.debug({
       msg: 'Add workspace to the folder store',
       workspaceId,
@@ -49,7 +49,7 @@ export class FolderStore {
     plainName?: string;
   }) {
     const decryptedName = Folder.decryptName({ plainName, name, parentId });
-    folderStore[workspaceId].folders[folderId] = { parentId, parentUuid, plainName: decryptedName };
+    FolderStore.store[workspaceId].folders[folderId] = { parentId, parentUuid, plainName: decryptedName };
   }
 
   static getFolderPath({
@@ -64,7 +64,7 @@ export class FolderStore {
     plainName: string;
   }) {
     const paths: string[] = [];
-    const workspace = folderStore[workspaceId];
+    const workspace = FolderStore.store[workspaceId];
 
     let folder = workspace.folders[parentId];
 

--- a/src/apps/main/remote-sync/handlers.ts
+++ b/src/apps/main/remote-sync/handlers.ts
@@ -16,8 +16,7 @@ import Queue from '@/apps/shared/Queue/Queue';
 import { driveFilesCollection, driveFoldersCollection, getRemoteSyncManager, remoteSyncManagers } from './store';
 import { TWorkerConfig } from '../background-processes/sync-engine/store';
 import { getSyncStatus } from './services/broadcast-sync-status';
-import { FolderStore, folderStore } from './folders/folder-store';
-import { Folder } from '@/context/virtual-drive/folders/domain/Folder';
+import { FolderStore } from './folders/folder-store';
 
 export function addRemoteSyncManager({ workspaceId, worker }: { workspaceId?: string; worker: TWorkerConfig }) {
   remoteSyncManagers.set(workspaceId ?? '', new RemoteSyncManager(worker, workspaceId));

--- a/src/apps/shared/logger/logger.ts
+++ b/src/apps/shared/logger/logger.ts
@@ -7,8 +7,9 @@ type TTag = 'AUTH' | 'BACKUPS' | 'SYNC-ENGINE' | 'ANTIVIRUS' | 'NODE-WIN';
 
 export type TLoggerBody = {
   process?: 'main' | 'renderer';
-  msg: string;
   tag?: TTag;
+  msg: string;
+  workspaceId?: string;
   exc?: Error | unknown;
   context?: Record<string, unknown>;
   attributes?: {
@@ -24,18 +25,23 @@ export class LoggerService {
   private prepareBody(rawBody: TLoggerBody) {
     const user = getUser();
 
+    const { tag, msg, workspaceId, ...rest1 } = rawBody;
+
     rawBody = {
       process: process.type === 'renderer' ? 'renderer' : 'main',
-      ...rawBody,
+      ...(tag && { tag }),
+      msg,
+      ...(workspaceId && { workspaceId }),
+      ...rest1,
       attributes: {
         userId: user?.uuid,
-        tag: rawBody.tag,
-        ...rawBody.attributes,
+        ...(tag && { tag }),
+        ...rest1.attributes,
       },
     };
 
-    const { attributes, ...rest } = rawBody;
-    const body = inspect(rest, { colors: true, depth: Infinity, breakLength: Infinity });
+    const { attributes, ...rest2 } = rawBody;
+    const body = inspect(rest2, { colors: true, depth: Infinity, breakLength: Infinity });
     return { attributes, body };
   }
 

--- a/src/apps/sync-engine/index.ts
+++ b/src/apps/sync-engine/index.ts
@@ -9,6 +9,8 @@ import { setConfig, Config, getConfig, setDefaultConfig } from './config';
 import { logger } from '../shared/logger/logger';
 import { INTERNXT_VERSION } from '@/core/utils/utils';
 import { driveServerWipModule } from '@/infra/drive-server-wip/drive-server-wip.module';
+import { File, FileAttributes } from '@/context/virtual-drive/files/domain/File';
+import { Folder, FolderAttributes } from '@/context/virtual-drive/folders/domain/Folder';
 
 logger.debug({ msg: 'Running sync engine' });
 
@@ -70,6 +72,30 @@ async function setUp() {
       Logger.error('[SYNC ENGINE] Error stopping and cleaning: ', error);
       Sentry.captureException(error);
       event.sender.send('ERROR_ON_STOP_AND_CLEAR_SYNC_ENGINE_PROCESS');
+    }
+  });
+
+  ipcRenderer.on('UPDATE_FILE_PLACEHOLDER', async (_, fileAttributes: FileAttributes) => {
+    try {
+      const file = File.from(fileAttributes);
+      await container.filesPlaceholderUpdater.update(file);
+    } catch (exc) {
+      logger.error({
+        msg: 'Error updating file placeholder',
+        exc,
+      });
+    }
+  });
+
+  ipcRenderer.on('UPDATE_FOLDER_PLACEHOLDER', async (_, folderAttributes: FolderAttributes) => {
+    try {
+      const folder = Folder.from(folderAttributes);
+      await container.folderPlaceholderUpdater.update(folder);
+    } catch (exc) {
+      logger.error({
+        msg: 'Error updating folder placeholder',
+        exc,
+      });
     }
   });
 

--- a/src/context/virtual-drive/files/domain/File.ts
+++ b/src/context/virtual-drive/files/domain/File.ts
@@ -28,8 +28,6 @@ export type FileAttributes = {
   status: string;
 };
 
-export type FileAttributesWithoutPath = Omit<FileAttributes, 'path'> & { plainName: string };
-
 export class File extends AggregateRoot {
   private constructor(
     private _id: number,

--- a/src/infra/drive-server-wip/services/folders.service.ts
+++ b/src/infra/drive-server-wip/services/folders.service.ts
@@ -1,20 +1,18 @@
 import { client } from '@/apps/shared/HttpClient/client';
 import { paths } from '@/apps/shared/HttpClient/schema';
-import { clientWrapper, ClientWrapperService } from '../in/client-wrapper.service';
+import { clientWrapper } from '../in/client-wrapper.service';
 
 type TGetFoldersQuery = paths['/folders']['get']['parameters']['query'];
 type TGetFoldersByFolderQuery = paths['/folders/content/{uuid}/folders']['get']['parameters']['query'];
 type TGetFilesByFolderQuery = paths['/folders/content/{uuid}/files']['get']['parameters']['query'];
 
 export class FoldersService {
-  constructor(private readonly clientWrapper = new ClientWrapperService()) {}
-
   getMetadata({ folderId }: { folderId: number }) {
     const promise = client.GET('/folders/{id}/metadata', {
       params: { path: { id: folderId } },
     });
 
-    return this.clientWrapper.run({
+    return clientWrapper({
       promise,
       loggerBody: {
         msg: 'Get folder metadata request was not successful',
@@ -34,7 +32,7 @@ export class FoldersService {
       params: { path: { uuid } },
     });
 
-    return this.clientWrapper.run({
+    return clientWrapper({
       promise,
       loggerBody: {
         msg: 'Get folder metadata request was not successful',
@@ -52,7 +50,7 @@ export class FoldersService {
   getFolders({ query }: { query: TGetFoldersQuery }) {
     const promise = client.GET('/folders', { params: { query } });
 
-    return this.clientWrapper.run({
+    return clientWrapper({
       promise,
       loggerBody: {
         msg: 'Get folders request was not successful',
@@ -72,7 +70,7 @@ export class FoldersService {
       params: { path: { uuid: folderUuid }, query },
     });
 
-    const res = await this.clientWrapper.run({
+    const res = await clientWrapper({
       promise,
       loggerBody: {
         msg: 'Get folders by folder request was not successful',
@@ -99,7 +97,7 @@ export class FoldersService {
       params: { path: { uuid: folderUuid }, query },
     });
 
-    const res = await this.clientWrapper.run({
+    const res = await clientWrapper({
       promise,
       loggerBody: {
         msg: 'Get files by folder request was not successful',


### PR DESCRIPTION
## What

1. Improve logger so it only prints workspaceId or tag if they are defined (we now exclude empty workspaceId, so that the default drive doesn't include workspaceId: '' always).
2. Create placeholders as we fetch. We have created an in memory store, that saves all folders so we can retrieve the path recursively. Also, as we fetch we send an IPC signal to the worker to create the placeholder.
3. Add to the CONTRIBUTING file how we are going to make comments.