### PR TITLE
Add abort signal to fetch backup items

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internxt-drive",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "author": "Internxt <hello@internxt.com>",
   "description": "Internxt client UI",
   "main": "./dist/main/main.js",

--- a/src/apps/backups/fetch-items/fetch-files-by-folder.ts
+++ b/src/apps/backups/fetch-items/fetch-files-by-folder.ts
@@ -16,6 +16,7 @@ export async function fetchFilesByFolder({ folderUuid, allFiles, abortSignal, of
 
   while (hasMore && !abortSignal.aborted) {
     logger.debug({
+      tag: 'BACKUPS',
       msg: 'Fetching backup files',
       folderUuid,
       offset,

--- a/src/apps/backups/fetch-items/fetch-files-by-folder.ts
+++ b/src/apps/backups/fetch-items/fetch-files-by-folder.ts
@@ -7,13 +7,14 @@ import { retryWrapper } from '@/infra/drive-server-wip/out/retry-wrapper';
 type TProps = {
   folderUuid: string;
   allFiles: FileDto[];
+  abortSignal: AbortSignal;
   offset?: number;
 };
 
-export async function fetchFilesByFolder({ folderUuid, allFiles, offset = 0 }: TProps) {
+export async function fetchFilesByFolder({ folderUuid, allFiles, abortSignal, offset = 0 }: TProps) {
   let hasMore = true;
 
-  while (hasMore) {
+  while (hasMore && !abortSignal.aborted) {
     logger.debug({
       msg: 'Fetching backup files',
       folderUuid,

--- a/src/apps/backups/fetch-items/fetch-folders-by-folder.ts
+++ b/src/apps/backups/fetch-items/fetch-folders-by-folder.ts
@@ -7,15 +7,16 @@ import { retryWrapper } from '@/infra/drive-server-wip/out/retry-wrapper';
 type TProps = {
   folderUuid: string;
   allFolders: FolderDto[];
+  abortSignal: AbortSignal;
   newFolders?: FolderDto[];
   retry?: number;
   offset?: number;
 };
 
-export async function fetchFoldersByFolder({ folderUuid, allFolders, newFolders = [], offset = 0 }: TProps) {
+export async function fetchFoldersByFolder({ folderUuid, allFolders, abortSignal, newFolders = [], offset = 0 }: TProps) {
   let hasMore = true;
 
-  while (hasMore) {
+  while (hasMore && !abortSignal.aborted) {
     logger.debug({
       msg: 'Fetching backup folders',
       folderUuid,

--- a/src/apps/backups/fetch-items/fetch-folders-by-folder.ts
+++ b/src/apps/backups/fetch-items/fetch-folders-by-folder.ts
@@ -18,6 +18,7 @@ export async function fetchFoldersByFolder({ folderUuid, allFolders, abortSignal
 
   while (hasMore && !abortSignal.aborted) {
     logger.debug({
+      tag: 'BACKUPS',
       msg: 'Fetching backup folders',
       folderUuid,
       offset,

--- a/src/apps/backups/fetch-items/fetch-items-by-folder.ts
+++ b/src/apps/backups/fetch-items/fetch-items-by-folder.ts
@@ -7,11 +7,12 @@ type TProps = {
   allFolders: FolderDto[];
   allFiles: FileDto[];
   skipFiles: boolean;
+  abortSignal: AbortSignal;
 };
 
-export async function fetchItemsByFolder({ folderUuid, allFolders, allFiles, skipFiles }: TProps): Promise<void> {
-  const filesPromise = skipFiles ? Promise.resolve() : fetchFilesByFolder({ folderUuid, allFiles });
-  const foldersPromise = fetchFoldersByFolder({ folderUuid, allFolders });
+export async function fetchItemsByFolder({ folderUuid, allFolders, allFiles, skipFiles, abortSignal }: TProps): Promise<void> {
+  const filesPromise = skipFiles ? Promise.resolve() : fetchFilesByFolder({ folderUuid, allFiles, abortSignal });
+  const foldersPromise = fetchFoldersByFolder({ folderUuid, allFolders, abortSignal });
 
   const [, { newFolders }] = await Promise.all([filesPromise, foldersPromise]);
 
@@ -22,6 +23,7 @@ export async function fetchItemsByFolder({ folderUuid, allFolders, allFiles, ski
         allFolders,
         allFiles,
         skipFiles,
+        abortSignal,
       });
     }),
   );

--- a/src/apps/backups/fetch-items/fetch-items.ts
+++ b/src/apps/backups/fetch-items/fetch-items.ts
@@ -5,9 +5,10 @@ import { fetchItemsByFolder } from './fetch-items-by-folder';
 type TProps = {
   folderUuid: string;
   skipFiles: boolean;
+  abortSignal: AbortSignal;
 };
 
-export async function fetchItems({ folderUuid, skipFiles }: TProps) {
+export async function fetchItems({ folderUuid, skipFiles, abortSignal }: TProps) {
   try {
     logger.debug({
       msg: 'Fetch backup items started',
@@ -22,6 +23,7 @@ export async function fetchItems({ folderUuid, skipFiles }: TProps) {
       allFolders,
       allFiles,
       skipFiles,
+      abortSignal,
     });
 
     logger.debug({

--- a/src/apps/backups/fetch-items/fetch-items.ts
+++ b/src/apps/backups/fetch-items/fetch-items.ts
@@ -11,6 +11,7 @@ type TProps = {
 export async function fetchItems({ folderUuid, skipFiles, abortSignal }: TProps) {
   try {
     logger.debug({
+      tag: 'BACKUPS',
       msg: 'Fetch backup items started',
       folderUuid,
     });
@@ -27,6 +28,7 @@ export async function fetchItems({ folderUuid, skipFiles, abortSignal }: TProps)
     });
 
     logger.debug({
+      tag: 'BACKUPS',
       msg: 'Fetch backup items finished',
       folderUuid,
       files: allFiles.length,
@@ -36,6 +38,7 @@ export async function fetchItems({ folderUuid, skipFiles, abortSignal }: TProps)
     return { folders: allFolders, files: allFiles };
   } catch (error) {
     throw logger.error({
+      tag: 'BACKUPS',
       msg: 'Fetch backup items failed',
       folderUuid,
       exc: error,

--- a/src/apps/backups/remote-tree/traverser.ts
+++ b/src/apps/backups/remote-tree/traverser.ts
@@ -108,6 +108,7 @@ export class Traverser {
     const items = await fetchItems({
       folderUuid: context.folderUuid,
       skipFiles: false,
+      abortSignal: context.abortController.signal,
     });
 
     const rootFolder = this.createRootFolder({ id: context.folderId, uuid: context.folderUuid });

--- a/src/apps/main/background-processes/backups/BackupsProcessStatus/BackupsStatus.ts
+++ b/src/apps/main/background-processes/backups/BackupsProcessStatus/BackupsStatus.ts
@@ -1,1 +1,1 @@
-export type BackupsStatus = 'STANDBY' | 'RUNNING';
+export type BackupsStatus = 'STANDBY' | 'RUNNING' | 'STOPPING';

--- a/src/apps/main/background-processes/backups/launchBackupProcesses.ts
+++ b/src/apps/main/background-processes/backups/launchBackupProcesses.ts
@@ -7,7 +7,6 @@ import { isAvailableBackups } from '../../ipcs/ipcMainAntivirus';
 import { logger } from '@/apps/shared/logger/logger';
 import { BackupsContext } from '@/apps/backups/BackupInfo';
 import { addBackupsIssue, clearBackupsIssues } from '../issues';
-import { sleep } from '../../util';
 
 function backupsCanRun(status: BackupsProcessStatus) {
   return status.isIn('STANDBY') && backupsConfig.enabled;

--- a/src/apps/main/background-processes/backups/launchBackupProcesses.ts
+++ b/src/apps/main/background-processes/backups/launchBackupProcesses.ts
@@ -42,6 +42,7 @@ export async function launchBackupProcesses(
   ipcMain.once('stop-backups-process', () => {
     logger.debug({ tag: 'BACKUPS', msg: 'Backups aborted' });
     abortController.abort();
+    status.set('STANDBY');
   });
 
   clearBackupsIssues();

--- a/src/apps/main/background-processes/backups/launchBackupProcesses.ts
+++ b/src/apps/main/background-processes/backups/launchBackupProcesses.ts
@@ -56,6 +56,10 @@ export async function launchBackupProcesses(
       backupInfo,
     });
 
+    if (abortController.signal.aborted) {
+      continue;
+    }
+
     const context: BackupsContext = {
       ...backupInfo,
       abortController,
@@ -66,10 +70,6 @@ export async function launchBackupProcesses(
         });
       },
     };
-
-    if (abortController.signal.aborted) {
-      continue;
-    }
 
     tracker.backing();
 

--- a/src/apps/main/background-processes/backups/launchBackupProcesses.ts
+++ b/src/apps/main/background-processes/backups/launchBackupProcesses.ts
@@ -7,6 +7,7 @@ import { isAvailableBackups } from '../../ipcs/ipcMainAntivirus';
 import { logger } from '@/apps/shared/logger/logger';
 import { BackupsContext } from '@/apps/backups/BackupInfo';
 import { addBackupsIssue, clearBackupsIssues } from '../issues';
+import { sleep } from '../../util';
 
 function backupsCanRun(status: BackupsProcessStatus) {
   return status.isIn('STANDBY') && backupsConfig.enabled;
@@ -18,7 +19,7 @@ export async function launchBackupProcesses(
   status: BackupsProcessStatus,
 ): Promise<void> {
   if (!backupsCanRun(status)) {
-    logger.debug({ tag: 'BACKUPS', msg: 'Already running' });
+    logger.debug({ tag: 'BACKUPS', msg: 'Already running', status });
     return;
   }
 
@@ -42,7 +43,7 @@ export async function launchBackupProcesses(
   ipcMain.once('stop-backups-process', () => {
     logger.debug({ tag: 'BACKUPS', msg: 'Backups aborted' });
     abortController.abort();
-    status.set('STANDBY');
+    status.set('STOPPING');
   });
 
   clearBackupsIssues();

--- a/src/apps/main/remote-sync/handlers.ts
+++ b/src/apps/main/remote-sync/handlers.ts
@@ -227,7 +227,13 @@ ipcMain.handle('DELETE_ITEM_DRIVE', async (_, itemId: FilePlaceholderId | Folder
 ipcMain.handle('get-item-by-folder-uuid', async (_, folderUuid): Promise<ItemBackup[]> => {
   Logger.info('Getting items by folder uuid', folderUuid);
 
-  const { folders } = await fetchItems({ folderUuid, skipFiles: true });
+  const abortController = new AbortController();
+
+  const { folders } = await fetchItems({
+    folderUuid,
+    skipFiles: true,
+    abortSignal: abortController.signal,
+  });
 
   return folders.map((folder) => ({
     id: folder.id,

--- a/src/apps/renderer/components/Backups/DetailedDevicePill.tsx
+++ b/src/apps/renderer/components/Backups/DetailedDevicePill.tsx
@@ -8,15 +8,16 @@ import { ShowBackupsIssues } from './ShowBackupsIssues';
 import { DeviceContext } from '../../context/DeviceContext';
 import { BackupContext } from '../../context/BackupContext';
 import { useIssues } from '../../hooks/useIssues';
+import { BackupsStatus } from '@/apps/main/background-processes/backups/BackupsProcessStatus/BackupsStatus';
 
 interface DetailedDevicePillProps {
   showIssues: () => void;
 }
 
-function BackingUp() {
+function BackingUp({ backupStatus }: { backupStatus: BackupsStatus }) {
   return (
     <span className="flex flex-row items-center text-primary">
-      <ArrowCircleUp className="mr-2 text-primary" /> Backing up...
+      <ArrowCircleUp className="mr-2 text-primary" /> {backupStatus === 'STOPPING' ? 'Stopping backup...' : 'Backing up...'}
     </span>
   );
 }
@@ -49,7 +50,7 @@ export function DetailedDevicePill({ showIssues }: DetailedDevicePillProps) {
         <div className="grow">
           {selected?.name}
           <br />
-          {selected?.id === current?.id && thereIsProgress ? <BackingUp /> : <LastBackupMade />}
+          {selected?.id === current?.id && thereIsProgress ? <BackingUp backupStatus={backupStatus} /> : <LastBackupMade />}
         </div>
         {selected === current && thereIsProgress && <BackupsProgressPercentage progress={percentualProgress} />}
       </div>

--- a/src/apps/renderer/pages/Settings/Backups/SelectedFoldersSection.tsx
+++ b/src/apps/renderer/pages/Settings/Backups/SelectedFoldersSection.tsx
@@ -19,7 +19,7 @@ export function SelectedFoldersSection({ className, onGoToList }: SelectedFolder
   return (
     <section className={`${className}`}>
       <SectionHeader>{translate('settings.backups.selected-folders-title')}</SectionHeader>
-      <Button variant="secondary" disabled={!isBackupAvailable || backupStatus === 'RUNNING'} onClick={onGoToList} size="md">
+      <Button variant="secondary" disabled={!isBackupAvailable || backupStatus !== 'STANDBY'} onClick={onGoToList} size="md">
         {translate('settings.backups.select-folders')}
       </Button>
       <SecondaryText className="ml-2 inline">

--- a/src/apps/renderer/pages/Settings/Backups/StartBackup.tsx
+++ b/src/apps/renderer/pages/Settings/Backups/StartBackup.tsx
@@ -31,7 +31,7 @@ export function StartBackup({ className }: StartBackupProps) {
   return (
     <>
       <Button
-        className={`${className} hover:cursor-pointer`}
+        className={className}
         variant={backupStatus === 'STANDBY' ? 'primary' : 'danger'}
         size="md"
         onClick={() => {
@@ -46,7 +46,7 @@ export function StartBackup({ className }: StartBackupProps) {
             toggleConfirmation();
           }
         }}
-        disabled={backups.length === 0 || thereIsDownloadProgress}>
+        disabled={backups.length === 0 || thereIsDownloadProgress || backupStatus === 'STOPPING'}>
         {translate(`settings.backups.action.${backupStatus === 'STANDBY' ? 'start' : 'stop'}`)}
       </Button>
       <ConfirmationModal


### PR DESCRIPTION
## What

1. Add abort signal when fetching backup files and folders so it stops when stopping backups.
2. Add STOPPING backup status.
3. Set the backup status as STOPPING immediately when aborting backups.