### PR TITLE
Fix restore parent folder

### DIFF
--- a/src/context/virtual-drive/files/infrastructure/restore-parent-folder.ts
+++ b/src/context/virtual-drive/files/infrastructure/restore-parent-folder.ts
@@ -39,7 +39,7 @@ export async function restoreParentFolder({ offline, drive }: TProps) {
     }),
   ]);
 
-  if (moveError || renameError) {
+  if (moveError || (renameError && renameError.code !== 'FOLDER_ALREADY_EXISTS')) {
     throw logger.error({ msg: 'Error restoring parent folder', path: offline.path, moveError, renameError });
   }
 }

--- a/src/infra/drive-server-wip/in/client-wrapper.service.ts
+++ b/src/infra/drive-server-wip/in/client-wrapper.service.ts
@@ -4,6 +4,7 @@ import { errorWrapper } from './error-wrapper';
 import { sleep } from '@/apps/main/util';
 import { exceptionWrapper } from './exception-wrapper';
 import { getInFlightRequest } from './get-in-flight-request';
+import { DriveServerWipError } from '../out/error.types';
 
 const MAX_RETRIES = 3;
 
@@ -19,6 +20,8 @@ type TProps<T> = {
   skipLog?: boolean;
 };
 
+export type TResponse<T> = Promise<{ data: NonNullable<T>; error?: undefined } | { error: DriveServerWipError; data?: undefined }>;
+
 /**
  * v2.5.5 Daniel Jiménez
  * Scenarios:
@@ -30,7 +33,14 @@ type TProps<T> = {
  *  - Network error (we want to retry always).
  *  - Unknown error (we want to retry 3 times).
  */
