### PR TITLE
Get items by workspace id

### DIFF
--- a/src/apps/main/database/entities/DriveFile.ts
+++ b/src/apps/main/database/entities/DriveFile.ts
@@ -1,10 +1,10 @@
+import { AbsolutePath, RelativePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
 import { Brand } from '@/context/shared/domain/Brand';
 import { Column, Entity, PrimaryColumn } from 'typeorm';
 
 export type FileUuid = Brand<string, 'FileUuid'>;
 export type ContentsId = Brand<string, 'ContentsId'>;
 export type SimpleDriveFile = {
-  id: number;
   uuid: FileUuid;
   name: string;
   nameWithExtension: string;
@@ -17,6 +17,10 @@ export type SimpleDriveFile = {
   updatedAt: string;
   modificationTime: string;
   status: 'EXISTS' | 'TRASHED' | 'DELETED';
+};
+export type ExtendedDriveFile = SimpleDriveFile & {
+  path: RelativePath;
+  absolutePath: AbsolutePath;
 };
 
 @Entity('drive_file')

--- a/src/apps/main/database/entities/DriveFolder.ts
+++ b/src/apps/main/database/entities/DriveFolder.ts
@@ -1,15 +1,19 @@
 import { Column, Entity, PrimaryColumn } from 'typeorm';
 import { Brand } from '@/context/shared/domain/Brand';
+import { AbsolutePath, RelativePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
 
 export type FolderUuid = Brand<string, 'FolderUuid'>;
 export type SimpleDriveFolder = {
-  id: number;
   uuid: FolderUuid;
   name: string;
   parentUuid: string | undefined;
   createdAt: string;
   updatedAt: string;
   status: 'EXISTS' | 'TRASHED' | 'DELETED';
+};
+export type ExtendedDriveFolder = SimpleDriveFolder & {
+  path: RelativePath;
+  absolutePath: AbsolutePath;
 };
 
 @Entity('drive_folder')

--- a/src/context/virtual-drive/items/validate-windows-name.ts
+++ b/src/context/virtual-drive/items/validate-windows-name.ts
@@ -1,8 +1,9 @@
 import { logger } from '@/apps/shared/logger/logger';
 import { ipcRendererSyncEngine } from '@/apps/sync-engine/ipcRendererSyncEngine';
+import { RelativePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
 
 type TProps = {
-  path: string;
+  path: RelativePath;
   name: string;
 };
 

--- a/src/infra/sqlite/services/file.module.ts
+++ b/src/infra/sqlite/services/file.module.ts
@@ -2,12 +2,14 @@ import { createOrUpdate } from './file/create-or-update';
 import { getByName } from './file/get-by-name';
 import { getByParentUuid } from './file/get-by-parent-uuid';
 import { getByUuid } from './file/get-by-uuid';
+import { getByWorkspaceId } from './file/get-by-workspace-id';
 import { updateByUuid } from './file/update-by-uuid';
 
 export const FileModule = {
   getByName,
   getByUuid,
   getByParentUuid,
+  getByWorkspaceId,
   createOrUpdate,
   updateByUuid,
 };

--- a/src/infra/sqlite/services/file/get-by-workspace-id.test.ts
+++ b/src/infra/sqlite/services/file/get-by-workspace-id.test.ts
@@ -1,0 +1,34 @@
+import * as fileDecryptName from '@/context/virtual-drive/files/domain/file-decrypt-name';
+import { fileRepository } from '../drive-file';
+import { mockProps, partialSpyOn } from '@/tests/vitest/utils.helper.test';
+import { getByWorkspaceId } from './get-by-workspace-id';
+
+describe('get-by-workspace-id', () => {
+  const findBy = partialSpyOn(fileRepository, 'findBy');
+  const fileDecryptNameSpy = partialSpyOn(fileDecryptName, 'fileDecryptName');
+
+  const props = mockProps<typeof getByWorkspaceId>({ workspaceId: 'uuid' });
+
+  beforeEach(() => {
+    fileDecryptNameSpy.mockResolvedValue({});
+  });
+
+  it('should return UNKNOWN when error is thrown', async () => {
+    // Given
+    findBy.mockRejectedValue(new Error());
+    // When
+    const { error } = await getByWorkspaceId(props);
+    // Then
+    expect(error?.code).toBe('UNKNOWN');
+  });
+
+  it('should return files', async () => {
+    // Given
+    findBy.mockResolvedValue([]);
+    // When
+    const { data } = await getByWorkspaceId(props);
+    // Then
+    expect(data).toBeDefined();
+    expect(findBy).toBeCalledWith({ workspaceId: 'uuid' });
+  });
+});

--- a/src/infra/sqlite/services/file/get-by-workspace-id.ts
+++ b/src/infra/sqlite/services/file/get-by-workspace-id.ts
@@ -1,0 +1,24 @@
+import { fileRepository } from '../drive-file';
+import { logger } from '@/apps/shared/logger/logger';
+import { parseData } from './parse-data';
+import { SqliteError } from '../common/sqlite-error';
+
+type Props = {
+  workspaceId: string;
+};
+
+export async function getByWorkspaceId({ workspaceId }: Props) {
+  try {
+    const items = await fileRepository.findBy({ workspaceId });
+
+    return { data: items.map((item) => parseData({ data: item })) };
+  } catch (exc) {
+    logger.error({
+      msg: 'Error getting files by workspace id',
+      workspaceId,
+      exc,
+    });
+
+    return { error: new SqliteError('UNKNOWN', exc) };
+  }
+}

--- a/src/infra/sqlite/services/file/parse-data.ts
+++ b/src/infra/sqlite/services/file/parse-data.ts
@@ -14,7 +14,6 @@ export function parseData({ data }: TProps) {
   });
 
   return {
-    id: data.id,
     uuid: data.uuid as FileUuid,
     name,
     nameWithExtension,

--- a/src/infra/sqlite/services/folder.module.ts
+++ b/src/infra/sqlite/services/folder.module.ts
@@ -3,11 +3,13 @@ import { updateByUuid } from './folder/update-by-uuid';
 import { createOrUpdate } from './folder/create-or-update';
 import { getByName } from './folder/get-by-name';
 import { getByParentUuid } from './folder/get-by-parent-uuid';
+import { getByWorkspaceId } from './folder/get-by-workspace-id';
 
 export const FolderModule = {
   getByName,
   getByUuid,
   getByParentUuid,
+  getByWorkspaceId,
   createOrUpdate,
   updateByUuid,
 };

--- a/src/infra/sqlite/services/folder/get-by-workspace-id.test.ts
+++ b/src/infra/sqlite/services/folder/get-by-workspace-id.test.ts
@@ -1,0 +1,30 @@
+import { mockProps, partialSpyOn } from '@/tests/vitest/utils.helper.test';
+import { getByWorkspaceId } from './get-by-workspace-id';
+import { Folder } from '@/context/virtual-drive/folders/domain/Folder';
+import { folderRepository } from '../drive-folder';
+
+describe('get-by-workspace-id', () => {
+  const findBy = partialSpyOn(folderRepository, 'findBy');
+  partialSpyOn(Folder, 'decryptName');
+
+  const props = mockProps<typeof getByWorkspaceId>({ workspaceId: 'uuid' });
+
+  it('should return UNKNOWN when error is thrown', async () => {
+    // Given
+    findBy.mockRejectedValue(new Error());
+    // When
+    const { error } = await getByWorkspaceId(props);
+    // Then
+    expect(error?.code).toBe('UNKNOWN');
+  });
+
+  it('should return folders', async () => {
+    // Given
+    findBy.mockResolvedValue([]);
+    // When
+    const { data } = await getByWorkspaceId(props);
+    // Then
+    expect(data).toBeDefined();
+    expect(findBy).toBeCalledWith({ workspaceId: 'uuid' });
+  });
+});

--- a/src/infra/sqlite/services/folder/get-by-workspace-id.ts
+++ b/src/infra/sqlite/services/folder/get-by-workspace-id.ts
@@ -1,0 +1,24 @@
+import { logger } from '@/apps/shared/logger/logger';
+import { parseData } from './parse-data';
+import { SqliteError } from '../common/sqlite-error';
+import { folderRepository } from '../drive-folder';
+
+type Props = {
+  workspaceId: string;
+};
+
+export async function getByWorkspaceId({ workspaceId }: Props) {
+  try {
+    const items = await folderRepository.findBy({ workspaceId });
+
+    return { data: items.map((item) => parseData({ data: item })) };
+  } catch (exc) {
+    logger.error({
+      msg: 'Error getting folders by workspace id',
+      workspaceId,
+      exc,
+    });
+
+    return { error: new SqliteError('UNKNOWN', exc) };
+  }
+}

--- a/src/infra/sqlite/services/folder/parse-data.ts
+++ b/src/infra/sqlite/services/folder/parse-data.ts
@@ -13,7 +13,6 @@ export function parseData({ data }: TProps) {
   });
 
   return {
-    id: data.id,
     uuid: data.uuid as FolderUuid,
     name,
     parentUuid: data.parentUuid,


### PR DESCRIPTION
## What

This is the first part of 2 PRs that removes the usage of the class `File` to start using `ExtendedDriveFile` in the sync traverser. Why? Because `File` is a class and cannot be sent using ipc and also because it simplifies the logic of the traverser.