### PR TITLE
Ignore notifications made by drive-desktop

### DIFF
--- a/src/apps/main/notification-schema.ts
+++ b/src/apps/main/notification-schema.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+const EVENT = z.object({
+  email: z.string(),
+  clientId: z.union([z.literal('drive-desktop'), z.literal('drive-web')]),
+  userId: z.string(),
+});
+
+export const ITEMS_TO_TRASH = EVENT.extend({
+  event: z.literal('ITEMS_TO_TRASH'),
+  payload: z.array(
+    z.object({
+      type: z.union([z.literal('file'), z.literal('folder')]),
+      uuid: z.string(),
+    }),
+  ),
+});
+
+export const FILE_CREATED = EVENT.extend({
+  event: z.literal('FILE_CREATED'),
+  payload: z.object({
+    id: z.number(),
+    uuid: z.string(),
+    fileId: z.string(),
+    name: z.string(),
+    type: z.string(),
+    bucket: z.string(),
+    folderId: z.number(),
+    status: z.literal('EXISTS'),
+  }),
+});
+
+export const FOLDER_CREATED = EVENT.extend({
+  event: z.literal('FOLDER_CREATED'),
+  payload: z.object({
+    id: z.number(),
+    uuid: z.string(),
+    name: z.string(),
+    plainName: z.string(),
+  }),
+});
+
+export const NOTIFICATION_SCHEMA = z.union([ITEMS_TO_TRASH, FILE_CREATED, FOLDER_CREATED]);

--- a/src/apps/main/notification-schema.ts
+++ b/src/apps/main/notification-schema.ts
@@ -6,7 +6,7 @@ const EVENT = z.object({
   userId: z.string(),
 });
 
-export const ITEMS_TO_TRASH = EVENT.extend({
+const ITEMS_TO_TRASH = EVENT.extend({
   event: z.literal('ITEMS_TO_TRASH'),
   payload: z.array(
     z.object({
@@ -16,7 +16,7 @@ export const ITEMS_TO_TRASH = EVENT.extend({
   ),
 });
 
-export const FILE_CREATED = EVENT.extend({
+const FILE_CREATED = EVENT.extend({
   event: z.literal('FILE_CREATED'),
   payload: z.object({
     id: z.number(),
@@ -30,7 +30,7 @@ export const FILE_CREATED = EVENT.extend({
   }),
 });
 
-export const FOLDER_CREATED = EVENT.extend({
+const FOLDER_CREATED = EVENT.extend({
   event: z.literal('FOLDER_CREATED'),
   payload: z.object({
     id: z.number(),

--- a/src/apps/main/realtime.ts
+++ b/src/apps/main/realtime.ts
@@ -4,6 +4,7 @@ import eventBus from './event-bus';
 import { broadcastToWindows } from './windows';
 import { logger } from '../shared/logger/logger';
 import { debouncedSynchronization } from './remote-sync/handlers';
+import { NOTIFICATION_SCHEMA } from './notification-schema';
 
 type XHRRequest = {
   getResponseHeader: (headerName: string) => string[] | null;
@@ -73,15 +74,19 @@ export function cleanAndStartRemoteNotifications() {
       user = getUser();
     }
 
-    if (data.payload.bucket !== user?.backupsBucket) {
+    const parsedData = await NOTIFICATION_SCHEMA.safeParseAsync(data);
+
+    if (parsedData.success && parsedData.data.clientId === 'drive-desktop') {
+      const { data } = parsedData;
+      logger.debug({
+        msg: 'Notification received',
+        event: data.event,
+        clientId: data.clientId,
+      });
+    } else {
       logger.info({ msg: 'Notification received', data });
       await debouncedSynchronization();
-      return;
     }
-
-    const { event, payload } = data;
-
-    logger.info({ msg: 'Notification received 2', event, payload });
   });
 }
 


### PR DESCRIPTION
## What

Currently, we were having a problem because, for example, folders created in backups were dispatching the notification of FOLDER_CREATED and executing the debounceSynchronization when it was not necessary. This was also happening with items created in windows.

Now, we are using the clientId property of the notification. If the value is `drive-desktop` it means we performed the action so it's not necessary to do the synchronization. This is also the beginning of start parsing the notifications and being able to perform the event action in realtime, without having to wait for the full synchronization.