### PR TITLE
Refactored Logic for Detecting File Modification During Upload to Prevent False Positives

### DIFF
--- a/src/context/virtual-drive/contents/infrastructure/EnvironmentRemoteFileContentsManagersFactory.ts
+++ b/src/context/virtual-drive/contents/infrastructure/EnvironmentRemoteFileContentsManagersFactory.ts
@@ -17,7 +17,7 @@ export class EnvironmentRemoteFileContentsManagersFactory {
     return new EnvironmentContentFileDownloader(this.environment.download, this.bucket);
   }
 
-  uploader(contents: LocalFileContents, abortSignal?: AbortSignal): ContentFileUploader {
+  uploader(contents: LocalFileContents, abortSignal: AbortSignal): ContentFileUploader {
     const fn =
       contents.size > EnvironmentRemoteFileContentsManagersFactory.MULTIPART_UPLOAD_SIZE_THRESHOLD
         ? this.environment.uploadMultipartFile.bind(this.environment)

--- a/src/context/virtual-drive/contents/infrastructure/FSLocalFileProvider.ts
+++ b/src/context/virtual-drive/contents/infrastructure/FSLocalFileProvider.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { Readable } from 'stream';
 import { LocalFileContents } from '../domain/LocalFileContents';
 import { LocalContentsProvider } from '../domain/LocalFileProvider';
+import { logger } from '@/apps/shared/logger/logger';
 
 function extractNameAndExtension(nameWithExtension: string): [string, string] {
   if (nameWithExtension.startsWith('.')) {
@@ -78,7 +79,6 @@ export class FSLocalFileProvider implements LocalContentsProvider {
 
   async provide(absoluteFilePath: string) {
     try {
-      // Creación del stream con posibilidad de aborto
       const { readable, controller } = await this.createAbortableStream(absoluteFilePath);
 
       const { size, mtimeMs, birthtimeMs } = await fs.stat(absoluteFilePath);
@@ -86,13 +86,42 @@ export class FSLocalFileProvider implements LocalContentsProvider {
       const absoluteFolderPath = path.dirname(absoluteFilePath);
       const nameWithExtension = path.basename(absoluteFilePath);
 
-      const watcher = watch(absoluteFolderPath, (_, filename) => {
+      const watcher = watch(absoluteFolderPath, async (event, filename) => {
         if (filename !== nameWithExtension) {
           return;
         }
-        Logger.warn(filename, ' has been changed during read, it will be aborted');
 
-        controller.abort();
+        try {
+          const { mtimeMs: newMtimeMs, size: newSize } = await fs.stat(absoluteFilePath);
+
+          if (newMtimeMs !== mtimeMs || newSize !== size) {
+            logger.debug({
+              msg: 'File changed, aborting read stream',
+              filePath: absoluteFilePath,
+              filename,
+              nameWithExtension,
+              event,
+              newMtimeMs,
+              newSize,
+            });
+
+            controller.abort();
+          } else {
+            logger.debug({
+              msg: 'File event detected, but no real changes found',
+              filePath: absoluteFilePath,
+              filename,
+              nameWithExtension,
+              event,
+            });
+          }
+        } catch (error) {
+          logger.error({
+            msg: 'Error while checking file changes',
+            exc: error,
+            filePath: absoluteFilePath,
+          });
+        }
       });
 
       readable.on('end', () => {

--- a/src/context/virtual-drive/contents/infrastructure/upload/EnvironmentContentFileUploader.ts
+++ b/src/context/virtual-drive/contents/infrastructure/upload/EnvironmentContentFileUploader.ts
@@ -3,7 +3,6 @@ import { EventEmitter, Readable } from 'stream';
 import { ContentFileUploader, FileUploadEvents } from '../../domain/contentHandlers/ContentFileUploader';
 import { ContentsId } from '../../domain/ContentsId';
 import { Stopwatch } from '../../../../../apps/shared/types/Stopwatch';
-import { logger } from '@/apps/shared/logger/logger';
 
 export class EnvironmentContentFileUploader implements ContentFileUploader {
   private eventEmitter: EventEmitter;
@@ -12,7 +11,7 @@ export class EnvironmentContentFileUploader implements ContentFileUploader {
   constructor(
     private readonly fn: UploadStrategyFunction,
     private readonly bucket: string,
-    private readonly abortSignal?: AbortSignal,
+    private readonly abortSignal: AbortSignal,
   ) {
     this.eventEmitter = new EventEmitter();
     this.stopwatch = new Stopwatch();
@@ -30,10 +29,6 @@ export class EnvironmentContentFileUploader implements ContentFileUploader {
           this.stopwatch.finish();
 
           if (err) {
-            logger.error({
-              msg: 'Error while uploading file',
-              exc: err,
-            });
             this.eventEmitter.emit('error', err);
             return reject(err);
           }
@@ -45,12 +40,10 @@ export class EnvironmentContentFileUploader implements ContentFileUploader {
         },
       });
 
-      if (this.abortSignal) {
-        this.abortSignal.addEventListener('abort', () => {
-          state.stop();
-          contents.destroy();
-        });
-      }
+      this.abortSignal.addEventListener('abort', () => {
+        state.stop();
+        contents.destroy();
+      });
     });
   }
 

--- a/src/context/virtual-drive/contents/infrastructure/upload/EnvironmentContentFileUploader.ts
+++ b/src/context/virtual-drive/contents/infrastructure/upload/EnvironmentContentFileUploader.ts
@@ -3,6 +3,7 @@ import { EventEmitter, Readable } from 'stream';
 import { ContentFileUploader, FileUploadEvents } from '../../domain/contentHandlers/ContentFileUploader';
 import { ContentsId } from '../../domain/ContentsId';
 import { Stopwatch } from '../../../../../apps/shared/types/Stopwatch';
+import { logger } from '@/apps/shared/logger/logger';
 
 export class EnvironmentContentFileUploader implements ContentFileUploader {
   private eventEmitter: EventEmitter;
@@ -29,6 +30,10 @@ export class EnvironmentContentFileUploader implements ContentFileUploader {
           this.stopwatch.finish();
 
           if (err) {
+            logger.error({
+              msg: 'Error while uploading file',
+              exc: err,
+            });
             this.eventEmitter.emit('error', err);
             return reject(err);
           }

--- a/tests/context/virtual-drive/contents/infrastructure/upload/EnvironmentContentFileUploader.test.ts
+++ b/tests/context/virtual-drive/contents/infrastructure/upload/EnvironmentContentFileUploader.test.ts
@@ -6,6 +6,7 @@ import { ContentsIdMother } from '../../domain/ContentsIdMother';
 describe('Environment Content File Uploader', () => {
   const validFileSize = 1926506743;
   const bucket = 'c7d4d5e7-0850-52f4-8cbe-c3f746fb7d3f';
+  const abortSignal = new AbortController().signal;
 
   describe('event emitter', () => {
     it('emits an event on start', async () => {
@@ -13,7 +14,7 @@ describe('Environment Content File Uploader', () => {
         opts.finishedCallback(null, ContentsIdMother.raw());
       });
 
-      const uploader = new EnvironmentContentFileUploader(strategy, bucket);
+      const uploader = new EnvironmentContentFileUploader(strategy, bucket, abortSignal);
 
       const handler = vi.fn();
 
@@ -30,7 +31,7 @@ describe('Environment Content File Uploader', () => {
         opts.finishedCallback(null, uploadedFileId);
       });
 
-      const uploader = new EnvironmentContentFileUploader(strategy, bucket);
+      const uploader = new EnvironmentContentFileUploader(strategy, bucket, abortSignal);
 
       uploader.on('finish', (fileId: string) => {
         expect(fileId).toBe(uploadedFileId);
@@ -47,7 +48,7 @@ describe('Environment Content File Uploader', () => {
         opts.finishedCallback(null, ContentsIdMother.raw());
       });
 
-      const uploader = new EnvironmentContentFileUploader(strategy, bucket);
+      const uploader = new EnvironmentContentFileUploader(strategy, bucket, abortSignal);
 
       const handler = vi.fn();
 
@@ -64,7 +65,7 @@ describe('Environment Content File Uploader', () => {
         opts.finishedCallback(null, ContentsIdMother.raw());
       });
 
-      const uploader = new EnvironmentContentFileUploader(strategy, bucket);
+      const uploader = new EnvironmentContentFileUploader(strategy, bucket, abortSignal);
 
       const progressHandler = vi.fn();
       const finishHandler = vi.fn();
@@ -85,7 +86,7 @@ describe('Environment Content File Uploader', () => {
         opts.finishedCallback({ message: errorMsg } as unknown as Error, null);
       });
 
-      const uploader = new EnvironmentContentFileUploader(strategy, bucket);
+      const uploader = new EnvironmentContentFileUploader(strategy, bucket, abortSignal);
 
       uploader.on('error', (error: Error) => {
         expect(error.message).toBe(errorMsg);
@@ -104,7 +105,7 @@ describe('Environment Content File Uploader', () => {
         setTimeout(() => opts.finishedCallback(null, ContentsIdMother.raw()), 100);
       });
 
-      const uploader = new EnvironmentContentFileUploader(strategy, bucket);
+      const uploader = new EnvironmentContentFileUploader(strategy, bucket, abortSignal);
 
       uploader.on('progress', () => {
         expect(uploader.elapsedTime()).toBeGreaterThan(-1);
@@ -121,7 +122,7 @@ describe('Environment Content File Uploader', () => {
         setTimeout(() => opts.finishedCallback(null, ContentsIdMother.raw()), delay);
       });
 
-      const uploader = new EnvironmentContentFileUploader(strategy, bucket);
+      const uploader = new EnvironmentContentFileUploader(strategy, bucket, abortSignal);
 
       await uploader.upload(Readable.from(''), validFileSize);
 


### PR DESCRIPTION
This Pull Request introduces an improvement to the logic that determines if a file has been modified before attempting to upload it, with the primary goal of preventing upload blocks caused by false positives.

- Change in modification detection logic to avoid false positives:
  - The logic used to verify if a file has been changed before initiating the upload has been refactored. The main objective of this modification is to prevent files that have not actually been modified from being incorrectly flagged as such, which could previously block the upload process. The new logic aims for more accurate detection to ensure that only genuine modifications trigger an upload.