### PR TITLE
Fix size bigint and root folder in traverser

### DIFF
--- a/src/apps/main/remote-sync/files/fetch-files.service.interface.ts
+++ b/src/apps/main/remote-sync/files/fetch-files.service.interface.ts
@@ -1,21 +1,11 @@
 import { RemoteSyncManager } from '../RemoteSyncManager';
-import { RemoteSyncedFile } from '../helpers';
 import { paths } from '@/apps/shared/HttpClient/schema';
 
 export type QueryFiles = paths['/files']['get']['parameters']['query'];
-export type QueryFilesInWorkspace = paths['/workspaces/{workspaceId}/files']['get']['parameters']['query'];
-export type QueryFilesInFolderInWorkspace = paths['/workspaces/{workspaceId}/folders/{folderUuid}/files']['get']['parameters']['query'];
 export interface FetchFilesServiceParams {
   self: RemoteSyncManager;
   folderUuid?: string;
   updatedAtCheckpoint?: Date;
   offset: number;
   status: QueryFiles['status'];
-}
-export interface FetchFilesServiceResult {
-  hasMore: boolean;
-  result: RemoteSyncedFile[];
-}
-export interface FetchFilesService {
-  run(params: FetchFilesServiceParams): Promise<FetchFilesServiceResult>;
 }

--- a/src/apps/main/remote-sync/files/fetch-remote-files.service.ts
+++ b/src/apps/main/remote-sync/files/fetch-remote-files.service.ts
@@ -30,6 +30,17 @@ export class FetchRemoteFilesService implements FetchFilesService {
     if (error) throw error;
 
     const hasMore = data.length === FETCH_LIMIT;
-    return { hasMore, result: data };
+    return {
+      hasMore,
+      result: data.map((file) => ({
+        ...file,
+        /**
+         * v2.5.2 Daniel Jiménez
+         * In drive-server-wip they are working with bigint and fetch converts it to string.
+         * We need to convert it to a number.
+         */
+        size: Number(file.size),
+      })),
+    };
   }
 }

--- a/src/apps/main/remote-sync/files/fetch-remote-files.service.ts
+++ b/src/apps/main/remote-sync/files/fetch-remote-files.service.ts
@@ -1,46 +1,31 @@
 import { FETCH_LIMIT } from '../store';
-import { FetchFilesService, FetchFilesServiceParams } from './fetch-files.service.interface';
-import { driveServerWipModule } from '@/infra/drive-server-wip/drive-server-wip.module';
+import { FetchFilesServiceParams } from './fetch-files.service.interface';
+import { driveServerWip } from '@/infra/drive-server-wip/drive-server-wip.module';
 