-export async function clientWrapper<T>({ loggerBody, promiseFn, key, sleepMs = 5_000, retry = 1, skipLog = false }: TProps<T>) {
+export async function clientWrapper<T>({
+  loggerBody,
+  promiseFn,
+  key,
+  sleepMs = 5_000,
+  retry = 1,
+  skipLog = false,
+}: TProps<T>): TResponse<T> {
   try {
     const { reused, promise } = getInFlightRequest({ key, promiseFn });
 

--- a/src/infra/drive-server-wip/services/files/create-file.test.ts
+++ b/src/infra/drive-server-wip/services/files/create-file.test.ts
@@ -13,4 +13,13 @@ describe('create-file', () => {
     expect(data).toBeUndefined();
     expect(error?.code).toStrictEqual('FOLDER_NOT_FOUND');
   });
+
+  it('should return FILE_ALREADY_EXISTS when server responds 409', async () => {
+    clientMock.POST.mockResolvedValue({ response: { status: 409 } });
+
+    const { error, data } = await createFile(props);
+
+    expect(data).toBeUndefined();
+    expect(error?.code).toStrictEqual('FILE_ALREADY_EXISTS');
+  });
 });

--- a/src/infra/drive-server-wip/services/files/create-file.ts
+++ b/src/infra/drive-server-wip/services/files/create-file.ts
@@ -2,14 +2,14 @@ import { client } from '@/apps/shared/HttpClient/client';
 import { paths } from '@/apps/shared/HttpClient/schema';
 import { DriveServerWipError, TDriveServerWipError } from '../../out/error.types';
 import { getRequestKey } from '../../in/get-in-flight-request';
-import { clientWrapper } from '../../in/client-wrapper.service';
-import { parseFileDto } from '../../out/dto';
+import { clientWrapper, TResponse } from '../../in/client-wrapper.service';
+import { FileDto, parseFileDto } from '../../out/dto';
 
 type TCreateFileBody = paths['/files']['post']['requestBody']['content']['application/json'];
 
 class CreateFileError extends DriveServerWipError {
   constructor(
-    public readonly code: TDriveServerWipError | 'FOLDER_NOT_FOUND',
+    public readonly code: TDriveServerWipError | 'FOLDER_NOT_FOUND' | 'FILE_ALREADY_EXISTS',
     cause: unknown,
   ) {
     super(code, cause);
@@ -29,20 +29,19 @@ export async function createFile(context: { path: string; body: TCreateFileBody 
   const res = await clientWrapper({
     promiseFn,
     key,
-    loggerBody: {
-      msg: 'Create file request',
-      context,
-      attributes: {
-        method,
-        endpoint,
-      },
-    },
+    loggerBody: { msg: 'Create file request', context },
   });
 
+  return parseCreateFileResponse(res);
+}
+
+export function parseCreateFileResponse(res: Awaited<TResponse<FileDto>>) {
   if (res.error?.code === 'UNKNOWN') {
     switch (true) {
       case res.error.response?.status === 404:
         return { error: new CreateFileError('FOLDER_NOT_FOUND', res.error.cause) };
+      case res.error.response?.status === 409:
+        return { error: new CreateFileError('FILE_ALREADY_EXISTS', res.error.cause) };
     }
   }
 

--- a/src/infra/drive-server-wip/services/files/rename-folder.ts
+++ b/src/infra/drive-server-wip/services/files/rename-folder.ts
@@ -1,0 +1,53 @@
+import { client, getWorkspaceHeader } from '@/apps/shared/HttpClient/client';
+import { getRequestKey } from '../../in/get-in-flight-request';
+import { clientWrapper } from '../../in/client-wrapper.service';
+import { DriveServerWipError, TDriveServerWipError } from '../../out/error.types';
+import { parseFolderDto } from '../../out/dto';
+
+class RenameFolderError extends DriveServerWipError {
+  constructor(
+    public readonly code: TDriveServerWipError | 'FOLDER_ALREADY_EXISTS',
+    cause: unknown,
+  ) {
+    super(code, cause);
+  }
+}
+
+export async function renameFolder(context: { uuid: string; name: string; workspaceToken: string }) {
+  const method = 'PUT';
+  const endpoint = '/folders/{uuid}/meta';
+  const key = getRequestKey({ method, endpoint, context });
+
+  const promiseFn = () =>
+    client.PUT(endpoint, {
+      headers: getWorkspaceHeader({ workspaceToken: context.workspaceToken }),
+      params: { path: { uuid: context.uuid } },
+      body: { plainName: context.name },
+    });
+
+  const res = await clientWrapper({
+    promiseFn,
+    key,
+    loggerBody: {
+      msg: 'Rename folder request',
+      context,
+      attributes: {
+        method,
+        endpoint,
+      },
+    },
+  });
+
+  if (res.error?.code === 'UNKNOWN') {
+    switch (true) {
+      case res.error.response?.status === 409:
+        return { error: new RenameFolderError('FOLDER_ALREADY_EXISTS', res.error.cause) };
+    }
+  }
+
+  if (res.data) {
+    return { data: parseFolderDto({ folderDto: res.data }) };
+  } else {
+    return { error: res.error };
+  }
+}

--- a/src/infra/drive-server-wip/services/folders.service.ts
+++ b/src/infra/drive-server-wip/services/folders.service.ts
@@ -5,6 +5,7 @@ import { createFolder } from './folders/create-folder';
 import { getRequestKey } from '../in/get-in-flight-request';
 import { parseFileDto, parseFolderDto } from '../out/dto';
 import { getByUuid } from './folders/get-by-uuid';
+import { renameFolder } from './files/rename-folder';
 
 export const folders = {
   getByUuid,
@@ -154,32 +155,6 @@ async function moveFolder(context: { uuid: string; parentUuid: string; workspace
     key,
     loggerBody: {
       msg: 'Move folder request',
-      context,
-      attributes: {
-        method,
-        endpoint,
-      },
-    },
-  });
-}
-
-async function renameFolder(context: { uuid: string; name: string; workspaceToken: string }) {
-  const method = 'PUT';
-  const endpoint = '/folders/{uuid}/meta';
-  const key = getRequestKey({ method, endpoint, context });
-
-  const promiseFn = () =>
-    client.PUT(endpoint, {
-      headers: getWorkspaceHeader({ workspaceToken: context.workspaceToken }),
-      params: { path: { uuid: context.uuid } },
-      body: { plainName: context.name },
-    });
-
-  return await clientWrapper({
-    promiseFn,
-    key,
-    loggerBody: {
-      msg: 'Rename folder request',
       context,
       attributes: {
         method,

--- a/src/infra/drive-server-wip/services/workspaces.service.ts
+++ b/src/infra/drive-server-wip/services/workspaces.service.ts
@@ -4,11 +4,10 @@ import { paths } from '@/apps/shared/HttpClient/schema';
 import { getRequestKey } from '../in/get-in-flight-request';
 import { getFilesByFolder } from './workspaces/get-files-by-folder';
 import { getFoldersByFolder } from './workspaces/get-folders-by-folder';
-import { parseFileDto } from '../out/dto';
+import { createFile } from './workspaces/create-file';
 
 type QueryFilesInWorkspace = paths['/workspaces/{workspaceId}/files']['get']['parameters']['query'];
 type QueryFoldersInWorkspace = paths['/workspaces/{workspaceId}/folders']['get']['parameters']['query'];
-type CreateFileInWorkspaceBody = paths['/workspaces/{workspaceId}/files']['post']['requestBody']['content']['application/json'];
 type CreateFolderInWorkspaceBody = paths['/workspaces/{workspaceId}/folders']['post']['requestBody']['content']['application/json'];
 
 export const workspaces = {
@@ -16,7 +15,7 @@ export const workspaces = {
   getCredentials,
   getFilesInWorkspace,
   getFoldersInWorkspace,
-  createFileInWorkspace,
+  createFile,
   createFolderInWorkspace,
   getFilesByFolder,
   getFoldersByFolder,
@@ -118,37 +117,6 @@ async function getFoldersInWorkspace(context: { workspaceId: string; query: Quer
       },
     },
   });
-}
-
-async function createFileInWorkspace(context: { workspaceId: string; path: string; body: CreateFileInWorkspaceBody }) {
-  const method = 'POST';
-  const endpoint = '/workspaces/{workspaceId}/files';
-  const key = getRequestKey({ method, endpoint, context });
-
-  const promiseFn = () =>
-    client.POST(endpoint, {
-      params: { path: { workspaceId: context.workspaceId } },
-      body: context.body,
-    });
-
-  const res = await clientWrapper({
-    promiseFn,
-    key,
-    loggerBody: {
-      msg: 'Create file in workspace request',
-      context,
-      attributes: {
-        method,
-        endpoint,
-      },
-    },
-  });
-
-  if (res.data) {
-    return { data: parseFileDto({ fileDto: res.data }) };
-  } else {
-    return { error: res.error };
-  }
 }
 
 async function createFolderInWorkspace(context: { path: string; workspaceId: string; body: CreateFolderInWorkspaceBody }) {

--- a/src/infra/drive-server-wip/services/workspaces/create-file.ts
+++ b/src/infra/drive-server-wip/services/workspaces/create-file.ts
@@ -1,0 +1,34 @@
+import { client } from '@/apps/shared/HttpClient/client';
+import { getRequestKey } from '../../in/get-in-flight-request';
+import { clientWrapper } from '../../in/client-wrapper.service';
+import { paths } from '@internxt/drive-desktop-core/build/backend';
+import { parseCreateFileResponse } from '../files/create-file';
+
+type CreateFileInWorkspaceBody = paths['/workspaces/{workspaceId}/files']['post']['requestBody']['content']['application/json'];
+
+export async function createFile(context: { workspaceId: string; path: string; body: CreateFileInWorkspaceBody }) {
+  const method = 'POST';
+  const endpoint = '/workspaces/{workspaceId}/files';
+  const key = getRequestKey({ method, endpoint, context });
+
+  const promiseFn = () =>
+    client.POST(endpoint, {
+      params: { path: { workspaceId: context.workspaceId } },
+      body: context.body,
+    });
+
+  const res = await clientWrapper({
+    promiseFn,
+    key,
+    loggerBody: {
+      msg: 'Create file in workspace request',
+      context,
+      attributes: {
+        method,
+        endpoint,
+      },
+    },
+  });
+
+  return parseCreateFileResponse(res);
+}


### PR DESCRIPTION
## What

Fix two issues when restoring parent folder:

1. If we have moved the folder and is has been marked as TRASHED for some reason. When we move back and rename it maybe the name was already right and it throws an error. This has happen to me when doing a test for the release.
2. When an error because of the rename, move or whatever, it enters in the catch and tries to do the getFileByPath which also fails because the problem was the folder or other thing. Now we just execute the getFileByPath if the create-file endpoint gives a 409 (conflict, file already exists).