### PR TITLE
Split logs into important and not

### DIFF
--- a/src/apps/main/logger.ts
+++ b/src/apps/main/logger.ts
@@ -5,12 +5,20 @@ import ElectronLog from 'electron-log';
 export function setupElectronLog() {
   ElectronLog.initialize();
 
-  ElectronLog.transports.file.resolvePathFn = () => PATHS.ELECTRON_LOGS;
+  ElectronLog.transports.file.resolvePathFn = (_, message) => {
+    const level = message?.level;
+    if (level === 'error' || level === 'info' || level === 'warn') {
+      return PATHS.ELECTRON_IMPORTANT_LOGS;
+    } else {
+      return PATHS.ELECTRON_LOGS;
+    }
+  };
+
   ElectronLog.transports.file.maxSize = 150 * 1024 * 1024; // 150MB
   ElectronLog.transports.file.format = '[{iso}] [{level}] {text}';
   ElectronLog.transports.console.format = '[{iso}] [{level}] {text}';
 
   ipcMain.on('open-logs', () => {
-    shell.openPath(PATHS.LOGS);
+    void shell.openPath(PATHS.LOGS);
   });
 }

--- a/src/core/electron/paths.ts
+++ b/src/core/electron/paths.ts
@@ -5,6 +5,7 @@ const HOME_FOLDER_PATH = app.getPath('home');
 const SQLITE_DB = join(app.getPath('appData'), 'internxt-drive', 'internxt_desktop.db');
 const LOGS = join(app.getPath('appData'), 'internxt-drive', 'logs');
 const ELECTRON_LOGS = join(LOGS, 'drive-desktop.ans');
+const ELECTRON_IMPORTANT_LOGS = join(LOGS, 'drive-desktop-important.ans');
 const QUEUE_MANAGER = join(app.getPath('appData'), 'internxt-drive', 'queue-manager.json');
 
-export const PATHS = { HOME_FOLDER_PATH, SQLITE_DB, LOGS, ELECTRON_LOGS, QUEUE_MANAGER };
+export const PATHS = { HOME_FOLDER_PATH, SQLITE_DB, LOGS, ELECTRON_LOGS, ELECTRON_IMPORTANT_LOGS, QUEUE_MANAGER };


### PR DESCRIPTION
## What

Split logs into two different files based on the level. With this approach we will be able to find faster the errors.