### PR TITLE
Move from ans to log in logger

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -85,10 +85,7 @@ We are only going to use events for IPC.
 
 ---
 
-We are going to start open telemetry and store the logs in S3 has a cost. That's why:
-
-- Use logger.debug and logger.warn for anything that shouldn't be stored in S3 (most logs).
-- Use logger.info, logger.error, and logger.fatal for a small number of logs (only the most important ones).
+Use logger.error for errors that should be logged in `drive-desktop-important.log` and logger.warn for all other errors. Almost all errors should be logged with logger.error.
 
 ### Comments
 

--- a/src/apps/backups/Backups.ts
+++ b/src/apps/backups/Backups.ts
@@ -52,7 +52,7 @@ export class Backup {
     });
 
     if (filesDiff.dangled.size > 0) {
-      logger.info({
+      logger.debug({
         msg: 'Dangling files found, handling them',
         tag: 'BACKUPS',
       });

--- a/src/apps/main/antivirus/antivirus-manager/get-active-antivirus-engine.test.ts
+++ b/src/apps/main/antivirus/antivirus-manager/get-active-antivirus-engine.test.ts
@@ -67,7 +67,7 @@ describe('getActiveEngine', () => {
     expect(result).toBe(mockNewEngine);
     expect(mockManager.currentEngine).toBe(mockNewEngine);
     expect(mockManager.currentType).toBe('windows-defender');
-    expect(loggerMock.info).toBeCalledWith(
+    expect(loggerMock.debug).toBeCalledWith(
       expect.objectContaining({
         msg: expect.stringContaining('Antivirus engine switched'),
       }),

--- a/src/apps/main/antivirus/antivirus-manager/get-active-antivirus-engine.ts
+++ b/src/apps/main/antivirus/antivirus-manager/get-active-antivirus-engine.ts
@@ -29,7 +29,7 @@ export async function getActiveEngine({ self }: { self: AntivirusManager }) {
     self.currentEngine = await createEngine({ type: selectedType });
     self.currentType = selectedType;
 
-    logger.info({
+    logger.debug({
       tag: 'ANTIVIRUS',
       msg: 'Antivirus engine switched',
     });

--- a/src/apps/main/antivirus/antivirus-manager/select-antivirus-engine.test.ts
+++ b/src/apps/main/antivirus/antivirus-manager/select-antivirus-engine.test.ts
@@ -18,7 +18,7 @@ describe('selectAntivirusEngine', () => {
     // Then
     expect(result).toBe('windows-defender');
     expect(isWindowsDefenderActiveMock).toBeCalled();
-    expect(loggerMock.info).toBeCalledWith(
+    expect(loggerMock.debug).toBeCalledWith(
       expect.objectContaining({
         msg: expect.stringContaining('Default antivirus selected as engine'),
       }),
@@ -37,7 +37,7 @@ describe('selectAntivirusEngine', () => {
     expect(result).toBe('clamav');
     expect(isWindowsDefenderActiveMock).toBeCalled();
     expect(initializeClamAVMock).toBeCalled();
-    expect(loggerMock.info).toBeCalledWith(
+    expect(loggerMock.debug).toBeCalledWith(
       expect.objectContaining({
         msg: expect.stringContaining('ClamAV'),
       }),

--- a/src/apps/main/antivirus/antivirus-manager/select-antivirus-engine.ts
+++ b/src/apps/main/antivirus/antivirus-manager/select-antivirus-engine.ts
@@ -10,7 +10,7 @@ export async function selectAntivirusEngine() {
   });
 
   if (await isWindowsDefenderRealTimeProtectionActive()) {
-    logger.info({
+    logger.debug({
       tag: 'ANTIVIRUS',
       msg: 'Default antivirus selected as engine',
     });
@@ -21,7 +21,7 @@ export async function selectAntivirusEngine() {
   if (!clamavAvailable) {
     const { antivirusEnabled } = await initializeClamAV();
     if (antivirusEnabled) {
-      logger.info({
+      logger.debug({
         tag: 'ANTIVIRUS',
         msg: 'ClamAV selected as fallback antivirus',
       });

--- a/src/apps/main/device/service.ts
+++ b/src/apps/main/device/service.ts
@@ -72,13 +72,13 @@ export async function fetchDevice(deviceUuid: string) {
 
   if (data) {
     const device = decryptDeviceName(data);
-    logger.info({ tag: 'BACKUPS', msg: 'Found device', device: device.name });
+    logger.debug({ tag: 'BACKUPS', msg: 'Found device', device: device.name });
     return { data: device };
   }
 
   if (error?.code === 'NOT_FOUND') {
     const msg = `Device not found for deviceUuid: ${deviceUuid}`;
-    logger.info({ tag: 'BACKUPS', msg });
+    logger.debug({ tag: 'BACKUPS', msg });
     addUnknownDeviceIssue(new Error(msg));
     return { data: null };
   } else {
@@ -98,7 +98,7 @@ async function tryCreateDevice(deviceName: string) {
 
   if (error?.code === 'ALREADY_EXISTS') {
     return {
-      error: logger.info({
+      error: logger.debug({
         tag: 'BACKUPS',
         msg: 'Device name already exists',
         deviceName,
@@ -120,7 +120,7 @@ export async function createUniqueDevice(attempts = 1000) {
   const nameVariants = [baseName, ...Array.from({ length: attempts }, (_, i) => `${baseName} (${i + 1})`)];
 
   for (const name of nameVariants) {
-    logger.info({ tag: 'BACKUPS', msg: `Trying to create device with name "${name}"` });
+    logger.debug({ tag: 'BACKUPS', msg: `Trying to create device with name "${name}"` });
     const { data, error } = await tryCreateDevice(name);
 
     if (data) return { data };
@@ -485,7 +485,7 @@ export async function changeBackupPath(currentPath: string): Promise<string | nu
   const newFolderName = path.basename(chosenPath);
 
   if (oldFolderName !== newFolderName) {
-    logger.info({ tag: 'BACKUPS', msg: 'Renaming backup', existingBackup });
+    logger.debug({ tag: 'BACKUPS', msg: 'Renaming backup', existingBackup });
 
     const folderUuid = await new BackupFolderUuid().getBackupFolderUuid({ backup: existingBackup });
 

--- a/src/apps/main/logger.ts
+++ b/src/apps/main/logger.ts
@@ -21,11 +21,15 @@ export function setupElectronLog() {
    */
   ElectronLog.transports.file.maxSize = 1024 * 1024 * 1024;
   ElectronLog.transports.file.format = logFormatter;
-  ElectronLog.transports.console.format = logFormatter;
+  /**
+   * v2.5.6 Daniel Jiménez
+   * Levels: silly < debug < verbose < info < log < warn < error
+   */
+  ElectronLog.transports.file.level = 'debug';
   ElectronLog.transports.console.writeFn = ({ message }) => {
-    if (message.level === 'debug') {
+    if (message.level === 'silly') {
       // eslint-disable-next-line no-console
-      console.log(`${message.data}`);
+      console.log(...message.data);
     }
   };
 

--- a/src/apps/main/main.ts
+++ b/src/apps/main/main.ts
@@ -83,7 +83,7 @@ logger.debug({ msg: 'Starting app', version: INTERNXT_VERSION, isPackaged: app.i
 async function checkForUpdates() {
   autoUpdater.logger = {
     debug: (msg) => logger.debug({ msg: `AutoUpdater: ${msg}` }),
-    info: (msg) => logger.info({ msg: `AutoUpdater: ${msg}` }),
+    info: (msg) => logger.debug({ msg: `AutoUpdater: ${msg}` }),
     error: (msg) => logger.error({ msg: `AutoUpdater: ${msg}` }),
     warn: (msg) => logger.warn({ msg: `AutoUpdater: ${msg}` }),
   };

--- a/src/apps/main/network/get-file-info.ts
+++ b/src/apps/main/network/get-file-info.ts
@@ -8,7 +8,7 @@ type Props = {
 };
 
 export async function getFileInfo({ bucketId, fileId, opts }: Props): Promise<FileInfo> {
-  logger.info({ tag: 'BACKUPS', msg: `Fetching file info for bucketId downloadV1: ${bucketId}, fileId: ${fileId}` });
+  logger.debug({ tag: 'BACKUPS', msg: `Fetching file info for bucketId downloadV1: ${bucketId}, fileId: ${fileId}` });
   const url = `${process.env.BRIDGE_URL}/buckets/${bucketId}/files/${fileId}/info`;
   const res = await fetch(url, {
     method: 'GET',

--- a/src/apps/renderer/hooks/backups/useBackups.tsx
+++ b/src/apps/renderer/hooks/backups/useBackups.tsx
@@ -38,13 +38,13 @@ export function useBackups(): BackupContextProps {
     } else {
       backups = await window.electron.getBackupsFromDevice(selected, selected.id === current?.id);
     }
-    window.electron.logger.info({ msg: 'Backups fetched', length: backups.length });
+    window.electron.logger.debug({ msg: 'Backups fetched', length: backups.length });
     setBackups(backups);
   }
 
   const validateIfBackupExists = async () => {
     const existsBackup = devices.some((device) => device.hasBackups);
-    window.electron.logger.info({
+    window.electron.logger.debug({
       msg: 'Backup exists',
       devices: devices.map((d) => d.name),
       existsBackup,

--- a/src/apps/sync-engine/dependency-injection/common/virtualDrive.ts
+++ b/src/apps/sync-engine/dependency-injection/common/virtualDrive.ts
@@ -20,9 +20,6 @@ export class DependencyInjectionVirtualDrive {
         debug(body) {
           logger.debug({ tag: 'NODE-WIN', ...body, workspaceId });
         },
-        info(body) {
-          logger.info({ tag: 'NODE-WIN', ...body, workspaceId });
-        },
         warn(body) {
           logger.warn({ tag: 'NODE-WIN', ...body, workspaceId });
         },

--- a/src/backend/features/auth/services/logout.service.test.ts
+++ b/src/backend/features/auth/services/logout.service.test.ts
@@ -71,6 +71,6 @@ describe('logout service', () => {
     expect(saveConfigModule.saveConfig).not.toHaveBeenCalled();
     expect(resetConfigModule.resetConfig).not.toHaveBeenCalled();
     expect(resetCredentialsModule.resetCredentials).not.toHaveBeenCalled();
-    expect(loggerMock.info).not.toHaveBeenCalled();
+    expect(loggerMock.debug).not.toHaveBeenCalled();
   });
 });

--- a/src/backend/features/auth/services/logout.service.ts
+++ b/src/backend/features/auth/services/logout.service.ts
@@ -7,7 +7,7 @@ import { areCredentialsAlreadyReseted } from './utils/are-credentials-already-re
 
 export async function logout() {
   if (!areCredentialsAlreadyReseted()) {
-    logger.info({
+    logger.debug({
       tag: 'AUTH',
       msg: 'Logging out',
     });
@@ -23,7 +23,7 @@ export async function logout() {
     saveConfig();
     resetConfig();
     resetCredentials();
-    logger.info({
+    logger.debug({
       tag: 'AUTH',
       msg: 'User logged out',
     });

--- a/src/backend/features/remote-notifications/in/process-web-socket-event.test.ts
+++ b/src/backend/features/remote-notifications/in/process-web-socket-event.test.ts
@@ -1,4 +1,3 @@
-import { beforeEach } from 'vitest';
 import { processWebSocketEvent } from '@/backend/features/remote-notifications/in/process-web-socket-event';
 import { debouncedSynchronization } from '@/apps/main/remote-sync/handlers';
 import { loggerMock } from '@/tests/vitest/mocks.helper.test';
@@ -20,7 +19,6 @@ describe('processWebSocketEvent', () => {
 
     await processWebSocketEvent({ data: event });
     expect(loggerMock.debug).toHaveBeenCalledTimes(1);
-    expect(loggerMock.info).not.toHaveBeenCalled();
     expect(debouncedSynchronizationMock).not.toHaveBeenCalled();
   });
 
@@ -31,8 +29,7 @@ describe('processWebSocketEvent', () => {
 
     await processWebSocketEvent({ data: event });
     expect(debouncedSynchronizationMock).toHaveBeenCalledTimes(1);
-    expect(loggerMock.info).toHaveBeenCalledWith({ msg: 'Remote notification received', data: event });
-    expect(loggerMock.debug).not.toHaveBeenCalled();
+    expect(loggerMock.debug).toHaveBeenCalledWith({ msg: 'Remote notification received', data: event });
   });
 
   it('should call debouncedSynchronization if schema is valid and clientId is not drive-desktop-windows', async () => {
@@ -46,7 +43,6 @@ describe('processWebSocketEvent', () => {
 
     await processWebSocketEvent({ data: event });
     expect(debouncedSynchronizationMock).toHaveBeenCalledTimes(1);
-    expect(loggerMock.info).toHaveBeenCalledWith({ msg: 'Remote notification received', data: event });
-    expect(loggerMock.debug).not.toHaveBeenCalled();
+    expect(loggerMock.debug).toHaveBeenCalledWith({ msg: 'Remote notification received', data: event });
   });
 });

--- a/src/backend/features/remote-notifications/in/process-web-socket-event.ts
+++ b/src/backend/features/remote-notifications/in/process-web-socket-event.ts
@@ -15,7 +15,7 @@ export async function processWebSocketEvent({ data }: { data: unknown }) {
       payload: event.payload,
     });
   } else {
-    logger.info({ msg: 'Remote notification received', data });
+    logger.debug({ msg: 'Remote notification received', data });
     await debouncedSynchronization();
   }
 }

--- a/src/context/virtual-drive/files/infrastructure/HttpRemoteFileSystem.ts
+++ b/src/context/virtual-drive/files/infrastructure/HttpRemoteFileSystem.ts
@@ -108,12 +108,12 @@ export class HttpRemoteFileSystem {
       throw new Error('Failed to generate new contents id');
     }
 
-    logger.info({
+    logger.debug({
       msg: `New contents id generated ${newContentsId}, path: ${attributes.path}`,
     });
     await driveServerWip.storage.deleteFile({ fileId: attributes.contentsId });
 
-    logger.info({
+    logger.debug({
       msg: `Deleted file with contents id ${attributes.contentsId}, path: ${attributes.path}`,
     });
 
@@ -127,7 +127,7 @@ export class HttpRemoteFileSystem {
         isDeleted = true;
         break;
       }
-      logger.info({
+      logger.debug({
         msg: `File not deleted yet, path: ${attributes.path}`,
       });
     }
@@ -138,7 +138,7 @@ export class HttpRemoteFileSystem {
     const offlineFile = OfflineFile.from({ ...attributes, contentsId: newContentsId });
 
     const persistedFile = await this.persist(offlineFile);
-    logger.info({
+    logger.debug({
       msg: `File persisted with new contents id ${newContentsId}, path: ${attributes.path}`,
     });
 

--- a/src/core/electron/paths.ts
+++ b/src/core/electron/paths.ts
@@ -5,7 +5,14 @@ const HOME_FOLDER_PATH = app.getPath('home');
 const SQLITE_DB = join(app.getPath('appData'), 'internxt-drive', 'internxt_desktop.db');
 const LOKIJS_DB = join(app.getPath('appData'), 'internxt-drive', 'internxt_desktop.json');
 const LOGS = join(app.getPath('appData'), 'internxt-drive', 'logs');
-const ELECTRON_LOGS = join(LOGS, 'drive-desktop.ans');
-const ELECTRON_IMPORTANT_LOGS = join(LOGS, 'drive-desktop-important.ans');
+const ELECTRON_LOGS = join(LOGS, 'drive-desktop.log');
+const ELECTRON_IMPORTANT_LOGS = join(LOGS, 'drive-desktop-important.log');
 
-export const PATHS = { HOME_FOLDER_PATH, SQLITE_DB, LOKIJS_DB, LOGS, ELECTRON_LOGS, ELECTRON_IMPORTANT_LOGS };
+export const PATHS = {
+  HOME_FOLDER_PATH,
+  SQLITE_DB,
+  LOKIJS_DB,
+  LOGS,
+  ELECTRON_LOGS,
+  ELECTRON_IMPORTANT_LOGS,
+};

--- a/src/node-win/logger.ts
+++ b/src/node-win/logger.ts
@@ -5,7 +5,6 @@ type TBody = {
 
 export type TLogger = {
   debug: (body: TBody) => void;
-  info: (body: TBody) => void;
   warn: (body: TBody) => void;
   error: (body: TBody) => void;
 };


### PR DESCRIPTION
## What

Basically we are going to remove `ans` because when the size of the file is big it takes too much time to load colors. Also, using the extension .log already uses colors in vscode.