-export class FetchRemoteFilesService implements FetchFilesService {
-  constructor(private readonly driveServerWip = driveServerWipModule) {}
+export async function fetchRemoteFiles({ updatedAtCheckpoint, offset, status, folderUuid }: FetchFilesServiceParams) {
+  const promise = folderUuid
+    ? driveServerWip.folders.getFiles({
+        folderUuid,
+        query: {
+          limit: FETCH_LIMIT,
+          offset,
+          sort: 'updatedAt',
+          order: 'DESC',
+        },
+      })
+    : driveServerWip.files.getFiles({
+        query: {
+          limit: FETCH_LIMIT,
+          offset,
+          status,
+          updatedAt: updatedAtCheckpoint?.toISOString(),
+        },
+      });
 
-  async run({ updatedAtCheckpoint, offset, status, folderUuid }: FetchFilesServiceParams) {
-    const promise = folderUuid
-      ? this.driveServerWip.folders.getFiles({
-          folderUuid,
-          query: {
-            limit: FETCH_LIMIT,
-            offset,
-            sort: 'updatedAt',
-            order: 'DESC',
-          },
-        })
-      : this.driveServerWip.files.getFiles({
-          query: {
-            limit: FETCH_LIMIT,
-            offset,
-            status,
-            updatedAt: updatedAtCheckpoint?.toISOString(),
-          },
-        });
+  const { data, error } = await promise;
 
-    const { data, error } = await promise;
+  if (error) throw error;
 
-    if (error) throw error;
-
-    const hasMore = data.length === FETCH_LIMIT;
-    return {
-      hasMore,
-      result: data.map((file) => ({
-        ...file,
-        /**
-         * v2.5.2 Daniel Jiménez
-         * In drive-server-wip they are working with bigint and fetch converts it to string.
-         * We need to convert it to a number.
-         */
-        size: Number(file.size),
-      })),
-    };
-  }
+  const hasMore = data.length === FETCH_LIMIT;
+  return { hasMore, result: data };
 }

--- a/src/apps/main/remote-sync/files/fetch-workspace-files.service.ts
+++ b/src/apps/main/remote-sync/files/fetch-workspace-files.service.ts
@@ -1,67 +1,40 @@
 import { logger } from '@/apps/shared/logger/logger';
-import { client } from '../../../shared/HttpClient/client';
-import {
-  FetchFilesService,
-  FetchFilesServiceParams,
-  QueryFilesInFolderInWorkspace,
-  QueryFilesInWorkspace,
-} from './fetch-files.service.interface';
+import { driveServerWip } from '@/infra/drive-server-wip/drive-server-wip.module';
+import { FetchFilesServiceParams } from './fetch-files.service.interface';
 import { FETCH_LIMIT } from '../store';
 
-export class FetchWorkspaceFilesService implements FetchFilesService {
-  async run({ self, offset, folderUuid, updatedAtCheckpoint, status }: FetchFilesServiceParams) {
-    if (!self.workspaceId) {
-      throw new Error('Workspace id is required to fetch files');
-    }
-
-    const promise = folderUuid
-      ? this.getFilesByFolderInWorkspace({
-          folderUuid,
-          workspaceId: self.workspaceId,
-          query: {
-            limit: FETCH_LIMIT,
-            offset,
-            sort: 'updatedAt',
-            order: 'DESC',
-          },
-        })
-      : this.getFileInWorkspace({
-          workspaceId: self.workspaceId,
-          query: {
-            limit: FETCH_LIMIT,
-            offset,
-            status,
-            updatedAt: updatedAtCheckpoint?.toISOString(),
-          },
-        });
-
-    const result = await promise;
-
-    if (result.data) {
-      const hasMore = result.data.length === FETCH_LIMIT;
-      return { hasMore, result: result.data };
-    }
-
-    throw logger.error({ msg: 'Fetch workspace files response not ok', error: result.error });
+export async function fetchWorkspaceFiles({ self, offset, folderUuid, updatedAtCheckpoint, status }: FetchFilesServiceParams) {
+  if (!self.workspaceId) {
+    throw new Error('Workspace id is required to fetch files');
   }
 
-  private async getFileInWorkspace({ query, workspaceId }: { workspaceId: string; query: QueryFilesInWorkspace }) {
-    const result = await client.GET('/workspaces/{workspaceId}/files', { params: { path: { workspaceId }, query } });
-    return { ...result, data: result.data };
+  const promise = folderUuid
+    ? driveServerWip.workspaces.getFilesByFolderInWorkspace({
+        folderUuid,
+        workspaceId: self.workspaceId,
+        query: {
+          limit: FETCH_LIMIT,
+          offset,
+          sort: 'updatedAt',
+          order: 'DESC',
+        },
+      })
+    : driveServerWip.workspaces.getFilesInWorkspace({
+        workspaceId: self.workspaceId,
+        query: {
+          limit: FETCH_LIMIT,
+          offset,
+          status,
+          updatedAt: updatedAtCheckpoint?.toISOString(),
+        },
+      });
+
+  const result = await promise;
+
+  if (result.data) {
+    const hasMore = result.data.length === FETCH_LIMIT;
+    return { hasMore, result: result.data };
   }
 
-  private async getFilesByFolderInWorkspace({
-    folderUuid,
-    workspaceId,
-    query,
-  }: {
-    folderUuid: string;
-    workspaceId: string;
-    query: QueryFilesInFolderInWorkspace;
-  }) {
-    const result = await client.GET('/workspaces/{workspaceId}/folders/{folderUuid}/files', {
-      params: { path: { workspaceId, folderUuid }, query },
-    });
-    return { ...result, data: result.data?.result };
-  }
+  throw logger.error({ msg: 'Fetch workspace files response not ok', error: result.error });
 }

--- a/src/apps/main/remote-sync/files/sync-remote-file.ts
+++ b/src/apps/main/remote-sync/files/sync-remote-file.ts
@@ -14,7 +14,7 @@ type TProps = {
 
 export async function syncRemoteFile({ self, user, remoteFile }: TProps) {
   try {
-    await driveFilesCollection.createOrUpdate({
+    const driveFile = await driveFilesCollection.createOrUpdate({
       ...remoteFile,
       isDangledStatus: false,
       userUuid: user.uuid,
@@ -26,30 +26,30 @@ export async function syncRemoteFile({ self, user, remoteFile }: TProps) {
     if (remoteFile.status === 'EXISTS') {
       try {
         const plainName = File.decryptName({
-          name: remoteFile.name,
-          parentId: remoteFile.folderId,
-          type: remoteFile.type,
-          plainName: remoteFile.plainName,
+          name: driveFile.name,
+          parentId: driveFile.folderId,
+          type: driveFile.type,
+          plainName: driveFile.plainName,
         });
 
         const { relativePath } = FolderStore.getFolderPath({
           workspaceId: self.workspaceId ?? '',
-          parentId: remoteFile.folderId,
-          parentUuid: remoteFile.folderUuid,
+          parentId: driveFile.folderId,
+          parentUuid: driveFile.folderUuid ?? null,
           plainName,
         });
 
         const fileAttributes: FileAttributes = {
-          uuid: remoteFile.uuid,
-          id: remoteFile.id,
-          contentsId: remoteFile.fileId,
-          folderId: remoteFile.folderId,
-          folderUuid: remoteFile.folderUuid,
-          createdAt: remoteFile.createdAt,
-          updatedAt: remoteFile.updatedAt,
-          status: remoteFile.status,
-          modificationTime: remoteFile.modificationTime,
-          size: remoteFile.size,
+          uuid: driveFile.uuid,
+          id: driveFile.id,
+          contentsId: driveFile.fileId,
+          folderId: driveFile.folderId,
+          folderUuid: driveFile.folderUuid,
+          createdAt: driveFile.createdAt,
+          updatedAt: driveFile.updatedAt,
+          status: driveFile.status,
+          modificationTime: driveFile.modificationTime,
+          size: driveFile.size,
           path: relativePath,
         };
 

--- a/src/apps/main/remote-sync/files/sync-remote-file.ts
+++ b/src/apps/main/remote-sync/files/sync-remote-file.ts
@@ -44,6 +44,7 @@ export async function syncRemoteFile({ self, user, remoteFile }: TProps) {
           id: remoteFile.id,
           contentsId: remoteFile.fileId,
           folderId: remoteFile.folderId,
+          folderUuid: remoteFile.folderUuid,
           createdAt: remoteFile.createdAt,
           updatedAt: remoteFile.updatedAt,
           status: remoteFile.status,

--- a/src/apps/main/remote-sync/files/sync-remote-file.ts
+++ b/src/apps/main/remote-sync/files/sync-remote-file.ts
@@ -1,21 +1,22 @@
 import { User } from '../../types';
-import { RemoteSyncedFile } from '../helpers';
 import { RemoteSyncManager } from '../RemoteSyncManager';
 import { driveFilesCollection } from '../store';
 import { logger } from '@/apps/shared/logger/logger';
 import { File, FileAttributes } from '@/context/virtual-drive/files/domain/File';
 import { FolderStore } from '../folders/folder-store';
+import { FileDto } from '@/infra/drive-server-wip/out/dto';
 
 type TProps = {
   self: RemoteSyncManager;
   user: User;
-  remoteFile: RemoteSyncedFile;
+  remoteFile: FileDto;
 };
 
 export async function syncRemoteFile({ self, user, remoteFile }: TProps) {
   try {
     const driveFile = await driveFilesCollection.createOrUpdate({
       ...remoteFile,
+      size: Number(remoteFile.size),
       isDangledStatus: false,
       userUuid: user.uuid,
       workspaceId: self.workspaceId,

--- a/src/apps/main/remote-sync/files/sync-remote-files.service.test.ts
+++ b/src/apps/main/remote-sync/files/sync-remote-files.service.test.ts
@@ -3,7 +3,6 @@ import { SyncRemoteFilesService } from './sync-remote-files.service';
 import { RemoteSyncManager } from '../RemoteSyncManager';
 import { LoggerService } from '@/apps/shared/logger/logger';
 import { deepMocked, getMockCalls } from 'tests/vitest/utils.helper.test';
-import { RemoteSyncedFile } from '../helpers';
 import { getUserOrThrow } from '../../auth/service';
 import { syncRemoteFile } from './sync-remote-file';
 import { fetchWorkspaceFiles } from './fetch-workspace-files.service';
@@ -106,12 +105,12 @@ describe('sync-remote-files.service', () => {
     // Given
     fetchWorkspaceFilesMock.mockResolvedValueOnce({
       hasMore: true,
-      result: [{ uuid: 'file1' } as unknown as RemoteSyncedFile],
+      result: [{ uuid: 'file1' }],
     });
     fetchWorkspaceFilesMock.mockRejectedValueOnce(new Error());
     fetchWorkspaceFilesMock.mockResolvedValueOnce({
       hasMore: false,
-      result: [{ uuid: 'file2' } as unknown as RemoteSyncedFile],
+      result: [{ uuid: 'file2' }],
     });
 
     // When

--- a/src/apps/main/remote-sync/files/sync-remote-files.service.test.ts
+++ b/src/apps/main/remote-sync/files/sync-remote-files.service.test.ts
@@ -1,27 +1,28 @@
 import { mockDeep } from 'vitest-mock-extended';
 import { SyncRemoteFilesService } from './sync-remote-files.service';
-import { FetchFilesService } from './fetch-files.service.interface';
 import { RemoteSyncManager } from '../RemoteSyncManager';
 import { LoggerService } from '@/apps/shared/logger/logger';
 import { deepMocked, getMockCalls } from 'tests/vitest/utils.helper.test';
 import { RemoteSyncedFile } from '../helpers';
 import { getUserOrThrow } from '../../auth/service';
 import { syncRemoteFile } from './sync-remote-file';
+import { fetchWorkspaceFiles } from './fetch-workspace-files.service';
 
 vi.mock(import('@/apps/main/util'));
 vi.mock(import('../../auth/service'));
 vi.mock(import('./sync-remote-file'));
+vi.mock(import('./fetch-workspace-files.service'));
 
 describe('sync-remote-files.service', () => {
   const workspaceId = 'workspaceId';
 
   const getUserOrThrowMock = deepMocked(getUserOrThrow);
   const syncRemoteFileMock = deepMocked(syncRemoteFile);
+  const fetchWorkspaceFilesMock = deepMocked(fetchWorkspaceFiles);
 
   const remoteSyncManager = mockDeep<RemoteSyncManager>();
-  const fetchFiles = mockDeep<FetchFilesService>();
   const logger = mockDeep<LoggerService>();
-  const service = new SyncRemoteFilesService(workspaceId, fetchFiles, logger);
+  const service = new SyncRemoteFilesService(workspaceId, logger);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -30,14 +31,14 @@ describe('sync-remote-files.service', () => {
 
   it('If hasMore is false, then do not fetch again', async () => {
     // Given
-    fetchFiles.run.mockResolvedValueOnce({ hasMore: false, result: [] });
+    fetchWorkspaceFilesMock.mockResolvedValueOnce({ hasMore: false, result: [] });
 
     // When
     const files = await service.run({ self: remoteSyncManager });
 
     // Then
     expect(files.length).toBe(0);
-    expect(fetchFiles.run).toHaveBeenCalledTimes(1);
+    expect(fetchWorkspaceFilesMock).toHaveBeenCalledTimes(1);
   });
 
   it('If checkpoint is null, fetch only EXISTS files', async () => {
@@ -45,7 +46,7 @@ describe('sync-remote-files.service', () => {
     await service.run({ self: remoteSyncManager });
 
     // Then
-    expect(fetchFiles.run).toHaveBeenCalledWith(
+    expect(fetchWorkspaceFilesMock).toHaveBeenCalledWith(
       expect.objectContaining({
         status: 'EXISTS',
       }),
@@ -57,7 +58,7 @@ describe('sync-remote-files.service', () => {
     await service.run({ self: remoteSyncManager, from: new Date() });
 
     // Then
-    expect(fetchFiles.run).toHaveBeenCalledWith(
+    expect(fetchWorkspaceFilesMock).toHaveBeenCalledWith(
       expect.objectContaining({
         status: 'ALL',
       }),
@@ -66,14 +67,14 @@ describe('sync-remote-files.service', () => {
 
   it('If fetch always throws an error, retry it 3 times with offset 0', async () => {
     // Given
-    fetchFiles.run.mockRejectedValue(new Error());
+    fetchWorkspaceFilesMock.mockRejectedValue(new Error());
 
     // When
     const files = await service.run({ self: remoteSyncManager });
 
     // Then
     expect(files.length).toBe(0);
-    expect(fetchFiles.run).toHaveBeenCalledTimes(3);
+    expect(fetchWorkspaceFilesMock).toHaveBeenCalledTimes(3);
     expect(remoteSyncManager.changeStatus).toHaveBeenCalledWith('SYNC_FAILED');
     expect(getMockCalls(logger.error)).toStrictEqual([
       expect.objectContaining({ msg: 'Remote files sync failed', offset: 0, retry: 1 }),
@@ -84,15 +85,15 @@ describe('sync-remote-files.service', () => {
 
   it('If fetch always throws an error, retry it 3 times with offset 0', async () => {
     // Given
-    fetchFiles.run.mockRejectedValue(new Error());
-    fetchFiles.run.mockResolvedValueOnce({ hasMore: true, result: [] });
+    fetchWorkspaceFilesMock.mockRejectedValue(new Error());
+    fetchWorkspaceFilesMock.mockResolvedValueOnce({ hasMore: true, result: [] });
 
     // When
     const files = await service.run({ self: remoteSyncManager });
 
     // Then
     expect(files.length).toBe(0);
-    expect(fetchFiles.run).toHaveBeenCalledTimes(4);
+    expect(fetchWorkspaceFilesMock).toHaveBeenCalledTimes(4);
     expect(remoteSyncManager.changeStatus).toHaveBeenCalledWith('SYNC_FAILED');
     expect(getMockCalls(logger.error)).toStrictEqual([
       expect.objectContaining({ msg: 'Remote files sync failed', offset: 50, retry: 1 }),
@@ -103,12 +104,12 @@ describe('sync-remote-files.service', () => {
 
   it('If fails in the middle, keep previous files', async () => {
     // Given
-    fetchFiles.run.mockResolvedValueOnce({
+    fetchWorkspaceFilesMock.mockResolvedValueOnce({
       hasMore: true,
       result: [{ uuid: 'file1' } as unknown as RemoteSyncedFile],
     });
-    fetchFiles.run.mockRejectedValueOnce(new Error());
-    fetchFiles.run.mockResolvedValueOnce({
+    fetchWorkspaceFilesMock.mockRejectedValueOnce(new Error());
+    fetchWorkspaceFilesMock.mockResolvedValueOnce({
       hasMore: false,
       result: [{ uuid: 'file2' } as unknown as RemoteSyncedFile],
     });
@@ -119,7 +120,7 @@ describe('sync-remote-files.service', () => {
     // Then
     expect(files.length).toBe(2);
     expect(syncRemoteFileMock).toHaveBeenCalledTimes(2);
-    expect(fetchFiles.run).toHaveBeenCalledTimes(3);
+    expect(fetchWorkspaceFilesMock).toHaveBeenCalledTimes(3);
     expect(getMockCalls(logger.error)).toStrictEqual([
       expect.objectContaining({
         msg: 'Remote files sync failed',

--- a/src/apps/main/remote-sync/files/sync-remote-files.service.ts
+++ b/src/apps/main/remote-sync/files/sync-remote-files.service.ts
@@ -1,20 +1,19 @@
 import { RemoteSyncedFile } from '../helpers';
 import { RemoteSyncManager } from '../RemoteSyncManager';
-import { FetchRemoteFilesService } from './fetch-remote-files.service';
-import { FetchWorkspaceFilesService } from './fetch-workspace-files.service';
-import { FetchFilesService, FetchFilesServiceParams } from './fetch-files.service.interface';
+import { FetchFilesServiceParams } from './fetch-files.service.interface';
 import { loggerService } from '@/apps/shared/logger/logger';
 import { FETCH_LIMIT } from '../store';
 import { sleep } from '../../util';
 import { getUserOrThrow } from '../../auth/service';
 import { syncRemoteFile } from './sync-remote-file';
+import { fetchRemoteFiles } from './fetch-remote-files.service';
+import { fetchWorkspaceFiles } from './fetch-workspace-files.service';
 
 const MAX_RETRIES = 3;
 
 export class SyncRemoteFilesService {
   constructor(
     private readonly workspaceId?: string,
-    private readonly fetchRemoteFiles: FetchFilesService = workspaceId ? new FetchWorkspaceFilesService() : new FetchRemoteFilesService(),
     private readonly logger = loggerService,
   ) {}
 
@@ -62,7 +61,9 @@ export class SyncRemoteFilesService {
           folderUuid,
         };
 
-        const { hasMore: newHasMore, result } = await this.fetchRemoteFiles.run(param);
+        const promise = this.workspaceId ? fetchWorkspaceFiles(param) : fetchRemoteFiles(param);
+
+        const { hasMore: newHasMore, result } = await promise;
 
         await Promise.all(
           result.map(async (remoteFile) => {

--- a/src/apps/main/remote-sync/files/sync-remote-files.service.ts
+++ b/src/apps/main/remote-sync/files/sync-remote-files.service.ts
@@ -1,4 +1,3 @@
-import { RemoteSyncedFile } from '../helpers';
 import { RemoteSyncManager } from '../RemoteSyncManager';
 import { FetchFilesServiceParams } from './fetch-files.service.interface';
 import { loggerService } from '@/apps/shared/logger/logger';
@@ -8,6 +7,7 @@ import { getUserOrThrow } from '../../auth/service';
 import { syncRemoteFile } from './sync-remote-file';
 import { fetchRemoteFiles } from './fetch-remote-files.service';
 import { fetchWorkspaceFiles } from './fetch-workspace-files.service';
+import { FileDto } from '@/infra/drive-server-wip/out/dto';
 
 const MAX_RETRIES = 3;
 
@@ -30,8 +30,8 @@ export class SyncRemoteFilesService {
     from?: Date;
     folderUuid?: string;
     offset?: number;
-    allResults?: RemoteSyncedFile[];
-  }): Promise<RemoteSyncedFile[]> {
+    allResults?: FileDto[];
+  }): Promise<FileDto[]> {
     let hasMore = true;
 
     try {

--- a/src/apps/main/remote-sync/folders/fetch-folders.service.interface.ts
+++ b/src/apps/main/remote-sync/folders/fetch-folders.service.interface.ts
@@ -1,6 +1,6 @@
 import { paths } from '@/apps/shared/HttpClient/schema';
 import { RemoteSyncManager } from '../RemoteSyncManager';
-import { RemoteSyncedFolder } from '../helpers';
+import { FolderDto } from '@/infra/drive-server-wip/out/dto';
 
 export type QueryFolders = paths['/folders']['get']['parameters']['query'];
 export type QueryFoldersInWorkspace = paths['/workspaces/{workspaceId}/folders']['get']['parameters']['query'];
@@ -16,7 +16,7 @@ export interface FetchFoldersServiceParams {
 
 export interface FetchFoldersServiceResult {
   hasMore: boolean;
-  result: RemoteSyncedFolder[];
+  result: FolderDto[];
 }
 
 export interface FetchFoldersService {

--- a/src/apps/main/remote-sync/folders/sync-remote-folder.ts
+++ b/src/apps/main/remote-sync/folders/sync-remote-folder.ts
@@ -1,15 +1,15 @@
 import { User } from '../../types';
-import { RemoteSyncedFolder } from '../helpers';
 import { RemoteSyncManager } from '../RemoteSyncManager';
 import { driveFoldersCollection } from '../store';
 import { logger } from '@/apps/shared/logger/logger';
 import { FolderStore } from './folder-store';
 import { Folder, FolderAttributes } from '@/context/virtual-drive/folders/domain/Folder';
+import { FolderDto } from '@/infra/drive-server-wip/out/dto';
 
 type TProps = {
   self: RemoteSyncManager;
   user: User;
-  remoteFolder: RemoteSyncedFolder;
+  remoteFolder: FolderDto;
 };
 
 export async function syncRemoteFolder({ self, user, remoteFolder }: TProps) {

--- a/src/apps/main/remote-sync/folders/sync-remote-folders.service.test.ts
+++ b/src/apps/main/remote-sync/folders/sync-remote-folders.service.test.ts
@@ -4,9 +4,9 @@ import { FetchFoldersService } from './fetch-folders.service.interface';
 import { RemoteSyncManager } from '../RemoteSyncManager';
 import { LoggerService } from '@/apps/shared/logger/logger';
 import { deepMocked, getMockCalls } from 'tests/vitest/utils.helper.test';
-import { RemoteSyncedFolder } from '../helpers';
 import { getUserOrThrow } from '../../auth/service';
 import { syncRemoteFolder } from './sync-remote-folder';
+import { FolderDto } from '@/infra/drive-server-wip/out/dto';
 
 vi.mock(import('@/apps/main/util'));
 vi.mock(import('../../auth/service'));
@@ -105,12 +105,12 @@ describe('sync-remote-folders.service', () => {
     // Given
     fetchFolders.run.mockResolvedValueOnce({
       hasMore: true,
-      result: [{ uuid: 'folder1' } as unknown as RemoteSyncedFolder],
+      result: [{ uuid: 'folder1' } as unknown as FolderDto],
     });
     fetchFolders.run.mockRejectedValueOnce(new Error());
     fetchFolders.run.mockResolvedValueOnce({
       hasMore: false,
-      result: [{ uuid: 'folder2' } as unknown as RemoteSyncedFolder],
+      result: [{ uuid: 'folder2' } as unknown as FolderDto],
     });
 
     // When

--- a/src/apps/main/remote-sync/folders/sync-remote-folders.service.ts
+++ b/src/apps/main/remote-sync/folders/sync-remote-folders.service.ts
@@ -1,4 +1,3 @@
-import { RemoteSyncedFolder } from '../helpers';
 import { RemoteSyncManager } from '../RemoteSyncManager';
 import { FetchRemoteFoldersService } from './fetch-remote-folders.service';
 import { FetchFoldersService, FetchFoldersServiceParams } from './fetch-folders.service.interface';
@@ -8,6 +7,7 @@ import { FETCH_LIMIT } from '../store';
 import { sleep } from '../../util';
 import { getUserOrThrow } from '../../auth/service';
 import { syncRemoteFolder } from './sync-remote-folder';
+import { FolderDto } from '@/infra/drive-server-wip/out/dto';
 
 const MAX_RETRIES = 3;
 
@@ -33,8 +33,8 @@ export class SyncRemoteFoldersService {
     from?: Date;
     folderUuid?: string;
     offset?: number;
-    allResults?: RemoteSyncedFolder[];
-  }): Promise<RemoteSyncedFolder[]> {
+    allResults?: FolderDto[];
+  }): Promise<FolderDto[]> {
     let hasMore = true;
 
     try {

--- a/src/apps/main/remote-sync/helpers.ts
+++ b/src/apps/main/remote-sync/helpers.ts
@@ -1,9 +1,4 @@
-import { paths } from '@/apps/shared/HttpClient/schema';
-
 export const FIVETEEN_MINUTES_IN_MILLISECONDS = 30 * 60 * 1000;
-
-export type RemoteSyncedFile = paths['/files']['get']['responses']['200']['content']['application/json'][number];
-export type RemoteSyncedFolder = paths['/folders']['get']['responses']['200']['content']['application/json'][number];
 
 export type RemoteSyncStatus = 'IDLE' | 'SYNCED' | 'SYNCING' | 'SYNC_FAILED' | 'SYNC_PENDING';
 

--- a/src/apps/shared/HttpClient/schema.d.ts
+++ b/src/apps/shared/HttpClient/schema.d.ts
@@ -2773,8 +2773,14 @@ export interface components {
       fileId: string;
       name: string;
       type: string;
-      /** Format: int64 */
-      size: number;
+      /**
+       * v2.5.2 Daniel Jiménez
+       * In drive-server-wip they work with size being a bigint.
+       * However, when we fetch it, size is converted to string, but openapi marks it as number.
+       * This issue is related with how sequelize converts bigint to number.
+       * https://github.com/internxt/drive-server-wip/pull/334
+       */
+      size: string;
       bucket: string;
       folderId: number;
       folder: Record<string, never>;

--- a/src/apps/shared/types/Primitives.ts
+++ b/src/apps/shared/types/Primitives.ts
@@ -1,1 +1,1 @@
-export type Primitives = string | number | boolean | null | undefined;
+export type Primitives = string | number | boolean | Date | null | undefined;

--- a/src/context/shared/domain/AggregateRoot.ts
+++ b/src/context/shared/domain/AggregateRoot.ts
@@ -1,5 +1,5 @@
+import { Primitives } from '@/apps/shared/types/Primitives';
 import { AllowedEvents } from '@/context/virtual-drive/shared/infrastructure/AllowedEvents';
-import { Primitives } from './value-objects/ValueObject';
 
 export abstract class AggregateRoot {
   private domainEvents: Array<AllowedEvents>;

--- a/src/context/shared/domain/ValueObject.ts
+++ b/src/context/shared/domain/ValueObject.ts
@@ -1,6 +1,5 @@
+import { Primitives } from '@/apps/shared/types/Primitives';
 import { InvalidArgumentError } from './InvalidArgumentError';
-
-export type Primitives = string | number | boolean | Date | undefined;
 
 export abstract class ValueObject<T extends Primitives> {
   readonly value: T;

--- a/src/context/shared/domain/value-objects/ValueObject.ts
+++ b/src/context/shared/domain/value-objects/ValueObject.ts
@@ -1,6 +1,5 @@
+import { Primitives } from '@/apps/shared/types/Primitives';
 import { InvalidArgumentError } from '../errors/InvalidArgumentError';
-
-export type Primitives = string | number | boolean | Date | undefined;
 
 export abstract class ValueObject<T extends Primitives> {
   readonly value: T;

--- a/src/context/virtual-drive/files/infrastructure/HttpRemoteFileSystem.ts
+++ b/src/context/virtual-drive/files/infrastructure/HttpRemoteFileSystem.ts
@@ -49,7 +49,7 @@ export class HttpRemoteFileSystem {
         createdAt: result.createdAt,
         modificationTime: result.updatedAt,
         path: offline.path,
-        size: result.size,
+        size: Number(result.size),
         updatedAt: result.updatedAt,
         status: FileStatuses.EXISTS,
       };
@@ -168,7 +168,7 @@ export class HttpRemoteFileSystem {
       createdAt: data.createdAt,
       modificationTime: data.modificationTime,
       path: filePath,
-      size: data.size,
+      size: Number(data.size),
       status: FileStatuses.EXISTS,
       updatedAt: data.updatedAt,
     };

--- a/src/context/virtual-drive/items/application/Traverser.test.ts
+++ b/src/context/virtual-drive/items/application/Traverser.test.ts
@@ -50,7 +50,7 @@ describe('Traverser', () => {
     const tree = await SUT.run();
 
     expect(extractPaths(tree.files)).toStrictEqual(['/file A']);
-    expect(extractPaths(tree.folders)).toStrictEqual([]);
+    expect(extractPaths(tree.folders)).toStrictEqual(['/']);
   });
 
   it('second level files starts with /', async () => {
@@ -81,7 +81,7 @@ describe('Traverser', () => {
     const tree = await SUT.run();
 
     expect(extractPaths(tree.files)).toStrictEqual(['/folder A/file A']);
-    expect(extractPaths(tree.folders)).toStrictEqual(['/folder A']);
+    expect(extractPaths(tree.folders)).toStrictEqual(['/', '/folder A']);
   });
 
   it('first level folder starts with /', async () => {
@@ -101,7 +101,7 @@ describe('Traverser', () => {
 
     const tree = await SUT.run();
 
-    expect(extractPaths(tree.folders)).toStrictEqual(['/folder A']);
+    expect(extractPaths(tree.folders)).toStrictEqual(['/', '/folder A']);
   });
 
   it('second level folder starts with /', async () => {
@@ -129,7 +129,7 @@ describe('Traverser', () => {
 
     const tree = await SUT.run();
 
-    expect(extractPaths(tree.folders)).toStrictEqual(['/folder A', '/folder A/folder B']);
+    expect(extractPaths(tree.folders)).toStrictEqual(['/', '/folder A', '/folder A/folder B']);
   });
 
   it('root folder should exist', async () => {
@@ -157,7 +157,7 @@ describe('Traverser', () => {
 
     const tree = await SUT.run();
 
-    expect(extractPaths(tree.folders)).toStrictEqual(['/folder A', '/folder A/folder B']);
+    expect(extractPaths(tree.folders)).toStrictEqual(['/', '/folder A', '/folder A/folder B']);
   });
 
   it('when a file data is invalid ignore it and continue', async () => {
@@ -218,7 +218,7 @@ describe('Traverser', () => {
     const tree = await SUT.run();
 
     expect(extractPaths(tree.files)).toStrictEqual([]);
-    expect(extractPaths(tree.folders)).toStrictEqual(['/folder A']);
+    expect(extractPaths(tree.folders)).toStrictEqual(['/', '/folder A']);
   });
 
   it('filters the files and folders depending on the filters set', async () => {
@@ -249,7 +249,7 @@ describe('Traverser', () => {
     const tree = await SUT.run();
 
     expect(extractPaths(tree.files)).toStrictEqual(['/file A']);
-    expect(extractPaths(tree.folders)).toStrictEqual([]);
+    expect(extractPaths(tree.folders)).toStrictEqual(['/']);
   });
 
   it('filters the files and folders depending on the filters set', async () => {
@@ -291,6 +291,6 @@ describe('Traverser', () => {
     const tree = await SUT.run();
 
     expect(extractPaths(tree.files)).toStrictEqual(['/file A.png']);
-    expect(extractPaths(tree.folders)).toStrictEqual([]);
+    expect(extractPaths(tree.folders)).toStrictEqual(['/']);
   });
 });

--- a/src/context/virtual-drive/items/application/Traverser.ts
+++ b/src/context/virtual-drive/items/application/Traverser.ts
@@ -110,7 +110,7 @@ export class Traverser {
 
     const tree: Tree = {
       files: [],
-      folders: [],
+      folders: [rootFolder],
       trashedFiles: [],
       trashedFolders: [],
     };

--- a/src/infra/drive-server-wip/drive-server-wip.module.ts
+++ b/src/infra/drive-server-wip/drive-server-wip.module.ts
@@ -4,12 +4,14 @@ import { FilesService } from './services/files.service';
 import { FoldersService } from './services/folders.service';
 import { StorageService } from './services/storage.service';
 import { UserService } from './services/user.service';
-import { getCredentials, getWorkspaces } from './services/workspaces.service';
+import { getCredentials, getFilesByFolderInWorkspace, getFilesInWorkspace, getWorkspaces } from './services/workspaces.service';
 
 export class DriveServerWipModule {
   public workspaces = {
     getWorkspaces,
     getCredentials,
+    getFilesInWorkspace,
+    getFilesByFolderInWorkspace,
   };
 
   constructor(

--- a/src/infra/drive-server-wip/out/dto.ts
+++ b/src/infra/drive-server-wip/out/dto.ts
@@ -1,0 +1,4 @@
+import { components } from '@/apps/shared/HttpClient/schema';
+
+export type FileDto = components['schemas']['FileDto'];
+export type FolderDto = components['schemas']['FolderDto'];

--- a/src/infra/drive-server-wip/services/workspaces.service.ts
+++ b/src/infra/drive-server-wip/services/workspaces.service.ts
@@ -1,5 +1,9 @@
 import { client } from '@/apps/shared/HttpClient/client';
 import { clientWrapper } from '../in/client-wrapper.service';
+import { paths } from '@/apps/shared/HttpClient/schema';
+
+type QueryFilesInWorkspace = paths['/workspaces/{workspaceId}/files']['get']['parameters']['query'];
+type QueryFilesInFolderInWorkspace = paths['/workspaces/{workspaceId}/folders/{folderUuid}/files']['get']['parameters']['query'];
 
 export function getWorkspaces() {
   const promise = client.GET('/workspaces');
@@ -16,22 +20,72 @@ export function getWorkspaces() {
   });
 }
 
-export function getCredentials({ workspaceId }: { workspaceId: string }) {
+export function getCredentials(context: { workspaceId: string }) {
   const promise = client.GET('/workspaces/{workspaceId}/credentials', {
-    params: { path: { workspaceId } },
+    params: { path: { workspaceId: context.workspaceId } },
   });
 
   return clientWrapper({
     promise,
     loggerBody: {
       msg: 'Get workspace credentials request was not successful',
-      context: {
-        workspaceId,
-      },
+      context,
       attributes: {
         method: 'GET',
         endpoint: '/workspaces/{workspaceId}/credentials',
       },
     },
   });
+}
+
+export function getFilesInWorkspace(context: { workspaceId: string; query: QueryFilesInWorkspace }) {
+  const promise = client.GET('/workspaces/{workspaceId}/files', {
+    params: {
+      path: { workspaceId: context.workspaceId },
+      query: context.query,
+    },
+  });
+
+  return clientWrapper({
+    promise,
+    loggerBody: {
+      msg: 'Get workspace files request was not successful',
+      context,
+      attributes: {
+        method: 'GET',
+        endpoint: '/workspaces/{workspaceId}/files',
+      },
+    },
+  });
+}
+
+export async function getFilesByFolderInWorkspace(context: {
+  workspaceId: string;
+  folderUuid: string;
+  query: QueryFilesInFolderInWorkspace;
+}) {
+  const promise = client.GET('/workspaces/{workspaceId}/folders/{folderUuid}/files', {
+    params: {
+      path: { workspaceId: context.workspaceId, folderUuid: context.folderUuid },
+      query: context.query,
+    },
+  });
+
+  const res = await clientWrapper({
+    promise,
+    loggerBody: {
+      msg: 'Get workspace files by folder request was not successful',
+      context,
+      attributes: {
+        method: 'GET',
+        endpoint: '/workspaces/{workspaceId}/folders/{folderUuid}/files',
+      },
+    },
+  });
+
+  if (res.data) {
+    return { data: res.data.result };
+  } else {
+    return { error: res.error };
+  }
 }


### PR DESCRIPTION
## What

1. Override schema.d.ts so file.size is marked as string. Then, wherever we need to use this size, convert it to Number(x).
2. Add root folder to traverser.