### PR TITLE
Create file or folder in background sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "package": "ts-node .erb/scripts/clean.js && npm run build && electron-builder build --publish never",
     "init:dev": "pnpm install && node node_modules/electron/install.js && npm run build:dll && npm run reload-native-deps",
     "========== Code style ==========": "",
-    "lint": "eslint . --ext .ts,.tsx --max-warnings 538",
+    "lint": "eslint . --ext .ts,.tsx --max-warnings 541",
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier src --check",
     "format:fix": "prettier src --write",

--- a/src/apps/main/background-processes/spawn-default-sync-engine-worker.test.ts
+++ b/src/apps/main/background-processes/spawn-default-sync-engine-worker.test.ts
@@ -31,6 +31,7 @@ describe('spawn-default-sync-engine-worker', () => {
           queueManagerPath: '\\mock\\logs\\internxt-drive\\logs\\queue-manager-user-user_id.log',
           rootPath: '/mock/path',
           rootUuid: undefined,
+          userUuid: 'user_id',
           workspaceId: '',
           workspaceToken: '',
         },

--- a/src/apps/main/background-processes/sync-engine.ts
+++ b/src/apps/main/background-processes/sync-engine.ts
@@ -54,6 +54,7 @@ export async function spawnDefaultSyncEngineWorker() {
 
   const providerId = `{${user.uuid.toUpperCase()}}`;
   const config: Config = {
+    userUuid: user.uuid,
     providerId,
     rootPath: getRootVirtualDrive(),
     providerName: 'Internxt Drive',

--- a/src/apps/main/background-processes/sync-engine/services/spawn-sync-engine-worker.ts
+++ b/src/apps/main/background-processes/sync-engine/services/spawn-sync-engine-worker.ts
@@ -109,7 +109,7 @@ export async function spawnSyncEngineWorker({ config }: TProps) {
 
     scheduleSync({ worker });
 
-    addRemoteSyncManager({ workspaceId, worker });
+    addRemoteSyncManager({ config, workspaceId, worker });
   } catch (exc) {
     logger.error({
       msg: '[MAIN] Error loading sync engine worker for workspace',

--- a/src/apps/main/background-processes/sync-engine/services/spawn-workspace.ts
+++ b/src/apps/main/background-processes/sync-engine/services/spawn-workspace.ts
@@ -32,6 +32,7 @@ export async function spawnWorkspace({ workspace }: TProps) {
   });
 
   const config: Config = {
+    userUuid: user.uuid,
     mnemonic: mnemonic.toString(),
     providerId: workspace.providerId,
     rootPath: workspace.rootPath,

--- a/src/apps/main/database/entities/DriveFile.ts
+++ b/src/apps/main/database/entities/DriveFile.ts
@@ -2,7 +2,7 @@ import { Column, Entity, PrimaryColumn } from 'typeorm';
 
 @Entity('drive_file')
 export class DriveFile {
-  @Column({ nullable: false, type: 'varchar' })
+  @Column({ nullable: false, unique: true, type: 'varchar' })
   fileId!: string;
 
   @Column({ nullable: false, type: 'int' })

--- a/src/apps/main/database/entities/DriveFile.ts
+++ b/src/apps/main/database/entities/DriveFile.ts
@@ -2,7 +2,7 @@ import { Column, Entity, PrimaryColumn } from 'typeorm';
 
 @Entity('drive_file')
 export class DriveFile {
-  @Column({ nullable: false, unique: true, type: 'varchar' })
+  @Column({ nullable: false, type: 'varchar' })
   fileId!: string;
 
   @Column({ nullable: false, type: 'int' })

--- a/src/apps/main/remote-sync/RemoteSyncManager.ts
+++ b/src/apps/main/remote-sync/RemoteSyncManager.ts
@@ -5,12 +5,14 @@ import { TWorkerConfig } from '../background-processes/sync-engine/store';
 import { syncRemoteFiles } from './files/sync-remote-files';
 import { syncRemoteFolders } from './folders/sync-remote-folders';
 import { RemoteSyncModule } from '@/backend/features/remote-sync/remote-sync.module';
+import { Config } from '@/apps/sync-engine/config';
 
 export class RemoteSyncManager {
   status: RemoteSyncStatus = 'IDLE';
   totalFilesUnsynced: string[] = [];
 
   constructor(
+    public readonly context: Config,
     public readonly worker: TWorkerConfig,
     public readonly workspaceId: string,
   ) {}

--- a/src/apps/main/remote-sync/files/sync-remote-files.test.ts
+++ b/src/apps/main/remote-sync/files/sync-remote-files.test.ts
@@ -1,31 +1,30 @@
 import { mockDeep } from 'vitest-mock-extended';
 import { RemoteSyncManager } from '../RemoteSyncManager';
 import { deepMocked } from 'tests/vitest/utils.helper.test';
-import { getUserOrThrow } from '../../auth/service';
 import { syncRemoteFile } from './sync-remote-file';
 import { driveServerWip } from '@/infra/drive-server-wip/drive-server-wip.module';
 import { syncRemoteFiles } from './sync-remote-files';
 import { TWorkerConfig } from '../../background-processes/sync-engine/store';
 import { LokijsModule } from '@/infra/lokijs/lokijs.module';
+import { Config } from '@/apps/sync-engine/config';
 
 vi.mock(import('@/apps/main/util'));
-vi.mock(import('../../auth/service'));
 vi.mock(import('./sync-remote-file'));
 vi.mock(import('@/infra/drive-server-wip/drive-server-wip.module'));
 vi.mock(import('@/infra/lokijs/lokijs.module'));
 
 describe('sync-remote-files.service', () => {
-  const getUserOrThrowMock = deepMocked(getUserOrThrow);
   const syncRemoteFileMock = deepMocked(syncRemoteFile);
   const getFilesMock = deepMocked(driveServerWip.files.getFiles);
   const updateCheckpointMock = vi.mocked(LokijsModule.CheckpointsModule.updateCheckpoint);
 
+  const config = mockDeep<Config>();
+  config.userUuid = 'uuid';
   const worker = mockDeep<TWorkerConfig>();
-  const remoteSyncManager = new RemoteSyncManager(worker, '');
+  const remoteSyncManager = new RemoteSyncManager(config, worker, '');
 
   beforeEach(() => {
     vi.clearAllMocks();
-    getUserOrThrowMock.mockReturnValue({ uuid: 'uuid' });
   });
 
   it('If we fetch less than 50 files, then do not fetch again', async () => {

--- a/src/apps/main/remote-sync/files/sync-remote-files.ts
+++ b/src/apps/main/remote-sync/files/sync-remote-files.ts
@@ -1,7 +1,6 @@
 import { RemoteSyncManager } from '../RemoteSyncManager';
 import { logger } from '@/apps/shared/logger/logger';
 import { FETCH_LIMIT } from '../store';
-import { getUserOrThrow } from '../../auth/service';
 import { syncRemoteFile } from './sync-remote-file';
 import { driveServerWip } from '@/infra/drive-server-wip/drive-server-wip.module';
 import { LokijsModule } from '@/infra/lokijs/lokijs.module';
@@ -13,7 +12,6 @@ type TProps = {
 };
 
 export async function syncRemoteFiles({ self, from, offset = 0 }: TProps) {
-  const user = getUserOrThrow();
   let hasMore = true;
 
   while (hasMore) {
@@ -51,14 +49,14 @@ export async function syncRemoteFiles({ self, from, offset = 0 }: TProps) {
 
     await Promise.all(
       data.map(async (remoteFile) => {
-        await syncRemoteFile({ self, user, remoteFile });
+        await syncRemoteFile({ self, remoteFile });
       }),
     );
 
     const lastFile = data.at(-1);
     if (lastFile) {
       await LokijsModule.CheckpointsModule.updateCheckpoint({
-        userUuid: user.uuid,
+        userUuid: self.context.userUuid,
         workspaceId: self.workspaceId,
         type: 'file',
         plainName: lastFile.plainName,

--- a/src/apps/main/remote-sync/folders/sync-remote-folder.ts
+++ b/src/apps/main/remote-sync/folders/sync-remote-folder.ts
@@ -1,24 +1,18 @@
-import { User } from '../../types';
 import { RemoteSyncManager } from '../RemoteSyncManager';
-import { driveFoldersCollection } from '../store';
 import { logger } from '@/apps/shared/logger/logger';
 import { FolderStore } from './folder-store';
 import { Folder, FolderAttributes } from '@/context/virtual-drive/folders/domain/Folder';
 import { FolderDto } from '@/infra/drive-server-wip/out/dto';
+import { createOrUpdateFolder } from '@/backend/features/remote-sync/update-in-sqlite/create-or-update-folder';
 
 type TProps = {
   self: RemoteSyncManager;
-  user: User;
   remoteFolder: FolderDto;
 };
 
-export async function syncRemoteFolder({ self, user, remoteFolder }: TProps) {
+export async function syncRemoteFolder({ self, remoteFolder }: TProps) {
   try {
-    await driveFoldersCollection.createOrUpdate({
-      ...remoteFolder,
-      userUuid: user.uuid,
-      workspaceId: self.workspaceId,
-    });
+    await createOrUpdateFolder({ context: self.context, folderDto: remoteFolder });
 
     FolderStore.addFolder({
       workspaceId: self.workspaceId,

--- a/src/apps/main/remote-sync/folders/sync-remote-folders.test.ts
+++ b/src/apps/main/remote-sync/folders/sync-remote-folders.test.ts
@@ -1,31 +1,30 @@
 import { mockDeep } from 'vitest-mock-extended';
 import { RemoteSyncManager } from '../RemoteSyncManager';
 import { deepMocked } from 'tests/vitest/utils.helper.test';
-import { getUserOrThrow } from '../../auth/service';
 import { syncRemoteFolder } from './sync-remote-folder';
 import { driveServerWip } from '@/infra/drive-server-wip/drive-server-wip.module';
 import { syncRemoteFolders } from './sync-remote-folders';
 import { TWorkerConfig } from '../../background-processes/sync-engine/store';
 import { LokijsModule } from '@/infra/lokijs/lokijs.module';
+import { Config } from '@/apps/sync-engine/config';
 
 vi.mock(import('@/apps/main/util'));
-vi.mock(import('../../auth/service'));
 vi.mock(import('./sync-remote-folder'));
 vi.mock(import('@/infra/drive-server-wip/drive-server-wip.module'));
 vi.mock(import('@/infra/lokijs/lokijs.module'));
 
 describe('sync-remote-folders.service', () => {
-  const getUserOrThrowMock = deepMocked(getUserOrThrow);
   const syncRemoteFolderMock = deepMocked(syncRemoteFolder);
   const getFoldersMock = deepMocked(driveServerWip.folders.getFolders);
   const updateCheckpointMock = vi.mocked(LokijsModule.CheckpointsModule.updateCheckpoint);
 
+  const config = mockDeep<Config>();
+  config.userUuid = 'uuid';
   const worker = mockDeep<TWorkerConfig>();
-  const remoteSyncManager = new RemoteSyncManager(worker, '');
+  const remoteSyncManager = new RemoteSyncManager(config, worker, '');
 
   beforeEach(() => {
     vi.clearAllMocks();
-    getUserOrThrowMock.mockReturnValue({ uuid: 'uuid' });
   });
 
   it('If we fetch less than 50 files, then do not fetch again', async () => {

--- a/src/apps/main/remote-sync/folders/sync-remote-folders.ts
+++ b/src/apps/main/remote-sync/folders/sync-remote-folders.ts
@@ -1,7 +1,6 @@
 import { RemoteSyncManager } from '../RemoteSyncManager';
 import { logger } from '@/apps/shared/logger/logger';
 import { FETCH_LIMIT } from '../store';
-import { getUserOrThrow } from '../../auth/service';
 import { syncRemoteFolder } from './sync-remote-folder';
 import { driveServerWip } from '@/infra/drive-server-wip/drive-server-wip.module';
 import { LokijsModule } from '@/infra/lokijs/lokijs.module';
@@ -13,7 +12,6 @@ type TProps = {
 };
 
 export async function syncRemoteFolders({ self, from, offset = 0 }: TProps) {
-  const user = getUserOrThrow();
   let hasMore = true;
 
   while (hasMore) {
@@ -51,14 +49,14 @@ export async function syncRemoteFolders({ self, from, offset = 0 }: TProps) {
 
     await Promise.all(
       data.map(async (remoteFolder) => {
-        await syncRemoteFolder({ self, user, remoteFolder });
+        await syncRemoteFolder({ self, remoteFolder });
       }),
     );
 
     const lastFolder = data.at(-1);
     if (lastFolder) {
       await LokijsModule.CheckpointsModule.updateCheckpoint({
-        userUuid: user.uuid,
+        userUuid: self.context.userUuid,
         workspaceId: self.workspaceId,
         type: 'folder',
         plainName: lastFolder.plainName,

--- a/src/apps/main/remote-sync/handlers.ts
+++ b/src/apps/main/remote-sync/handlers.ts
@@ -16,9 +16,10 @@ import { getSyncStatus } from './services/broadcast-sync-status';
 import { FolderStore } from './folders/folder-store';
 import { fetchItems } from '@/apps/backups/fetch-items/fetch-items';
 import { ipcMainSyncEngine } from '@/apps/sync-engine/ipcMainSyncEngine';
+import { Config } from '@/apps/sync-engine/config';
 
-export function addRemoteSyncManager({ workspaceId, worker }: { workspaceId: string; worker: TWorkerConfig }) {
-  remoteSyncManagers.set(workspaceId, new RemoteSyncManager(worker, workspaceId));
+export function addRemoteSyncManager({ config, workspaceId, worker }: { config: Config; workspaceId: string; worker: TWorkerConfig }) {
+  remoteSyncManagers.set(workspaceId, new RemoteSyncManager(config, worker, workspaceId));
 }
 
 type UpdateFileInBatchInput = {

--- a/src/apps/sync-engine/config.ts
+++ b/src/apps/sync-engine/config.ts
@@ -1,6 +1,7 @@
 import { getUser } from '../main/auth/service';
 
 export type Config = {
+  userUuid: string;
   providerId: string;
   rootPath: string;
   rootUuid: string;
@@ -17,6 +18,7 @@ export type Config = {
 
 const emptyValues = (): Config => {
   return {
+    userUuid: '',
     providerId: '',
     rootPath: '',
     providerName: '',
@@ -42,6 +44,7 @@ const defaultValues = (): Config => {
   }
 
   return {
+    userUuid: user.uuid,
     providerId: config.providerId,
     rootPath: config.rootPath,
     providerName: config.providerName,

--- a/src/backend/features/remote-sync/sync-items-by-folder/update-file-statuses.test.ts
+++ b/src/backend/features/remote-sync/sync-items-by-folder/update-file-statuses.test.ts
@@ -1,15 +1,14 @@
-import { driveFilesCollection } from '@/apps/main/remote-sync/store';
 import { fetchFilesByFolder } from './fetch-files-by-folder';
 import { deepMocked, mockProps } from '@/tests/vitest/utils.helper.test';
 import { updateFileStatuses } from './update-file-statuses';
-import { In } from 'typeorm';
+import { createOrUpdateFile } from '../update-in-sqlite/create-or-update-file';
 
 vi.mock(import('./fetch-files-by-folder'));
-vi.mock(import('@/apps/main/remote-sync/store'));
+vi.mock(import('../update-in-sqlite/create-or-update-file'));
 
 describe('update-file-statuses', () => {
   const fetchFilesByFolderMock = deepMocked(fetchFilesByFolder);
-  const driveFilesCollectionMock = vi.mocked(driveFilesCollection);
+  const createOrUpdateFileMock = vi.mocked(createOrUpdateFile);
 
   it('should update file statuses', async () => {
     // Given
@@ -20,10 +19,10 @@ describe('update-file-statuses', () => {
     await updateFileStatuses(props);
 
     // Then
-    expect(driveFilesCollectionMock.updateInBatch).toBeCalledTimes(1);
-    expect(driveFilesCollectionMock.updateInBatch).toHaveBeenCalledWith({
-      payload: { status: 'EXISTS' },
-      where: { folderUuid: 'folderUuid', uuid: In(['uuid']) },
+    expect(createOrUpdateFileMock).toBeCalledTimes(1);
+    expect(createOrUpdateFileMock).toHaveBeenCalledWith({
+      context: props.context,
+      fileDto: { uuid: 'uuid' },
     });
   });
 });

--- a/src/backend/features/remote-sync/sync-items-by-folder/update-file-statuses.ts
+++ b/src/backend/features/remote-sync/sync-items-by-folder/update-file-statuses.ts
@@ -1,8 +1,7 @@
-import { driveFilesCollection } from '@/apps/main/remote-sync/store';
 import { fetchFilesByFolder } from './fetch-files-by-folder';
-import { In } from 'typeorm';
 import { logger } from '@/apps/shared/logger/logger';
 import { Config } from '@/apps/sync-engine/config';
+import { createOrUpdateFile } from '../update-in-sqlite/create-or-update-file';
 
 type TProps = {
   context: Config;
@@ -12,17 +11,8 @@ type TProps = {
 export async function updateFileStatuses({ context, folderUuid }: TProps) {
   try {
     const files = await fetchFilesByFolder({ context, folderUuid });
-    const fileUuids = files.map((file) => file.uuid);
-
-    /**
-     * v2.5.6 Daniel Jiménez
-     * TODO: this should be improved because it can happen that the file doesn't exist in our local database,
-     * and we have to create it, however, we cannot do that yet because we will break the checkpoint
-     */
-    await driveFilesCollection.updateInBatch({
-      payload: { status: 'EXISTS' },
-      where: { folderUuid, uuid: In(fileUuids) },
-    });
+    const promises = files.map((fileDto) => createOrUpdateFile({ context, fileDto }));
+    await Promise.all(promises);
   } catch (exc) {
     logger.error({
       tag: 'SYNC-ENGINE',

--- a/src/backend/features/remote-sync/sync-items-by-folder/update-folder-statuses.test.ts
+++ b/src/backend/features/remote-sync/sync-items-by-folder/update-folder-statuses.test.ts
@@ -1,15 +1,14 @@
-import { driveFoldersCollection } from '@/apps/main/remote-sync/store';
 import { fetchFoldersByFolder } from './fetch-folders-by-folder';
 import { deepMocked, mockProps } from '@/tests/vitest/utils.helper.test';
 import { updateFolderStatuses } from './update-folder-statuses';
-import { In } from 'typeorm';
+import { createOrUpdateFolder } from '../update-in-sqlite/create-or-update-folder';
 
 vi.mock(import('./fetch-folders-by-folder'));
-vi.mock(import('@/apps/main/remote-sync/store'));
+vi.mock(import('../update-in-sqlite/create-or-update-folder'));
 
 describe('update-folder-statuses', () => {
   const fetchFoldersByFolderMock = deepMocked(fetchFoldersByFolder);
-  const driveFoldersCollectionMock = vi.mocked(driveFoldersCollection);
+  const createOrUpdateFolderMock = vi.mocked(createOrUpdateFolder);
 
   it('should update folder statuses', async () => {
     // Given
@@ -20,10 +19,10 @@ describe('update-folder-statuses', () => {
     await updateFolderStatuses(props);
 
     // Then
-    expect(driveFoldersCollectionMock.updateInBatch).toBeCalledTimes(1);
-    expect(driveFoldersCollectionMock.updateInBatch).toHaveBeenCalledWith({
-      payload: { status: 'EXISTS' },
-      where: { parentUuid: 'folderUuid', uuid: In(['uuid']) },
+    expect(createOrUpdateFolderMock).toBeCalledTimes(1);
+    expect(createOrUpdateFolderMock).toHaveBeenCalledWith({
+      context: props.context,
+      folderDto: { uuid: 'uuid' },
     });
   });
 });

--- a/src/backend/features/remote-sync/update-in-sqlite/create-or-update-file.ts
+++ b/src/backend/features/remote-sync/update-in-sqlite/create-or-update-file.ts
@@ -1,0 +1,18 @@
+import { driveFilesCollection } from '@/apps/main/remote-sync/store';
+import { Config } from '@/apps/sync-engine/config';
+import { FileDto } from '@/infra/drive-server-wip/out/dto';
+
+type TProps = {
+  context: Config;
+  fileDto: FileDto;
+};
+
+export async function createOrUpdateFile({ context, fileDto }: TProps) {
+  return await driveFilesCollection.createOrUpdate({
+    ...fileDto,
+    size: Number(fileDto.size),
+    isDangledStatus: false,
+    userUuid: context.userUuid,
+    workspaceId: context.workspaceId,
+  });
+}

--- a/src/backend/features/remote-sync/update-in-sqlite/create-or-update-folder.ts
+++ b/src/backend/features/remote-sync/update-in-sqlite/create-or-update-folder.ts
@@ -1,0 +1,16 @@
+import { driveFoldersCollection } from '@/apps/main/remote-sync/store';
+import { Config } from '@/apps/sync-engine/config';
+import { FolderDto } from '@/infra/drive-server-wip/out/dto';
+
+type TProps = {
+  context: Config;
+  folderDto: FolderDto;
+};
+
+export async function createOrUpdateFolder({ context, folderDto }: TProps) {
+  return await driveFoldersCollection.createOrUpdate({
+    ...folderDto,
+    userUuid: context.userUuid,
+    workspaceId: context.workspaceId,
+  });
+}


### PR DESCRIPTION
## What

Now, since we have move the checkpoint outside the sqlite database we can create files and folders in the background sync.