### PR TITLE
Migrate to context

### DIFF
--- a/src/apps/sync-engine/BindingManager.ts
+++ b/src/apps/sync-engine/BindingManager.ts
@@ -3,7 +3,7 @@ import { DependencyContainer } from './dependency-injection/DependencyContainer'
 import { ipcRendererSyncEngine } from './ipcRendererSyncEngine';
 import { ipcRenderer } from 'electron';
 import { DangledFilesManager, PushAndCleanInput } from '@/context/virtual-drive/shared/domain/DangledFilesManager';
-import { getConfig, SyncContext } from './config';
+import { getConfig, ProcessSyncContext } from './config';
 import { logger } from '../shared/logger/logger';
 import { Tree } from '@/context/virtual-drive/items/application/Traverser';
 import { Callbacks } from '@/node-win/types/callbacks.type';
@@ -23,7 +23,7 @@ export class BindingsManager {
     this.controllers = buildControllers(this.container);
   }
 
-  async start({ ctx }: { ctx: SyncContext }) {
+  async start({ ctx }: { ctx: ProcessSyncContext }) {
     const callbacks: Callbacks = {
       fetchDataCallback: async (filePlaceholderId, callback) => {
         await fetchData({
@@ -69,7 +69,7 @@ export class BindingsManager {
     });
   }
 
-  watch() {
+  watch({ ctx }: { ctx: ProcessSyncContext }) {
     const { queueManager, watcher } = createWatcher({
       virtulDrive: this.container.virtualDrive,
       watcherCallbacks: {
@@ -85,7 +85,7 @@ export class BindingsManager {
       },
     });
 
-    watcher.watchAndWait();
+    watcher.watchAndWait({ ctx });
 
     void this.polling();
     void queueManager.processQueue();

--- a/src/apps/sync-engine/callbacks-controllers/controllers/add-controller.ts
+++ b/src/apps/sync-engine/callbacks-controllers/controllers/add-controller.ts
@@ -63,7 +63,7 @@ export class AddController {
     }
   }
 
-  async createFolder({ path, absolutePath }: { path: RelativePath; absolutePath: AbsolutePath }) {
-    await createFolder({ path, absolutePath, folderCreator: this.folderCreator });
+  async createFolder({ ctx, path, absolutePath }: { ctx: ProcessSyncContext; path: RelativePath; absolutePath: AbsolutePath }) {
+    await createFolder({ ctx, path, absolutePath, folderCreator: this.folderCreator });
   }
 }

--- a/src/apps/sync-engine/callbacks-controllers/controllers/add-controller.ts
+++ b/src/apps/sync-engine/callbacks-controllers/controllers/add-controller.ts
@@ -7,6 +7,7 @@ import { createFile } from '@/features/sync/add-item/create-file';
 import { BucketEntry } from '@/context/virtual-drive/shared/domain/BucketEntry';
 import { isTemporaryFile } from '@/apps/utils/isTemporalFile';
 import { Stats } from 'fs';
+import { ProcessSyncContext } from '../../config';
 
 export class AddController {
   // Gets called when:
@@ -19,7 +20,17 @@ export class AddController {
     private readonly folderCreator: FolderCreator,
   ) {}
 
-  async createFile({ absolutePath, path, stats }: { absolutePath: AbsolutePath; path: RelativePath; stats: Stats }) {
+  async createFile({
+    ctx,
+    absolutePath,
+    path,
+    stats,
+  }: {
+    ctx: ProcessSyncContext;
+    absolutePath: AbsolutePath;
+    path: RelativePath;
+    stats: Stats;
+  }) {
     logger.debug({ msg: 'Create file', path });
 
     try {
@@ -40,6 +51,7 @@ export class AddController {
       }
 
       await createFile({
+        ctx,
         absolutePath,
         path,
         folderCreator: this.folderCreator,

--- a/src/apps/sync-engine/config.ts
+++ b/src/apps/sync-engine/config.ts
@@ -1,6 +1,7 @@
 import { AuthContext } from '@/backend/features/auth/utils/context';
 import { getUser } from '../main/auth/service';
 import { FolderUuid } from '../main/database/entities/DriveFolder';
+import { VirtualDrive } from '@/node-win/virtual-drive';
 
 export type Config = {
   userUuid: string;
@@ -19,6 +20,10 @@ export type Config = {
 };
 
 export type SyncContext = AuthContext & Config;
+
+export type ProcessSyncContext = SyncContext & {
+  virtualDrive: VirtualDrive;
+};
 
 const emptyValues = (): Config => {
   return {

--- a/src/apps/sync-engine/dependency-injection/files/builder.ts
+++ b/src/apps/sync-engine/dependency-injection/files/builder.ts
@@ -17,7 +17,7 @@ export function buildFilesContainer(contentsContainer: ContentsContainer): {
 
   const repository = new InMemoryFileRepository();
 
-  const fileCreator = new FileCreator(remoteFileSystem, virtualDrive);
+  const fileCreator = new FileCreator(remoteFileSystem);
 
   const filePlaceholderUpdater = new FilePlaceholderUpdater(virtualDrive);
 

--- a/src/apps/sync-engine/dependency-injection/folders/builder.ts
+++ b/src/apps/sync-engine/dependency-injection/folders/builder.ts
@@ -8,7 +8,7 @@ import { virtualDrive } from '../common/virtualDrive';
 export function buildFoldersContainer(): FoldersContainer {
   const remoteFolderSystem = new HttpRemoteFolderSystem(getConfig().workspaceId);
 
-  const folderCreator = new FolderCreator(remoteFolderSystem, virtualDrive);
+  const folderCreator = new FolderCreator(remoteFolderSystem);
 
   const folderPlaceholderUpdater = new FolderPlaceholderUpdater(virtualDrive);
 

--- a/src/apps/sync-engine/in/add-pending-files.ts
+++ b/src/apps/sync-engine/in/add-pending-files.ts
@@ -2,13 +2,15 @@ import { PendingPaths } from './get-pending-items';
 import { pathUtils } from '@/context/local/localFile/infrastructure/AbsolutePath';
 import { virtualDrive } from '../dependency-injection/common/virtualDrive';
 import { IControllers } from '../callbacks-controllers/buildControllers';
+import { ProcessSyncContext } from '../config';
 
 type TProps = {
+  ctx: ProcessSyncContext;
   controllers: IControllers;
   pendingFiles: PendingPaths[];
 };
 
-export async function addPendingFiles({ controllers, pendingFiles }: TProps) {
+export async function addPendingFiles({ ctx, controllers, pendingFiles }: TProps) {
   await Promise.all(
     pendingFiles.map(async ({ absolutePath, stats }) => {
       const path = pathUtils.absoluteToRelative({
@@ -16,7 +18,7 @@ export async function addPendingFiles({ controllers, pendingFiles }: TProps) {
         path: absolutePath,
       });
 
-      await controllers.addFile.createFile({ absolutePath, path, stats });
+      await controllers.addFile.createFile({ ctx, absolutePath, path, stats });
     }),
   );
 }

--- a/src/apps/sync-engine/in/add-pending-folders.ts
+++ b/src/apps/sync-engine/in/add-pending-folders.ts
@@ -2,13 +2,15 @@ import { PendingPaths } from './get-pending-items';
 import { IControllers } from '../callbacks-controllers/buildControllers';
 import { virtualDrive } from '../dependency-injection/common/virtualDrive';
 import { pathUtils } from '@/context/local/localFile/infrastructure/AbsolutePath';
+import { ProcessSyncContext } from '../config';
 
 type TProps = {
+  ctx: ProcessSyncContext;
   controllers: IControllers;
   pendingFolders: PendingPaths[];
 };
 
-export async function addPendingFolders({ controllers, pendingFolders }: TProps) {
+export async function addPendingFolders({ ctx, controllers, pendingFolders }: TProps) {
   await Promise.all(
     pendingFolders.map(async ({ absolutePath }) => {
       const path = pathUtils.absoluteToRelative({
@@ -16,7 +18,7 @@ export async function addPendingFolders({ controllers, pendingFolders }: TProps)
         path: absolutePath,
       });
 
-      await controllers.addFile.createFolder({ path, absolutePath });
+      await controllers.addFile.createFolder({ ctx, path, absolutePath });
     }),
   );
 }

--- a/src/apps/sync-engine/in/add-pending-items.ts
+++ b/src/apps/sync-engine/in/add-pending-items.ts
@@ -29,7 +29,7 @@ export async function addPendingItems({ ctx, controllers, fileContentsUploader }
       pendingFolders: pendingFolders.length,
     });
 
-    await Promise.all([addPendingFiles({ ctx, pendingFiles, controllers }), addPendingFolders({ pendingFolders, controllers })]);
+    await Promise.all([addPendingFiles({ ctx, pendingFiles, controllers }), addPendingFolders({ ctx, pendingFolders, controllers })]);
     await syncModifiedFiles({ fileContentsUploader, virtualDrive });
   } catch (exc) {
     logger.error({

--- a/src/apps/sync-engine/in/add-pending-items.ts
+++ b/src/apps/sync-engine/in/add-pending-items.ts
@@ -6,10 +6,10 @@ import { addPendingFolders } from './add-pending-folders';
 import { IControllers } from '../callbacks-controllers/buildControllers';
 import { syncModifiedFiles } from './sync-modified-files';
 import { ContentsUploader } from '@/context/virtual-drive/contents/application/ContentsUploader';
-import { SyncContext } from '../config';
+import { ProcessSyncContext } from '../config';
 
 type Props = {
-  ctx: SyncContext;
+  ctx: ProcessSyncContext;
   controllers: IControllers;
   fileContentsUploader: ContentsUploader;
 };
@@ -29,7 +29,7 @@ export async function addPendingItems({ ctx, controllers, fileContentsUploader }
       pendingFolders: pendingFolders.length,
     });
 
-    await Promise.all([addPendingFiles({ pendingFiles, controllers }), addPendingFolders({ pendingFolders, controllers })]);
+    await Promise.all([addPendingFiles({ ctx, pendingFiles, controllers }), addPendingFolders({ pendingFolders, controllers })]);
     await syncModifiedFiles({ fileContentsUploader, virtualDrive });
   } catch (exc) {
     logger.error({

--- a/src/context/virtual-drive/boundaryBridge/application/FileCreationOrchestrator.ts
+++ b/src/context/virtual-drive/boundaryBridge/application/FileCreationOrchestrator.ts
@@ -4,8 +4,10 @@ import { AbsolutePath, RelativePath } from '@/context/local/localFile/infrastruc
 import { Stats } from 'fs';
 import { ContentsUploader } from '../../contents/application/ContentsUploader';
 import { FileUuid } from '@/apps/main/database/entities/DriveFile';
+import { ProcessSyncContext } from '@/apps/sync-engine/config';
 
 type TProps = {
+  ctx: ProcessSyncContext;
   path: RelativePath;
   absolutePath: AbsolutePath;
   stats: Stats;
@@ -17,7 +19,7 @@ export class FileCreationOrchestrator {
     private readonly fileCreator: FileCreator,
   ) {}
 
-  async run({ path, absolutePath, stats }: TProps): Promise<FileUuid> {
+  async run({ ctx, path, absolutePath, stats }: TProps): Promise<FileUuid> {
     const fileContents = await this.contentsUploader.run({ path, stats });
 
     logger.debug({
@@ -29,6 +31,7 @@ export class FileCreationOrchestrator {
     });
 
     const createdFile = await this.fileCreator.run({
+      ctx,
       path,
       contents: fileContents,
       absolutePath,

--- a/src/context/virtual-drive/files/application/FileCreator.ts
+++ b/src/context/virtual-drive/files/application/FileCreator.ts
@@ -1,16 +1,16 @@
 import { HttpRemoteFileSystem } from '../infrastructure/HttpRemoteFileSystem';
-import { getConfig } from '@/apps/sync-engine/config';
+import { getConfig, ProcessSyncContext } from '@/apps/sync-engine/config';
 import { ipcRendererSyncEngine } from '@/apps/sync-engine/ipcRendererSyncEngine';
 import { logger } from '@/apps/shared/logger/logger';
 import { FolderNotFoundError } from '../../folders/domain/errors/FolderNotFoundError';
 import { NodeWin } from '@/infra/node-win/node-win.module';
-import VirtualDrive from '@/node-win/virtual-drive';
 import { ipcRendererSqlite } from '@/infra/sqlite/ipc/ipc-renderer';
 import { AbsolutePath, pathUtils, RelativePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
 import { ContentsId } from '@/apps/main/database/entities/DriveFile';
 import { basename } from 'path';
 
 type Props = {
+  ctx: ProcessSyncContext;
   path: RelativePath;
   absolutePath: AbsolutePath;
   contents: {
@@ -20,16 +20,13 @@ type Props = {
 };
 
 export class FileCreator {
-  constructor(
-    private readonly remote: HttpRemoteFileSystem,
-    private readonly virtualDrive: VirtualDrive,
-  ) {}
+  constructor(private readonly remote: HttpRemoteFileSystem) {}
 
-  async run({ path, absolutePath, contents }: Props) {
+  async run({ ctx, path, absolutePath, contents }: Props) {
     try {
       const parentPath = pathUtils.dirname(path);
       const { data: folderUuid } = NodeWin.getFolderUuid({
-        drive: this.virtualDrive,
+        drive: ctx.virtualDrive,
         path: parentPath,
       });
 

--- a/src/context/virtual-drive/folders/application/FolderCreator.test.ts
+++ b/src/context/virtual-drive/folders/application/FolderCreator.test.ts
@@ -20,10 +20,10 @@ describe('Folder Creator', () => {
   const invokeMock = partialSpyOn(ipcRendererSqlite, 'invoke');
   const updateFolderStatusMock = partialSpyOn(updateFolderStatus, 'updateFolderStatus');
 
-  const SUT = new FolderCreator(remote, virtualDrive);
+  const SUT = new FolderCreator(remote);
 
   const path = createRelativePath('folder1', 'folder2');
-  const props = mockProps<typeof SUT.run>({ path });
+  const props = mockProps<typeof SUT.run>({ ctx: { virtualDrive }, path });
 
   beforeEach(() => {
     invokeMock.mockResolvedValue({});

--- a/src/context/virtual-drive/folders/application/FolderCreator.ts
+++ b/src/context/virtual-drive/folders/application/FolderCreator.ts
@@ -1,28 +1,25 @@
 import { HttpRemoteFolderSystem } from '../infrastructure/HttpRemoteFolderSystem';
-import VirtualDrive from '@/node-win/virtual-drive';
 import { posix } from 'path';
 import { FolderNotFoundError } from '../domain/errors/FolderNotFoundError';
-import { getConfig } from '@/apps/sync-engine/config';
+import { getConfig, ProcessSyncContext } from '@/apps/sync-engine/config';
 import { NodeWin } from '@/infra/node-win/node-win.module';
 import { ipcRendererSqlite } from '@/infra/sqlite/ipc/ipc-renderer';
 import { AbsolutePath, pathUtils, RelativePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
 import { updateFolderStatus } from '@/backend/features/local-sync/placeholders/update-folder-status';
 
 type TProps = {
+  ctx: ProcessSyncContext;
   path: RelativePath;
   absolutePath: AbsolutePath;
 };
 
 export class FolderCreator {
-  constructor(
-    private readonly remote: HttpRemoteFolderSystem,
-    private readonly virtualDrive: VirtualDrive,
-  ) {}
+  constructor(private readonly remote: HttpRemoteFolderSystem) {}
 
-  async run({ path, absolutePath }: TProps) {
+  async run({ ctx, path, absolutePath }: TProps) {
     const posixDir = pathUtils.dirname(path);
     const { data: parentUuid } = NodeWin.getFolderUuid({
-      drive: this.virtualDrive,
+      drive: ctx.virtualDrive,
       path: posixDir,
     });
 
@@ -46,7 +43,7 @@ export class FolderCreator {
 
     if (error) throw error;
 
-    this.virtualDrive.convertToPlaceholder({ itemPath: path, id: `FOLDER:${folderDto.uuid}` });
+    ctx.virtualDrive.convertToPlaceholder({ itemPath: path, id: `FOLDER:${folderDto.uuid}` });
     await updateFolderStatus({ path, absolutePath });
   }
 }

--- a/src/features/sync/add-item/create-folder.ts
+++ b/src/features/sync/add-item/create-folder.ts
@@ -2,8 +2,10 @@ import { logger } from '@/apps/shared/logger/logger';
 import { FolderCreator } from '@/context/virtual-drive/folders/application/FolderCreator';
 import { FolderNotFoundError } from '@/context/virtual-drive/folders/domain/errors/FolderNotFoundError';
 import { AbsolutePath, pathUtils, RelativePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
+import { ProcessSyncContext } from '@/apps/sync-engine/config';
 
 type TProps = {
+  ctx: ProcessSyncContext;
   path: RelativePath;
   absolutePath: AbsolutePath;
   folderCreator: FolderCreator;
@@ -14,7 +16,7 @@ export async function createParentFolder({ path, ...props }: TProps) {
   await createFolder({ path: posixDir, ...props });
 }
 
-export async function createFolder({ path, absolutePath, folderCreator }: TProps) {
+export async function createFolder({ ctx, path, absolutePath, folderCreator }: TProps) {
   logger.debug({
     tag: 'SYNC-ENGINE',
     msg: 'Create folder',
@@ -22,11 +24,11 @@ export async function createFolder({ path, absolutePath, folderCreator }: TProps
   });
 
   try {
-    await folderCreator.run({ path, absolutePath });
+    await folderCreator.run({ ctx, path, absolutePath });
   } catch (error) {
     if (error instanceof FolderNotFoundError) {
-      await createParentFolder({ path, absolutePath, folderCreator });
-      await createFolder({ path, absolutePath, folderCreator });
+      await createParentFolder({ ctx, path, absolutePath, folderCreator });
+      await createFolder({ ctx, path, absolutePath, folderCreator });
     } else {
       logger.error({
         tag: 'SYNC-ENGINE',

--- a/src/node-win/watcher/events/on-add-dir.service.test.ts
+++ b/src/node-win/watcher/events/on-add-dir.service.test.ts
@@ -19,6 +19,7 @@ describe('on-add-dir', () => {
 
   beforeEach(() => {
     props = mockProps<typeof onAddDir>({
+      ctx: {},
       absolutePath: 'C:\\Users\\user\\drive\\folder' as AbsolutePath,
       self: {
         queueManager: { enqueue: vi.fn() },

--- a/src/node-win/watcher/events/on-add-dir.service.ts
+++ b/src/node-win/watcher/events/on-add-dir.service.ts
@@ -3,13 +3,15 @@ import { AbsolutePath, pathUtils } from '@/context/local/localFile/infrastructur
 import { NodeWin } from '@/infra/node-win/node-win.module';
 import { moveFolder } from '@/backend/features/local-sync/watcher/events/rename-or-move/move-folder';
 import { trackAddDirEvent } from '@/backend/features/local-sync/watcher/events/unlink/is-move-event';
+import { ProcessSyncContext } from '@/apps/sync-engine/config';
 
 type TProps = {
+  ctx: ProcessSyncContext;
   self: Watcher;
   absolutePath: AbsolutePath;
 };
 
-export async function onAddDir({ self, absolutePath }: TProps) {
+export async function onAddDir({ ctx, self, absolutePath }: TProps) {
   const path = pathUtils.absoluteToRelative({
     base: self.virtualDrive.syncRootPath,
     path: absolutePath,
@@ -17,12 +19,12 @@ export async function onAddDir({ self, absolutePath }: TProps) {
 
   try {
     const { data: uuid } = NodeWin.getFolderUuid({
-      drive: self.virtualDrive,
+      drive: ctx.virtualDrive,
       path,
     });
 
     if (!uuid) {
-      await self.callbacks.addController.createFolder({ path, absolutePath });
+      await self.callbacks.addController.createFolder({ ctx, path, absolutePath });
       return;
     }
 

--- a/src/node-win/watcher/events/on-add.service.ts
+++ b/src/node-win/watcher/events/on-add.service.ts
@@ -5,14 +5,16 @@ import { NodeWin } from '@/infra/node-win/node-win.module';
 import { AbsolutePath, pathUtils } from '@/context/local/localFile/infrastructure/AbsolutePath';
 import { moveFile } from '@/backend/features/local-sync/watcher/events/rename-or-move/move-file';
 import { trackAddEvent } from '@/backend/features/local-sync/watcher/events/unlink/is-move-event';
+import { ProcessSyncContext } from '@/apps/sync-engine/config';
 
 type TProps = {
+  ctx: ProcessSyncContext;
   self: Watcher;
   absolutePath: AbsolutePath;
   stats: Stats;
 };
 
-export async function onAdd({ self, absolutePath, stats }: TProps) {
+export async function onAdd({ ctx, self, absolutePath, stats }: TProps) {
   const path = pathUtils.absoluteToRelative({
     base: self.virtualDrive.syncRootPath,
     path: absolutePath,
@@ -24,6 +26,7 @@ export async function onAdd({ self, absolutePath, stats }: TProps) {
     if (!uuid) {
       self.fileInDevice.add(absolutePath);
       await self.callbacks.addController.createFile({
+        ctx,
         absolutePath,
         path,
         stats,

--- a/src/node-win/watcher/watcher.helper.test.ts
+++ b/src/node-win/watcher/watcher.helper.test.ts
@@ -7,7 +7,7 @@ import { QueueManager } from '../queue/queue-manager';
 import { TLogger } from '../logger';
 import VirtualDrive from '../virtual-drive';
 import { AbsolutePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
-import { getMockCalls, partialSpyOn } from '@/tests/vitest/utils.helper.test';
+import { getMockCalls, mockProps, partialSpyOn } from '@/tests/vitest/utils.helper.test';
 import * as unlinkFile from '@/backend/features/local-sync/watcher/events/unlink/unlink-file';
 import * as unlinkFolder from '@/backend/features/local-sync/watcher/events/unlink/unlink-folder';
 import * as onAll from './events/on-all.service';
@@ -35,7 +35,8 @@ export async function setupWatcher(syncRootPath: string) {
   }
 
   watcher = new Watcher(syncRootPath as AbsolutePath, {}, queueManager, logger, virtualDrive, watcherCallbacks);
-  watcher.watchAndWait();
+  const props = mockProps<typeof watcher.watchAndWait>({ ctx: { virtualDrive } });
+  watcher.watchAndWait(props);
 }
 
 export function getEvents() {

--- a/src/node-win/watcher/watcher.ts
+++ b/src/node-win/watcher/watcher.ts
@@ -52,7 +52,7 @@ export class Watcher {
          * - we move an item locally or when we move it using sync by checkpoint.
          */
         .on('add', (absolutePath: AbsolutePath, stats) => onAdd({ ctx, self: this, absolutePath, stats: stats! }))
-        .on('addDir', (absolutePath: AbsolutePath) => onAddDir({ self: this, absolutePath }))
+        .on('addDir', (absolutePath: AbsolutePath) => onAddDir({ ctx, self: this, absolutePath }))
         /**
          * v2.5.6 Daniel Jiménez
          * unlink events are triggered when:

--- a/src/node-win/watcher/watcher.ts
+++ b/src/node-win/watcher/watcher.ts
@@ -12,6 +12,7 @@ import { unlinkFolder } from '@/backend/features/local-sync/watcher/events/unlin
 import { Stats } from 'fs';
 import { debounceOnRaw } from './events/debounce-on-raw';
 import { onAll } from './events/on-all.service';
+import { ProcessSyncContext } from '@/apps/sync-engine/config';
 
 export type TWatcherCallbacks = {
   addController: AddController;
@@ -39,7 +40,7 @@ export class Watcher {
     this.logger.debug({ msg: 'onReady' });
   };
 
-  watchAndWait() {
+  watchAndWait({ ctx }: { ctx: ProcessSyncContext }) {
     try {
       this.chokidar = watch(this.syncRootPath, this.options);
       this.chokidar
@@ -50,7 +51,7 @@ export class Watcher {
          * - we create an item locally.
          * - we move an item locally or when we move it using sync by checkpoint.
          */
-        .on('add', (absolutePath: AbsolutePath, stats) => onAdd({ self: this, absolutePath, stats: stats! }))
+        .on('add', (absolutePath: AbsolutePath, stats) => onAdd({ ctx, self: this, absolutePath, stats: stats! }))
         .on('addDir', (absolutePath: AbsolutePath) => onAddDir({ self: this, absolutePath }))
         /**
          * v2.5.6 Daniel Jiménez


### PR DESCRIPTION
## What

Start sending `ctx` using prop drilling to we can stop using getConfig and migrate the sync engine process to main.