### PR TITLE
Solve antivirus call stack error

### DIFF
--- a/src/apps/main/antivirus/ManualSystemScan.ts
+++ b/src/apps/main/antivirus/ManualSystemScan.ts
@@ -191,14 +191,9 @@ class ManualSystemScan {
         pathNames = [userSystemPath.path];
       }
 
-      const allFilePaths: string[] = [];
-
-      await Promise.all(
-        pathNames.map(async (p) => {
-          const filePaths = await getFilesFromDirectory({ rootFolder: p });
-          allFilePaths.push(...filePaths);
-        }),
-      );
+      const promises = pathNames.map((p) => getFilesFromDirectory({ rootFolder: p }));
+      const result = await Promise.all(promises);
+      const allFilePaths = result.flat();
 
       this.totalItemsToScan = allFilePaths.length;
 
@@ -227,7 +222,11 @@ class ManualSystemScan {
       this.finishScan(currentSession);
     } catch (error) {
       if (!isPermissionError(error)) {
-        throw error;
+        throw logger.error({
+          tag: 'ANTIVIRUS',
+          msg: 'Error during manual scan',
+          exc: error,
+        });
       }
       this.resetCounters();
       await this.manualQueue?.drain();

--- a/src/apps/main/antivirus/utils/get-files-from-directory.ts
+++ b/src/apps/main/antivirus/utils/get-files-from-directory.ts
@@ -8,6 +8,12 @@ type TProps = {
 };
 
 export async function getFilesFromDirectory({ rootFolder }: TProps) {
+  logger.debug({
+    tag: 'ANTIVIRUS',
+    msg: 'Getting files from directory',
+    rootFolder,
+  });
+
   const isFolder = await PathTypeChecker.isFolder(rootFolder);
   if (!isFolder) return [];
 

--- a/src/apps/main/main.ts
+++ b/src/apps/main/main.ts
@@ -156,9 +156,9 @@ eventBus.on('USER_LOGGED_IN', async () => {
     } else if (widget) {
       widget.show();
     }
-  } catch (error) {
-    Logger.error(error);
-    reportError(error as Error);
+  } catch (exc) {
+    logger.error({ msg: 'Error logging in', exc });
+    reportError(exc as Error);
   }
 });
 


### PR DESCRIPTION
## What

We had a problem that when reading some folders the antivirus was throwing an error because of reaching the call stack.