### PR TITLE
Create or update items immediately

### DIFF
--- a/src/apps/main/background-processes/sync-engine/services/spawn-sync-engine-worker.ts
+++ b/src/apps/main/background-processes/sync-engine/services/spawn-sync-engine-worker.ts
@@ -8,7 +8,7 @@ import { monitorHealth } from './monitor-health';
 import { logger } from '@/apps/shared/logger/logger';
 import { scheduleSync } from './schedule-sync';
 import { addRemoteSyncManager } from '@/apps/main/remote-sync/handlers';
-import { RemoteSyncModule } from '@/backend/features/remote-sync/remote-sync.module';
+// import { RemoteSyncModule } from '@/backend/features/remote-sync/remote-sync.module';
 
 type TProps = {
   config: Config;
@@ -47,10 +47,10 @@ export async function spawnSyncEngineWorker({ config }: TProps) {
    * Since we can have a different status in our local database that in remote,
    * we want to run also this sync in background to update the statuses.
    */
-  void RemoteSyncModule.syncItemsByFolder({
-    rootFolderUuid: config.rootUuid,
-    context: config,
-  });
+  // void RemoteSyncModule.syncItemsByFolder({
+  //   rootFolderUuid: config.rootUuid,
+  //   context: config,
+  // });
 
   try {
     const browserWindow = new BrowserWindow({

--- a/src/apps/main/background-processes/sync-engine/services/spawn-sync-engine-worker.ts
+++ b/src/apps/main/background-processes/sync-engine/services/spawn-sync-engine-worker.ts
@@ -8,8 +8,7 @@ import { monitorHealth } from './monitor-health';
 import { logger } from '@/apps/shared/logger/logger';
 import { scheduleSync } from './schedule-sync';
 import { addRemoteSyncManager } from '@/apps/main/remote-sync/handlers';
-// import { RemoteSyncModule } from '@/backend/features/remote-sync/remote-sync.module';
-// import { LokijsModule } from '@/infra/lokijs/lokijs.module';
+import { RemoteSyncModule } from '@/backend/features/remote-sync/remote-sync.module';
 
 type TProps = {
   config: Config;
@@ -48,10 +47,10 @@ export async function spawnSyncEngineWorker({ config }: TProps) {
    * Since we can have a different status in our local database that in remote,
    * we want to run also this sync in background to update the statuses.
    */
-  // void RemoteSyncModule.syncItemsByFolder({
-  //   rootFolderUuid: config.rootUuid,
-  //   context: config,
-  // });
+  void RemoteSyncModule.syncItemsByFolder({
+    rootFolderUuid: config.rootUuid,
+    context: config,
+  });
 
   try {
     const browserWindow = new BrowserWindow({

--- a/src/apps/main/database/entities/DriveFile.ts
+++ b/src/apps/main/database/entities/DriveFile.ts
@@ -4,15 +4,19 @@ import { Column, Entity, PrimaryColumn } from 'typeorm';
 export type FileUuid = Brand<string, 'FileUuid'>;
 export type ContentsId = Brand<string, 'ContentsId'>;
 export type SimpleDriveFile = {
+  id: number;
   uuid: FileUuid;
   name: string;
   nameWithExtension: string;
   extension: string;
+  parentId: number;
   parentUuid: string | undefined;
-  contentsId: string;
+  contentsId: ContentsId;
   size: number;
   createdAt: string;
   updatedAt: string;
+  modificationTime: string;
+  status: 'EXISTS' | 'TRASHED' | 'DELETED';
 };
 
 @Entity('drive_file')

--- a/src/apps/main/database/entities/DriveFolder.ts
+++ b/src/apps/main/database/entities/DriveFolder.ts
@@ -3,10 +3,13 @@ import { Brand } from '@/context/shared/domain/Brand';
 
 export type FolderUuid = Brand<string, 'FolderUuid'>;
 export type SimpleDriveFolder = {
+  id: number;
+  uuid: FolderUuid;
   name: string;
   parentUuid: string | undefined;
   createdAt: string;
   updatedAt: string;
+  status: 'EXISTS' | 'TRASHED' | 'DELETED';
 };
 
 @Entity('drive_folder')

--- a/src/apps/main/remote-sync/folders/folder-store.test.ts
+++ b/src/apps/main/remote-sync/folders/folder-store.test.ts
@@ -7,7 +7,7 @@ describe('folder-store', () => {
   const FolderMock = vi.mocked(Folder);
 
   const workspaceId = '';
-  const plainName = 'file.png';
+  const name = 'file.png';
 
   beforeAll(() => {
     FolderMock.decryptName.mockImplementation(({ name }) => name);
@@ -19,16 +19,16 @@ describe('folder-store', () => {
 
   it('Should return path if all folders exist using parentId', () => {
     FolderStore.addWorkspace({ workspaceId, rootId: 109862695, rootUuid: 'c133cad4-4bf4-4b03-86eb-794aeed82302' });
-    FolderStore.addFolder({ folderId: 110355389, parentId: 109862695, parentUuid: null, name: 'folder', workspaceId });
-    FolderStore.addFolder({ folderId: 110750590, parentId: 110355389, parentUuid: null, name: 'folder2', workspaceId });
+    FolderStore.addFolder({ folderId: 110355389, parentId: 109862695, parentUuid: undefined, name: 'folder', workspaceId });
+    FolderStore.addFolder({ folderId: 110750590, parentId: 110355389, parentUuid: undefined, name: 'folder2', workspaceId });
 
-    const path1 = FolderStore.getFolderPath({ workspaceId, parentId: 109862695, parentUuid: null, plainName });
+    const path1 = FolderStore.getFolderPath({ workspaceId, parentId: 109862695, parentUuid: undefined, name });
     expect(path1.relativePath).toBe('/file.png');
 
-    const path2 = FolderStore.getFolderPath({ workspaceId, parentId: 110355389, parentUuid: null, plainName });
+    const path2 = FolderStore.getFolderPath({ workspaceId, parentId: 110355389, parentUuid: undefined, name });
     expect(path2.relativePath).toBe('/folder/file.png');
 
-    const path3 = FolderStore.getFolderPath({ workspaceId, parentId: 110750590, parentUuid: null, plainName });
+    const path3 = FolderStore.getFolderPath({ workspaceId, parentId: 110750590, parentUuid: undefined, name });
     expect(path3.relativePath).toBe('/folder/folder2/file.png');
   });
 
@@ -55,14 +55,14 @@ describe('folder-store', () => {
       workspaceId,
       parentId: 109862695,
       parentUuid: 'c133cad4-4bf4-4b03-86eb-794aeed82302',
-      plainName,
+      name,
     });
     expect(path1.relativePath).toBe('/file.png');
 
-    const path2 = FolderStore.getFolderPath({ workspaceId, parentId: 110355389, parentUuid: null, plainName });
+    const path2 = FolderStore.getFolderPath({ workspaceId, parentId: 110355389, parentUuid: undefined, name });
     expect(path2.relativePath).toBe('/folder/file.png');
 
-    const path3 = FolderStore.getFolderPath({ workspaceId, parentId: 110750590, parentUuid: null, plainName });
+    const path3 = FolderStore.getFolderPath({ workspaceId, parentId: 110750590, parentUuid: undefined, name });
     expect(path3.relativePath).toBe('/folder/folder2/file.png');
   });
 
@@ -72,12 +72,12 @@ describe('folder-store', () => {
     FolderStore.addFolder({
       folderId: 110753145,
       parentId: 0,
-      parentUuid: null,
+      parentUuid: undefined,
       name: 'wrong_parent_id',
       workspaceId,
     });
 
-    expect(() => FolderStore.getFolderPath({ workspaceId, parentId: 0, parentUuid: null, plainName })).toThrowError();
-    expect(() => FolderStore.getFolderPath({ workspaceId, parentId: 110753145, parentUuid: null, plainName })).toThrowError();
+    expect(() => FolderStore.getFolderPath({ workspaceId, parentId: 0, parentUuid: undefined, name })).toThrowError();
+    expect(() => FolderStore.getFolderPath({ workspaceId, parentId: 110753145, parentUuid: undefined, name })).toThrowError();
   });
 });

--- a/src/apps/main/remote-sync/folders/folder-store.ts
+++ b/src/apps/main/remote-sync/folders/folder-store.ts
@@ -12,8 +12,8 @@ export class FolderStore {
         number,
         {
           parentId: number;
-          parentUuid: string | null;
-          plainName: string;
+          parentUuid: string | undefined;
+          name: string;
         }
       >;
     }
@@ -39,29 +39,26 @@ export class FolderStore {
     parentId,
     parentUuid,
     name,
-    plainName,
   }: {
     workspaceId: string;
     folderId: number;
     parentId: number;
-    parentUuid: string | null;
+    parentUuid: string | undefined;
     name: string;
-    plainName?: string;
   }) {
-    const decryptedName = Folder.decryptName({ plainName, name, parentId });
-    FolderStore.store[workspaceId].folders[folderId] = { parentId, parentUuid, plainName: decryptedName };
+    FolderStore.store[workspaceId].folders[folderId] = { parentId, parentUuid, name };
   }
 
   static getFolderPath({
     workspaceId,
     parentId,
     parentUuid,
-    plainName,
+    name,
   }: {
     workspaceId: string;
     parentId: number;
-    parentUuid: string | null;
-    plainName: string;
+    parentUuid: string | undefined;
+    name: string;
   }) {
     const paths: string[] = [];
     const workspace = FolderStore.store[workspaceId];
@@ -75,12 +72,12 @@ export class FolderStore {
         throw new Error(`Folder not found for workspaceId "${workspaceId}" and parentId "${parentId}"`);
       }
 
-      paths.unshift(folder.plainName);
+      paths.unshift(folder.name);
       parentId = folder.parentId;
       parentUuid = folder.parentUuid;
     }
 
-    const relativePath = posix.join(...paths, plainName);
+    const relativePath = posix.join(...paths, name);
 
     return {
       relativePath: posix.sep + relativePath,

--- a/src/apps/main/remote-sync/folders/folder-store.ts
+++ b/src/apps/main/remote-sync/folders/folder-store.ts
@@ -1,5 +1,4 @@
 import { logger } from '@/apps/shared/logger/logger';
-import { Folder } from '@/context/virtual-drive/folders/domain/Folder';
 import { posix } from 'path';
 
 export class FolderStore {

--- a/src/apps/main/remote-sync/handlers.ts
+++ b/src/apps/main/remote-sync/handlers.ts
@@ -114,8 +114,7 @@ async function updateRemoteSync({ workspaceId }: { workspaceId: string }) {
         workspaceId,
         folderId: folder.id,
         parentId: folder.parentId!,
-        parentUuid: folder.parentUuid ?? null,
-        plainName: folder.plainName,
+        parentUuid: folder.parentUuid,
         name: folder.name,
       });
     });

--- a/src/backend/features/remote-sync/sync-items-by-folder/update-file-statuses.test.ts
+++ b/src/backend/features/remote-sync/sync-items-by-folder/update-file-statuses.test.ts
@@ -22,7 +22,7 @@ describe('update-file-statuses', () => {
     expect(createOrUpdateFileMock).toBeCalledTimes(1);
     expect(createOrUpdateFileMock).toHaveBeenCalledWith({
       context: props.context,
-      fileDto: { uuid: 'uuid' },
+      fileDto: { uuid: 'uuid', updatedAt: '2000-01-01T00:00:00Z' },
     });
   });
 });

--- a/src/backend/features/remote-sync/sync-items-by-folder/update-file-statuses.ts
+++ b/src/backend/features/remote-sync/sync-items-by-folder/update-file-statuses.ts
@@ -11,7 +11,15 @@ type TProps = {
 export async function updateFileStatuses({ context, folderUuid }: TProps) {
   try {
     const files = await fetchFilesByFolder({ context, folderUuid });
-    const promises = files.map((fileDto) => createOrUpdateFile({ context, fileDto }));
+    const promises = files.map((fileDto) =>
+      createOrUpdateFile({
+        context,
+        fileDto: {
+          ...fileDto,
+          updatedAt: '2000-01-01T00:00:00Z',
+        },
+      }),
+    );
     await Promise.all(promises);
   } catch (exc) {
     logger.error({

--- a/src/backend/features/remote-sync/sync-items-by-folder/update-folder-statuses.test.ts
+++ b/src/backend/features/remote-sync/sync-items-by-folder/update-folder-statuses.test.ts
@@ -22,7 +22,7 @@ describe('update-folder-statuses', () => {
     expect(createOrUpdateFolderMock).toBeCalledTimes(1);
     expect(createOrUpdateFolderMock).toHaveBeenCalledWith({
       context: props.context,
-      folderDto: { uuid: 'uuid' },
+      folderDto: { uuid: 'uuid', updatedAt: '2000-01-01T00:00:00Z' },
     });
   });
 });

--- a/src/backend/features/remote-sync/sync-items-by-folder/update-folder-statuses.ts
+++ b/src/backend/features/remote-sync/sync-items-by-folder/update-folder-statuses.ts
@@ -15,7 +15,15 @@ export async function updateFolderStatuses({ context, folderUuid }: TProps) {
     const folders = await fetchFoldersByFolder({ context, folderUuid });
     folderUuids = folders.map((folder) => folder.uuid);
 
-    const promises = folders.map((folderDto) => createOrUpdateFolder({ context, folderDto }));
+    const promises = folders.map((folderDto) =>
+      createOrUpdateFolder({
+        context,
+        folderDto: {
+          ...folderDto,
+          updatedAt: '2000-01-01T00:00:00Z',
+        },
+      }),
+    );
     await Promise.all(promises);
   } catch (exc) {
     logger.error({

--- a/src/backend/features/remote-sync/update-in-sqlite/create-or-update-file.ts
+++ b/src/backend/features/remote-sync/update-in-sqlite/create-or-update-file.ts
@@ -1,6 +1,6 @@
-import { driveFilesCollection } from '@/apps/main/remote-sync/store';
 import { Config } from '@/apps/sync-engine/config';
 import { FileDto } from '@/infra/drive-server-wip/out/dto';
+import { SqliteModule } from '@/infra/sqlite/sqlite.module';
 
 type TProps = {
   context: Config;
@@ -8,11 +8,13 @@ type TProps = {
 };
 
 export async function createOrUpdateFile({ context, fileDto }: TProps) {
-  return await driveFilesCollection.createOrUpdate({
-    ...fileDto,
-    size: Number(fileDto.size),
-    isDangledStatus: false,
-    userUuid: context.userUuid,
-    workspaceId: context.workspaceId,
+  return await SqliteModule.FileModule.createOrUpdate({
+    file: {
+      ...fileDto,
+      size: Number(fileDto.size),
+      isDangledStatus: false,
+      userUuid: context.userUuid,
+      workspaceId: context.workspaceId,
+    },
   });
 }

--- a/src/backend/features/remote-sync/update-in-sqlite/create-or-update-folder.ts
+++ b/src/backend/features/remote-sync/update-in-sqlite/create-or-update-folder.ts
@@ -1,6 +1,6 @@
-import { driveFoldersCollection } from '@/apps/main/remote-sync/store';
 import { Config } from '@/apps/sync-engine/config';
 import { FolderDto } from '@/infra/drive-server-wip/out/dto';
+import { SqliteModule } from '@/infra/sqlite/sqlite.module';
 
 type TProps = {
   context: Config;
@@ -8,9 +8,11 @@ type TProps = {
 };
 
 export async function createOrUpdateFolder({ context, folderDto }: TProps) {
-  return await driveFoldersCollection.createOrUpdate({
-    ...folderDto,
-    userUuid: context.userUuid,
-    workspaceId: context.workspaceId,
+  return await SqliteModule.FolderModule.createOrUpdate({
+    folder: {
+      ...folderDto,
+      userUuid: context.userUuid,
+      workspaceId: context.workspaceId,
+    },
   });
 }

--- a/src/context/virtual-drive/files/infrastructure/HttpRemoteFileSystem.ts
+++ b/src/context/virtual-drive/files/infrastructure/HttpRemoteFileSystem.ts
@@ -14,7 +14,7 @@ export class HttpRemoteFileSystem {
     private readonly workspaceId?: string | null,
   ) {}
 
-  async persist(offline: OfflineFile): Promise<FileAttributes> {
+  async persist(offline: OfflineFile) {
     try {
       const body = {
         bucket: this.bucket,
@@ -33,6 +33,7 @@ export class HttpRemoteFileSystem {
       if (!data) throw error;
 
       return {
+        dto: data,
         id: data.id,
         uuid: data.uuid,
         contentsId: data.fileId,
@@ -65,7 +66,7 @@ export class HttpRemoteFileSystem {
     }
   }
 
-  async getFileByPath(filePath: string): Promise<null | FileAttributes> {
+  async getFileByPath(filePath: string) {
     const response = await client.GET('/files/meta', {
       params: {
         query: {
@@ -84,7 +85,8 @@ export class HttpRemoteFileSystem {
     const data = response.data;
     if (data.status !== FileStatuses.EXISTS) return null;
 
-    const attributes: FileAttributes = {
+    const attributes = {
+      dto: data,
       id: data.id,
       uuid: data.uuid,
       contentsId: data.fileId,

--- a/src/context/virtual-drive/files/infrastructure/HttpRemoteFileSystem.ts
+++ b/src/context/virtual-drive/files/infrastructure/HttpRemoteFileSystem.ts
@@ -1,5 +1,4 @@
 import { EncryptionVersion } from '@internxt/sdk/dist/drive/storage/types';
-import { FileAttributes } from '../domain/File';
 import { FileStatuses } from '../domain/FileStatus';
 import { OfflineFile, OfflineFileAttributes } from '../domain/OfflineFile';
 import { Service } from 'diod';

--- a/src/context/virtual-drive/folders/application/FolderCreator.test.ts
+++ b/src/context/virtual-drive/folders/application/FolderCreator.test.ts
@@ -13,6 +13,8 @@ import { FolderNotFoundError } from '../domain/errors/FolderNotFoundError';
 import { v4 } from 'uuid';
 import { createRelativePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
 import { FolderUuid as TFolderUuid } from '@/apps/main/database/entities/DriveFolder';
+import { partialSpyOn } from '@/tests/vitest/utils.helper.test';
+import { ipcRendererSqlite } from '@/infra/sqlite/ipc/ipc-renderer';
 
 vi.mock(import('@/infra/node-win/node-win.module'));
 
@@ -21,6 +23,7 @@ describe('Folder Creator', () => {
   const remote = mockDeep<HttpRemoteFolderSystem>();
   const virtualDrive = mockDeep<VirtualDrive>();
   const getFolderUuid = deepMocked(NodeWin.getFolderUuid);
+  const invokeMock = partialSpyOn(ipcRendererSqlite, 'invoke');
 
   const SUT = new FolderCreator(repository, remote, virtualDrive);
 
@@ -29,6 +32,7 @@ describe('Folder Creator', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    invokeMock.mockResolvedValue({});
   });
 
   it('If placeholderId is not found, throw error', async () => {
@@ -45,7 +49,7 @@ describe('Folder Creator', () => {
   it('If placeholder id is found, create folder', async () => {
     // Given
     const folder = FolderMother.fromPartial({ parentId: 1, parentUuid: v4(), path });
-    remote.persist.mockResolvedValueOnce(folder.attributes());
+    remote.persist.mockResolvedValueOnce(folder.attributes() as any);
     getFolderUuid.mockReturnValueOnce({ data: folder.parentUuid as TFolderUuid });
 
     // When

--- a/src/context/virtual-drive/folders/application/FolderCreator.ts
+++ b/src/context/virtual-drive/folders/application/FolderCreator.ts
@@ -8,6 +8,7 @@ import { FolderNotFoundError } from '../domain/errors/FolderNotFoundError';
 import { getConfig } from '@/apps/sync-engine/config';
 import { NodeWin } from '@/infra/node-win/node-win.module';
 import { PlatformPathConverter } from '../../shared/application/PlatformPathConverter';
+import { ipcRendererSqlite } from '@/infra/sqlite/ipc/ipc-renderer';
 
 type TProps = {
   path: string;
@@ -38,8 +39,18 @@ export class FolderCreator {
       path,
     });
 
-    const folder = Folder.from(attributes);
+    const { error } = await ipcRendererSqlite.invoke('folderCreateOrUpdate', {
+      folder: {
+        ...attributes.dto,
+        userUuid: getConfig().userUuid,
+        workspaceId: getConfig().workspaceId,
+        updatedAt: '2000-01-01T00:00:00Z',
+      },
+    });
 
+    if (error) throw error;
+
+    const folder = Folder.from(attributes);
     this.repository.add(folder);
 
     this.virtualDrive.convertToPlaceholder({

--- a/src/context/virtual-drive/folders/infrastructure/HttpRemoteFolderSystem.ts
+++ b/src/context/virtual-drive/folders/infrastructure/HttpRemoteFolderSystem.ts
@@ -8,7 +8,7 @@ import { driveServerWip } from '@/infra/drive-server-wip/drive-server-wip.module
 export class HttpRemoteFolderSystem {
   constructor(private readonly workspaceId?: string) {}
 
-  async persist(offline: { basename: string; parentUuid: string; path: string }): Promise<FolderAttributes> {
+  async persist(offline: { basename: string; parentUuid: string; path: string }) {
     if (!offline.basename) {
       throw new Error('Bad folder name');
     }
@@ -27,6 +27,7 @@ export class HttpRemoteFolderSystem {
       if (!data) throw error;
 
       return {
+        dto: data,
         id: data.id,
         uuid: data.uuid,
         parentId: data.parentId,
@@ -53,13 +54,14 @@ export class HttpRemoteFolderSystem {
     }
   }
 
-  private async existFolder(offline: { parentUuid: string; basename: string; path: string }): Promise<FolderAttributes> {
+  private async existFolder(offline: { parentUuid: string; basename: string; path: string }) {
     const { data, error } = await driveServerWip.folders.existsFolder({
       parentUuid: offline.parentUuid,
       basename: offline.basename,
     });
     if (!data) throw error;
     return {
+      dto: data.existentFolders[0],
       ...data.existentFolders[0],
       path: offline.path,
     };

--- a/src/core/electron/paths.ts
+++ b/src/core/electron/paths.ts
@@ -3,9 +3,9 @@ import { join } from 'path';
 
 const HOME_FOLDER_PATH = app.getPath('home');
 const SQLITE_DB = join(app.getPath('appData'), 'internxt-drive', 'internxt_desktop.db');
-const CHECKPOINTS_DB = join(app.getPath('appData'), 'internxt-drive', 'checkpoints.json');
+const LOKIJS_DB = join(app.getPath('appData'), 'internxt-drive', 'internxt_desktop.json');
 const LOGS = join(app.getPath('appData'), 'internxt-drive', 'logs');
 const ELECTRON_LOGS = join(LOGS, 'drive-desktop.ans');
 const ELECTRON_IMPORTANT_LOGS = join(LOGS, 'drive-desktop-important.ans');
 
-export const PATHS = { HOME_FOLDER_PATH, SQLITE_DB, CHECKPOINTS_DB, LOGS, ELECTRON_LOGS, ELECTRON_IMPORTANT_LOGS };
+export const PATHS = { HOME_FOLDER_PATH, SQLITE_DB, LOKIJS_DB, LOGS, ELECTRON_LOGS, ELECTRON_IMPORTANT_LOGS };

--- a/src/infra/lokijs/databases/checkpoints/checkpoints-db.ts
+++ b/src/infra/lokijs/databases/checkpoints/checkpoints-db.ts
@@ -2,7 +2,7 @@ import Loki from 'lokijs';
 import { TCheckpoints } from './checkpoints-schema';
 import { PATHS } from '@/core/electron/paths';
 
-const db = new Loki(PATHS.CHECKPOINTS_DB, {
+const db = new Loki(PATHS.LOKIJS_DB, {
   autoload: true,
   autosave: true,
   autosaveInterval: 5000,

--- a/src/infra/sqlite/ipc/ipc-main.ts
+++ b/src/infra/sqlite/ipc/ipc-main.ts
@@ -10,11 +10,23 @@ export function setupIpcSqlite() {
     return await SqliteModule.FileModule.getByName(props);
   });
 
+  void ipcMainSqlite.handle('folderGetByName', async (_, props) => {
+    return await SqliteModule.FolderModule.getByName(props);
+  });
+
   void ipcMainSqlite.handle('fileGetByUuid', async (_, props) => {
     return await SqliteModule.FileModule.getByUuid(props);
   });
 
   void ipcMainSqlite.handle('folderGetByUuid', async (_, props) => {
     return await SqliteModule.FolderModule.getByUuid(props);
+  });
+
+  void ipcMainSqlite.handle('fileCreateOrUpdate', async (_, props) => {
+    return await SqliteModule.FileModule.createOrUpdate(props);
+  });
+
+  void ipcMainSqlite.handle('folderCreateOrUpdate', async (_, props) => {
+    return await SqliteModule.FolderModule.createOrUpdate(props);
   });
 }

--- a/src/infra/sqlite/ipc/ipc.ts
+++ b/src/infra/sqlite/ipc/ipc.ts
@@ -4,12 +4,21 @@ export type FromProcess = {
   fileGetByName: (
     props: Parameters<typeof SqliteModule.FileModule.getByName>[0],
   ) => Awaited<ReturnType<typeof SqliteModule.FileModule.getByName>>;
+  folderGetByName: (
+    props: Parameters<typeof SqliteModule.FolderModule.getByName>[0],
+  ) => Awaited<ReturnType<typeof SqliteModule.FolderModule.getByName>>;
   fileGetByUuid: (
     props: Parameters<typeof SqliteModule.FileModule.getByUuid>[0],
   ) => Awaited<ReturnType<typeof SqliteModule.FileModule.getByUuid>>;
   folderGetByUuid: (
     props: Parameters<typeof SqliteModule.FolderModule.getByUuid>[0],
   ) => Awaited<ReturnType<typeof SqliteModule.FolderModule.getByUuid>>;
+  fileCreateOrUpdate: (
+    props: Parameters<typeof SqliteModule.FileModule.createOrUpdate>[0],
+  ) => Awaited<ReturnType<typeof SqliteModule.FileModule.createOrUpdate>>;
+  folderCreateOrUpdate: (
+    props: Parameters<typeof SqliteModule.FolderModule.createOrUpdate>[0],
+  ) => Awaited<ReturnType<typeof SqliteModule.FolderModule.createOrUpdate>>;
 };
 
 export type FromMain = {};

--- a/src/infra/sqlite/services/drive-file.ts
+++ b/src/infra/sqlite/services/drive-file.ts
@@ -29,11 +29,6 @@ export class DriveFileCollection {
     return result;
   }
 
-  async createOrUpdate(payload: DriveFile) {
-    const result = await fileRepository.save(payload);
-    return result;
-  }
-
   async updateInBatch({ where, payload }: UpdateInBatchPayload) {
     const user = getUserOrThrow();
     const match = await fileRepository.update({ ...this.parseWhere(where), userUuid: user.uuid }, payload);

--- a/src/infra/sqlite/services/drive-folder.ts
+++ b/src/infra/sqlite/services/drive-folder.ts
@@ -29,11 +29,6 @@ export class DriveFolderCollection {
     return result;
   }
 
-  async createOrUpdate(payload: DriveFolder) {
-    const result = await folderRepository.save(payload);
-    return result;
-  }
-
   async updateInBatch(input: UpdateInBatchPayload) {
     const { where, payload } = input;
     const user = getUserOrThrow();

--- a/src/infra/sqlite/services/file.module.ts
+++ b/src/infra/sqlite/services/file.module.ts
@@ -1,3 +1,4 @@
+import { createOrUpdate } from './file/create-or-update';
 import { getByName } from './file/get-by-name';
 import { getByUuid } from './file/get-by-uuid';
 import { updateByUuid } from './file/update-by-uuid';
@@ -5,5 +6,6 @@ import { updateByUuid } from './file/update-by-uuid';
 export const FileModule = {
   getByName,
   getByUuid,
+  createOrUpdate,
   updateByUuid,
 };

--- a/src/infra/sqlite/services/file/create-or-update.test.ts
+++ b/src/infra/sqlite/services/file/create-or-update.test.ts
@@ -1,0 +1,38 @@
+import * as fileDecryptName from '@/context/virtual-drive/files/domain/file-decrypt-name';
+import { fileRepository } from '../drive-file';
+import { mockProps, partialSpyOn } from '@/tests/vitest/utils.helper.test';
+import { createOrUpdate } from './create-or-update';
+
+describe('create-or-update', () => {
+  const saveMock = partialSpyOn(fileRepository, 'save');
+  const fileDecryptNameSpy = partialSpyOn(fileDecryptName, 'fileDecryptName');
+
+  const props = mockProps<typeof createOrUpdate>({});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    fileDecryptNameSpy.mockImplementation(({ encryptedName }) => ({
+      name: encryptedName,
+      nameWithExtension: encryptedName,
+    }));
+  });
+
+  it('should return UNKNOWN when error is thrown', async () => {
+    // Given
+    saveMock.mockRejectedValue(new Error());
+    // When
+    const { error } = await createOrUpdate(props);
+    // Then
+    expect(error?.code).toBe('UNKNOWN');
+  });
+
+  it('should return file', async () => {
+    // Given
+    saveMock.mockResolvedValue({});
+    // When
+    const { data } = await createOrUpdate(props);
+    // Then
+    expect(data).toBeDefined();
+  });
+});

--- a/src/infra/sqlite/services/file/create-or-update.ts
+++ b/src/infra/sqlite/services/file/create-or-update.ts
@@ -1,0 +1,25 @@
+import { fileRepository } from '../drive-file';
+import { logger } from '@/apps/shared/logger/logger';
+import { parseData } from './parse-data';
+import { DriveFile } from '@/apps/main/database/entities/DriveFile';
+import { SqliteError } from '../common/sqlite-error';
+
+type Props = {
+  file: DriveFile;
+};
+
+export async function createOrUpdate({ file }: Props) {
+  try {
+    const data = await fileRepository.save(file);
+
+    return { data: parseData({ data }) };
+  } catch (exc) {
+    logger.error({
+      msg: 'Error creating or updating file',
+      file,
+      exc,
+    });
+
+    return { error: new SqliteError('UNKNOWN', exc) };
+  }
+}

--- a/src/infra/sqlite/services/file/parse-data.ts
+++ b/src/infra/sqlite/services/file/parse-data.ts
@@ -1,4 +1,4 @@
-import { DriveFile, FileUuid, SimpleDriveFile } from '@/apps/main/database/entities/DriveFile';
+import { ContentsId, DriveFile, FileUuid, SimpleDriveFile } from '@/apps/main/database/entities/DriveFile';
 import { fileDecryptName } from '@/context/virtual-drive/files/domain/file-decrypt-name';
 
 type TProps = {
@@ -14,14 +14,18 @@ export function parseData({ data }: TProps) {
   });
 
   return {
+    id: data.id,
     uuid: data.uuid as FileUuid,
     name,
     nameWithExtension,
     extension: data.type,
+    parentId: data.folderId,
     parentUuid: data.folderUuid,
-    contentsId: data.fileId,
+    contentsId: data.fileId as ContentsId,
     size: data.size,
     createdAt: data.createdAt,
     updatedAt: data.updatedAt,
+    modificationTime: data.modificationTime,
+    status: data.status,
   } satisfies SimpleDriveFile;
 }

--- a/src/infra/sqlite/services/folder.module.ts
+++ b/src/infra/sqlite/services/folder.module.ts
@@ -1,7 +1,11 @@
 import { getByUuid } from './folder/get-by-uuid';
 import { updateByUuid } from './folder/update-by-uuid';
+import { createOrUpdate } from './folder/create-or-update';
+import { getByName } from './folder/get-by-name';
 
 export const FolderModule = {
+  getByName,
   getByUuid,
+  createOrUpdate,
   updateByUuid,
 };

--- a/src/infra/sqlite/services/folder/create-or-update.test.ts
+++ b/src/infra/sqlite/services/folder/create-or-update.test.ts
@@ -1,0 +1,35 @@
+import { folderRepository } from '../drive-folder';
+import { mockProps, partialSpyOn } from '@/tests/vitest/utils.helper.test';
+import { createOrUpdate } from './create-or-update';
+import { Folder } from '@/context/virtual-drive/folders/domain/Folder';
+
+describe('create-or-update', () => {
+  const saveMock = partialSpyOn(folderRepository, 'save');
+  const decryptNameSpy = partialSpyOn(Folder, 'decryptName');
+
+  const props = mockProps<typeof createOrUpdate>({});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    decryptNameSpy.mockImplementation(({ name }) => name);
+  });
+
+  it('should return UNKNOWN when error is thrown', async () => {
+    // Given
+    saveMock.mockRejectedValue(new Error());
+    // When
+    const { error } = await createOrUpdate(props);
+    // Then
+    expect(error?.code).toBe('UNKNOWN');
+  });
+
+  it('should return folder', async () => {
+    // Given
+    saveMock.mockResolvedValue({});
+    // When
+    const { data } = await createOrUpdate(props);
+    // Then
+    expect(data).toBeDefined();
+  });
+});

--- a/src/infra/sqlite/services/folder/create-or-update.ts
+++ b/src/infra/sqlite/services/folder/create-or-update.ts
@@ -1,0 +1,25 @@
+import { logger } from '@/apps/shared/logger/logger';
+import { parseData } from './parse-data';
+import { DriveFolder } from '@/apps/main/database/entities/DriveFolder';
+import { SqliteError } from '../common/sqlite-error';
+import { folderRepository } from '../drive-folder';
+
+type Props = {
+  folder: DriveFolder;
+};
+
+export async function createOrUpdate({ folder }: Props) {
+  try {
+    const data = await folderRepository.save(folder);
+
+    return { data: parseData({ data }) };
+  } catch (exc) {
+    logger.error({
+      msg: 'Error creating or updating folder',
+      folder,
+      exc,
+    });
+
+    return { error: new SqliteError('UNKNOWN', exc) };
+  }
+}

--- a/src/infra/sqlite/services/folder/get-by-name.test.ts
+++ b/src/infra/sqlite/services/folder/get-by-name.test.ts
@@ -42,7 +42,7 @@ describe('get-by-name', () => {
     expect(data).toBeDefined();
     expect(findOneSpy).toBeCalledWith({
       where: expect.objectContaining({
-        plainName: 'folder',
+        name: 'folder',
         status: 'EXISTS',
       }),
     });

--- a/src/infra/sqlite/services/folder/get-by-name.test.ts
+++ b/src/infra/sqlite/services/folder/get-by-name.test.ts
@@ -1,0 +1,50 @@
+import { folderRepository } from '../drive-folder';
+import { mockProps, partialSpyOn } from '@/tests/vitest/utils.helper.test';
+import { getByName } from './get-by-name';
+import { Folder } from '@/context/virtual-drive/folders/domain/Folder';
+
+describe('get-by-name', () => {
+  const findOneSpy = partialSpyOn(folderRepository, 'findOne');
+  const decryptNameSpy = partialSpyOn(Folder, 'decryptName');
+
+  const props = mockProps<typeof getByName>({ name: 'folder' });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    decryptNameSpy.mockImplementation(({ name }) => name);
+  });
+
+  it('should return NOT_FOUND when folder is not found', async () => {
+    // Given
+    findOneSpy.mockResolvedValue(null);
+    // When
+    const { error } = await getByName(props);
+    // Then
+    expect(error?.code).toBe('NOT_FOUND');
+  });
+
+  it('should return UNKNOWN when error is thrown', async () => {
+    // Given
+    findOneSpy.mockRejectedValue(new Error());
+    // When
+    const { error } = await getByName(props);
+    // Then
+    expect(error?.code).toBe('UNKNOWN');
+  });
+
+  it('should return folder', async () => {
+    // Given
+    findOneSpy.mockResolvedValue({ name: 'name' });
+    // When
+    const { data } = await getByName(props);
+    // Then
+    expect(data).toBeDefined();
+    expect(findOneSpy).toBeCalledWith({
+      where: expect.objectContaining({
+        plainName: 'folder',
+        status: 'EXISTS',
+      }),
+    });
+  });
+});

--- a/src/infra/sqlite/services/folder/get-by-name.ts
+++ b/src/infra/sqlite/services/folder/get-by-name.ts
@@ -1,0 +1,35 @@
+import { folderRepository } from '../drive-folder';
+import { FolderUuid } from '@/apps/main/database/entities/DriveFolder';
+import { logger } from '@/apps/shared/logger/logger';
+import { basename, extname } from 'path';
+import { parseData } from './parse-data';
+import { SingleItemError } from '../common/single-item-error';
+
+type Props = {
+  parentUuid: FolderUuid;
+  name: string;
+};
+
+export async function getByName({ parentUuid, name }: Props) {
+  try {
+    const data = await folderRepository.findOne({
+      where: {
+        parentUuid,
+        name,
+        status: 'EXISTS',
+      },
+    });
+
+    if (data) return { data: parseData({ data }) };
+    return { error: new SingleItemError('NOT_FOUND') };
+  } catch (exc) {
+    logger.error({
+      msg: 'Error getting folder by name',
+      parentUuid,
+      name,
+      exc,
+    });
+
+    return { error: new SingleItemError('UNKNOWN', exc) };
+  }
+}

--- a/src/infra/sqlite/services/folder/get-by-uuid.ts
+++ b/src/infra/sqlite/services/folder/get-by-uuid.ts
@@ -3,6 +3,7 @@ import { SimpleDriveFolder } from '@/apps/main/database/entities/DriveFolder';
 import { Folder } from '@/context/virtual-drive/folders/domain/Folder';
 import { logger } from '@/apps/shared/logger/logger';
 import { SingleItemError } from '../common/single-item-error';
+import { parseData } from './parse-data';
 
 type Props = {
   uuid: string;
@@ -12,22 +13,7 @@ export async function getByUuid({ uuid }: Props) {
   try {
     const data = await folderRepository.findOne({ where: { uuid } });
 
-    if (data) {
-      const name = Folder.decryptName({
-        name: data.name,
-        parentId: data.parentId,
-        plainName: data.plainName,
-      });
-
-      return {
-        data: {
-          name,
-          parentUuid: data.parentUuid,
-          createdAt: data.createdAt,
-          updatedAt: data.updatedAt,
-        } satisfies SimpleDriveFolder,
-      };
-    }
+    if (data) return { data: parseData({ data }) };
 
     return { error: new SingleItemError('NOT_FOUND') };
   } catch (exc) {

--- a/src/infra/sqlite/services/folder/parse-data.ts
+++ b/src/infra/sqlite/services/folder/parse-data.ts
@@ -1,0 +1,24 @@
+import { DriveFolder, FolderUuid, SimpleDriveFolder } from '@/apps/main/database/entities/DriveFolder';
+import { Folder } from '@/context/virtual-drive/folders/domain/Folder';
+
+type TProps = {
+  data: DriveFolder;
+};
+
+export function parseData({ data }: TProps) {
+  const name = Folder.decryptName({
+    name: data.name,
+    parentId: data.parentId,
+    plainName: data.plainName,
+  });
+
+  return {
+    id: data.id,
+    uuid: data.uuid as FolderUuid,
+    name,
+    parentUuid: data.parentUuid,
+    createdAt: data.createdAt,
+    updatedAt: data.updatedAt,
+    status: data.status,
+  } satisfies SimpleDriveFolder;
+}


### PR DESCRIPTION
## What

Extract methods createOrUpdate from file and folder inside the infra in it's own file. Now, when we create a new item in our local drive, we also store the created item in the sqlite without a real updateAt so we don't lose the checkpoint. We also create the method getByName in folder that is going to help for looking for a deleted folder (since we cannot longer use the file explorer to obatin the uuid)