### PR TITLE
Set workspace id as nullable

### DIFF
--- a/src/apps/main/database/entities/DriveFile.ts
+++ b/src/apps/main/database/entities/DriveFile.ts
@@ -15,8 +15,8 @@ export class DriveFile {
   })
   uuid!: string;
 
-  @Column({ nullable: false, default: '', type: 'varchar' })
-  workspaceId!: string;
+  @Column({ nullable: true, default: '', type: 'varchar' })
+  workspaceId?: string;
 
   @Column({ nullable: true, default: '', type: 'varchar' })
   type!: string;

--- a/src/apps/main/database/entities/DriveFolder.ts
+++ b/src/apps/main/database/entities/DriveFolder.ts
@@ -14,8 +14,8 @@ export class DriveFolder {
   @Column({ nullable: false, unique: true, type: 'int' })
   id!: number;
 
-  @Column({ nullable: false, default: '', type: 'varchar' })
-  workspaceId!: string;
+  @Column({ nullable: true, default: '', type: 'varchar' })
+  workspaceId?: string;
 
   @Column({ nullable: true, type: 'int' })
   parentId?: number;


### PR DESCRIPTION
## What

Revert changes about workspaceId being only empty string and disallowing null in the database. We will handle this in the future.