### PR TITLE
[PB-4515] feat: add gmt+2 to logs

### DIFF
--- a/src/apps/main/logger.ts
+++ b/src/apps/main/logger.ts
@@ -1,6 +1,7 @@
 import { PATHS } from '@/core/electron/paths';
 import { ipcMain, shell } from 'electron';
 import ElectronLog from 'electron-log';
+import { logFormatter } from '@/core/utils/logFormatter';
 
 export function setupElectronLog() {
   ElectronLog.initialize();
@@ -14,8 +15,8 @@ export function setupElectronLog() {
   };
 
   ElectronLog.transports.file.maxSize = 150 * 1024 * 1024; // 150MB
-  ElectronLog.transports.file.format = '[{iso}] {text}';
-  ElectronLog.transports.console.format = '[{iso}] {text}';
+  ElectronLog.transports.file.format = logFormatter;
+  ElectronLog.transports.console.format = logFormatter;
   ElectronLog.transports.console.writeFn = ({ message }) => {
     if (message.level === 'debug') {
       // eslint-disable-next-line no-console

--- a/src/core/utils/convertUTCDateToGMT2.test.ts
+++ b/src/core/utils/convertUTCDateToGMT2.test.ts
@@ -1,0 +1,33 @@
+import { convertUTCDateToGMT2 } from './convertUTCDateToGMT2';
+
+describe('convertUTCDateToGMT2', () => {
+  it('should return a string in the format YYYY-MM-DD HH:mm:SS.SSS', () => {
+    const result = convertUTCDateToGMT2();
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}$/);
+  });
+
+  it('should use current date when no argument is passed', () => {
+    const now = new Date();
+    const expected = convertUTCDateToGMT2(now);
+    const actual = convertUTCDateToGMT2();
+    expect(actual).toBe(expected);
+  });
+
+  it('should correctly convert a specific UTC date to GMT+2', () => {
+    const input = new Date('2025-04-17T12:00:00.000Z'); // UTC
+    const result = convertUTCDateToGMT2(input);
+    expect(result).toBe('2025-04-17 14:00:00.000'); // +2h
+  });
+
+  it('should correctly convert and preserve milliseconds', () => {
+    const input = new Date('2025-04-17T23:59:59.987Z');
+    const result = convertUTCDateToGMT2(input);
+    expect(result).toBe('2025-04-18 01:59:59.987');
+  });
+
+  it('should correctly handle dates near midnight UTC', () => {
+    const date = new Date('2025-04-17T23:30:00.000Z'); // UTC
+    const result = convertUTCDateToGMT2(date);
+    expect(result).toBe('2025-04-18 01:30:00.000'); // next day in GMT+2
+  });
+});

--- a/src/core/utils/convertUTCDateToGMT2.ts
+++ b/src/core/utils/convertUTCDateToGMT2.ts
@@ -1,0 +1,17 @@
+/*
+ * formats a date to format YYYY-MM-DD HH:mm:SS.SSS
+ */
+const formatDate = (date: Date) => {
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  const padMs = (n: number) => n.toString().padStart(3, '0');
+  return (
+    `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())} ` +
+    `${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}.` +
+    `${padMs(date.getUTCMilliseconds())}`
+  );
+};
+
+export const convertUTCDateToGMT2 = (date = new Date()) => {
+  const gmt2Date = new Date(date.getTime() + 2 * 60 * 60 * 1000);
+  return formatDate(gmt2Date);
+};

--- a/src/core/utils/logFormatter.test.ts
+++ b/src/core/utils/logFormatter.test.ts
@@ -1,42 +1,38 @@
+import { mockProps } from 'tests/vitest/utils.helper.test';
 import { logFormatter } from './logFormatter';
 import { FormatParams } from 'electron-log';
 
 describe('logFormatter', () => {
   it('should include GMT+2 formatted timestamp and message data', () => {
-    const formatParams: FormatParams = {
+    const formatParams: FormatParams = mockProps<typeof logFormatter>({
       data: ['App started'],
       level: 'info',
-      logger: {} as any,
-      transport: {} as any,
       message: {
         data: ['App started'],
         level: 'info',
         date: new Date('2025-04-17T12:00:00.000Z'),
       },
-    };
-
+    });
     const result = logFormatter(formatParams);
 
     expect(result[0]).toBe('[2025-04-17 14:00:00.000]');
-    expect(result.slice(1)).toEqual(['App started']);
+    expect(result.slice(1)).toStrictEqual(['App started']);
   });
 
   it('should include all original data arguments after the timestamp', () => {
-    const formatParams: FormatParams = {
+    const formatParams: FormatParams = mockProps<typeof logFormatter>({
       data: ['User', 42, 'logged in'],
       level: 'info',
-      logger: {} as any,
-      transport: {} as any,
       message: {
         data: ['User', 42, 'logged in'],
         level: 'info',
         date: new Date('2025-04-17T10:00:00.000Z'),
       },
-    };
+    });
 
     const result = logFormatter(formatParams);
 
     expect(result[0]).toBe('[2025-04-17 12:00:00.000]');
-    expect(result.slice(1)).toEqual(['User', 42, 'logged in']);
+    expect(result.slice(1)).toStrictEqual(['User', 42, 'logged in']);
   });
 });

--- a/src/core/utils/logFormatter.test.ts
+++ b/src/core/utils/logFormatter.test.ts
@@ -1,0 +1,42 @@
+import { logFormatter } from './logFormatter';
+import { FormatParams } from 'electron-log';
+
+describe('logFormatter', () => {
+  it('should include GMT+2 formatted timestamp and message data', () => {
+    const formatParams: FormatParams = {
+      data: ['App started'],
+      level: 'info',
+      logger: {} as any,
+      transport: {} as any,
+      message: {
+        data: ['App started'],
+        level: 'info',
+        date: new Date('2025-04-17T12:00:00.000Z'),
+      },
+    };
+
+    const result = logFormatter(formatParams);
+
+    expect(result[0]).toBe('[2025-04-17 14:00:00.000]');
+    expect(result.slice(1)).toEqual(['App started']);
+  });
+
+  it('should include all original data arguments after the timestamp', () => {
+    const formatParams: FormatParams = {
+      data: ['User', 42, 'logged in'],
+      level: 'info',
+      logger: {} as any,
+      transport: {} as any,
+      message: {
+        data: ['User', 42, 'logged in'],
+        level: 'info',
+        date: new Date('2025-04-17T10:00:00.000Z'),
+      },
+    };
+
+    const result = logFormatter(formatParams);
+
+    expect(result[0]).toBe('[2025-04-17 12:00:00.000]');
+    expect(result.slice(1)).toEqual(['User', 42, 'logged in']);
+  });
+});

--- a/src/core/utils/logFormatter.ts
+++ b/src/core/utils/logFormatter.ts
@@ -1,0 +1,6 @@
+import { FormatParams } from 'electron-log';
+import { convertUTCDateToGMT2 } from '@/core/utils/convertUTCDateToGMT2';
+
+export const logFormatter = (message: FormatParams) => {
+  return [`[${convertUTCDateToGMT2(message.message.date)}]`, ...message.data];
+};


### PR DESCRIPTION
## What is changed
Added gmt+2 to the logs in order to have the same timezone as the servers.
----
### This would be the  'Previous' log system:
```bash
[2025-06-12T10:44:28.362Z] { level: 'debug', process: 'main', tag: 'BACKUPS', msg: 'Setting up backups' }
[2025-06-12T10:44:28.376Z] [BACKUPS] Start service
[2025-06-12T10:44:28.381Z] [BACKUPS] Backups ready
[2025-06-12T10:44:28.406Z] { level: 'debug', process: 'main', msg: 'User identified for error reporting' }
[2025-06-12T10:44:28.593Z] { level: 'debug', process: 'main', msg: 'Current root virtual drive', current: 'C:\\Users\\inxt\\InternxtDrive - xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\' }
[2025-06-12T10:44:28.596Z] { level: 'debug', process: 'main', msg: 'Add workspace to the folder store', rootId: xxx, rootUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' }
[2025-06-12T10:44:28.599Z] { level: 'debug', process: 'main', msg: '[MAIN] Spawn sync engine worker' }
[2025-06-12T10:44:30.074Z] { level: 'debug', process: 'main', msg: '[MAIN] Browser window loaded' }
[2025-06-12T10:44:30.087Z] { level: 'debug', process: 'main', msg: 'Get workspaces', retry: 1 }
[2025-06-12T10:44:30.497Z] { level: 'debug', process: 'main', msg: 'Current provider ids', currentProviderIds: [ '{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}' ] }
[2025-06-12T10:44:32.422Z] Discovered backup xxx
```
### This would be the 'NEW' log system:
```bash
[2025-06-12 12:52:38.899] { level: 'debug', process: 'main', tag: 'BACKUPS', msg: 'Setting up backups' }
[2025-06-12 12:52:38.934] [BACKUPS] Start service
[2025-06-12 12:52:38.959] [BACKUPS] Backups ready
[2025-06-12 12:52:38.982] { level: 'debug', process: 'main', msg: 'User identified for error reporting' }
[2025-06-12 12:52:39.206] { level: 'debug', process: 'main', msg: 'Current root virtual drive', current: 'C:\\Users\\inxt\\InternxtDrive - xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\' }
[2025-06-12 12:52:39.213] { level: 'debug', process: 'main', msg: 'Add workspace to the folder store',rootId: xxx, rootUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' }
[2025-06-12 12:52:39.221] { level: 'debug', process: 'main', msg: '[MAIN] Spawn sync engine worker' }
[2025-06-12 12:52:41.265] { level: 'debug', process: 'main', msg: '[MAIN] Browser window loaded' }
[2025-06-12 12:52:41.306] { level: 'debug', process: 'main', msg: 'Get workspaces', retry: 1 }
[2025-06-12 12:52:41.889] { level: 'debug', process: 'main', msg: 'Current provider ids',  currentProviderIds: [ '{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}' ] }
[2025-06-12 12:52:46.595] Discovered backup xxx
```

