### PR TITLE
Use only new token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "depcheck": "^1.4.7",
         "dotenv": "^10.0.0",
         "dotenv-webpack": "^7.0.3",
-        "electron": "^35.7.5",
+        "electron": "^29.4.6",
         "electron-builder": "^26.0.12",
         "electron-rebuild": "^3.2.9",
         "eslint": "^8.5.0",
@@ -10904,15 +10904,15 @@
       }
     },
     "node_modules/electron": {
-      "version": "35.7.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-35.7.5.tgz",
-      "integrity": "sha512-dnL+JvLraKZl7iusXTVTGYs10TKfzUi30uEDTqsmTm0guN9V2tbOjTzyIZbh9n3ygUjgEYyo+igAwMRXIi3IPw==",
+      "version": "29.4.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-29.4.6.tgz",
+      "integrity": "sha512-fz8ndj8cmmf441t4Yh2FDP3Rn0JhLkVGvtUf2YVMbJ5SdJPlc0JWll9jYkhh60jDKVVCr/tBAmfxqRnXMWJpzg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^22.7.7",
+        "@types/node": "^20.9.0",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -11421,16 +11421,6 @@
       },
       "engines": {
         "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/electron/node_modules/@types/node": {
-      "version": "22.18.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
-      "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
       }
     },
     "node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "depcheck": "^1.4.7",
     "dotenv": "^10.0.0",
     "dotenv-webpack": "^7.0.3",
-    "electron": "^35.7.5",
+    "electron": "^29.4.6",
     "electron-builder": "^26.0.12",
     "electron-rebuild": "^3.2.9",
     "eslint": "^8.5.0",

--- a/src/apps/main/auth/handlers.ts
+++ b/src/apps/main/auth/handlers.ts
@@ -28,8 +28,8 @@ export function getIsLoggedIn() {
 }
 
 export function onUserUnauthorized() {
-  eventBus.emit('USER_LOGGED_OUT');
   logger.debug({ tag: 'AUTH', msg: 'User has been logged out because it was unauthorized' });
+  eventBus.emit('USER_LOGGED_OUT');
   setIsLoggedIn(false);
 }
 
@@ -37,9 +37,7 @@ export async function checkIfUserIsLoggedIn() {
   const user = getUser();
 
   if (user && user.needLogout === undefined) {
-    logger.debug({
-      msg: 'User need logout is undefined',
-    });
+    logger.debug({ tag: 'AUTH', msg: 'User need logout is undefined' });
     eventBus.emit('USER_LOGGED_OUT');
     setIsLoggedIn(false);
   }
@@ -59,7 +57,7 @@ export async function checkIfUserIsLoggedIn() {
 export function setupAuthIpcHandlers() {
   ipcMain.handle('is-user-logged-in', getIsLoggedIn);
   ipcMain.handle('get-user', getUser);
-  ipcMain.handle('GET_HEADERS', () => getAuthHeaders());
+  ipcMain.handle('GET_HEADERS', getAuthHeaders);
 
   ipcMain.on('user-logged-in', async (_, data: AccessResponse) => {
     setCredentials({
@@ -77,7 +75,6 @@ export function setupAuthIpcHandlers() {
 
   ipcMainSyncEngine.on('USER_LOGGED_OUT', () => {
     eventBus.emit('USER_LOGGED_OUT');
-
     setIsLoggedIn(false);
   });
 }

--- a/src/apps/main/auth/headers.ts
+++ b/src/apps/main/auth/headers.ts
@@ -9,7 +9,7 @@ export const HEADERS = {
 };
 
 export function getAuthHeaders(): Record<string, string> {
-  const token = obtainToken('newToken');
+  const token = obtainToken();
 
   return {
     Authorization: `Bearer ${token}`,

--- a/src/apps/main/auth/refresh-token.ts
+++ b/src/apps/main/auth/refresh-token.ts
@@ -1,6 +1,6 @@
 import { logger } from '@/apps/shared/logger/logger';
 import { TokenScheduler } from '../token-scheduler/TokenScheduler';
-import { obtainTokens, updateCredentials } from './service';
+import { obtainToken, updateCredentials } from './service';
 import { driveServerWipModule } from '@/infra/drive-server-wip/drive-server-wip.module';
 import { onUserUnauthorized } from './handlers';
 
@@ -19,17 +19,17 @@ async function refreshToken() {
 
   updateCredentials({ newToken });
 
-  return [newToken];
+  return newToken;
 }
 
-export async function createTokenSchedule(refreshedTokens?: Array<string>) {
-  const tokens = refreshedTokens || obtainTokens();
+export async function createTokenSchedule(refreshedToken?: string) {
+  const token = refreshedToken || obtainToken();
 
-  const shceduler = new TokenScheduler(5, tokens);
+  const shceduler = new TokenScheduler(token);
   const schedule = shceduler.schedule(refreshToken);
 
-  if (!schedule && !refreshedTokens) {
-    logger.debug({ msg: 'Refreshing tokens' });
+  if (!schedule && !refreshedToken) {
+    logger.debug({ msg: 'Refreshing token' });
     createTokenSchedule(await refreshToken());
   }
 }

--- a/src/apps/main/auth/service.ts
+++ b/src/apps/main/auth/service.ts
@@ -5,19 +5,15 @@ import { User } from '../types';
 
 const TOKEN_ENCODING = 'latin1';
 
-const tokensKeys = ['newToken'] as const;
-type TokenKey = (typeof tokensKeys)[number];
-type EncryptedTokenKey = `${(typeof tokensKeys)[number]}Encrypted`;
-
 type Credentials = {
   userData: User;
   newToken: string;
   password: string;
 };
 
-export function obtainToken(tokenName: TokenKey): string {
-  const token = ConfigStore.get(tokenName);
-  const isEncrypted = ConfigStore.get<EncryptedTokenKey>(`${tokenName}Encrypted`);
+export function obtainToken(): string {
+  const token = ConfigStore.get('newToken');
+  const isEncrypted = ConfigStore.get('newTokenEncrypted');
 
   if (!isEncrypted) {
     return token;
@@ -78,10 +74,6 @@ export function getUserOrThrow(): User {
   const user = getUser();
   if (!user) throw new Error('User not found');
   return user;
-}
-
-export function obtainTokens(): Array<string> {
-  return tokensKeys.map(obtainToken);
 }
 
 export function canHisConfigBeRestored(uuid: string) {

--- a/src/apps/main/payments/get-available-products.ts
+++ b/src/apps/main/payments/get-available-products.ts
@@ -5,7 +5,7 @@ import { INTERNXT_CLIENT, INTERNXT_VERSION } from '@/core/utils/utils';
 import { getUserAvailableProducts, logger } from '@internxt/drive-desktop-core/build/backend';
 
 export function getAvailableProducts() {
-  const newToken = obtainToken('newToken');
+  const newToken = obtainToken();
 
   logger.debug({ msg: 'Get user products' });
 

--- a/src/apps/main/realtime.ts
+++ b/src/apps/main/realtime.ts
@@ -18,7 +18,7 @@ export function cleanAndStartRemoteNotifications() {
   socket = io(process.env.NOTIFICATIONS_URL, {
     transports: ['websocket'],
     auth: {
-      token: obtainToken('newToken'),
+      token: obtainToken(),
     },
     withCredentials: true,
   });

--- a/src/apps/main/token-scheduler/token-scheduler.test.ts
+++ b/src/apps/main/token-scheduler/token-scheduler.test.ts
@@ -9,12 +9,6 @@ function calculateDayFromToday(t: StringValue): Date {
   return new Date(today.getTime() + ms(t));
 }
 
-const dataSet = [
-  { daysBefore: 5, day: calculateDayFromToday('25 days') },
-  { daysBefore: 1, day: calculateDayFromToday('29 day') },
-  { daysBefore: 10, day: calculateDayFromToday('20 days') },
-];
-
 function createToken(expiresIn: StringValue) {
   const email = 'test@inxternxt.com';
 
@@ -23,8 +17,6 @@ function createToken(expiresIn: StringValue) {
 
 describe('Token Scheduler', () => {
   let scheduler: TokenScheduler;
-
-  const jwtExpiresInThirtyDays = createToken('30 days');
 
   const jwtExpiresInThirtyOneDays = createToken('31 day');
 
@@ -41,18 +33,8 @@ describe('Token Scheduler', () => {
     scheduler.cancelAll();
   });
 
-  it.each(dataSet)('schedules the token refresh n days before fist token expiration', (data) => {
-    scheduler = new TokenScheduler(data.daysBefore, [jwtExpiresInThirtyDays, jwtExpiresInThirtyOneDays]);
-
-    const schedule = scheduler.schedule(task);
-
-    const nextInvocation = schedule?.nextInvocation();
-
-    expect(nextInvocation?.getDate()).toBe(data.day.getDate());
-  });
-
-  it('shcedules to refresh even if a token does not expire', () => {
-    scheduler = new TokenScheduler(4, [jwtWithoutExpiration, jwtExpiresInThirtyDays, jwtExpiresInThirtyOneDays]);
+  it('should schedule if the token is valid', () => {
+    scheduler = new TokenScheduler(jwtExpiresInThirtyOneDays);
 
     const expectedExpireDay = calculateDayFromToday('26 days');
 
@@ -64,32 +46,16 @@ describe('Token Scheduler', () => {
     expect(nextInvocation?.getDay()).toBe(expectedExpireDay.getDay());
   });
 
-  it('schedules to refresh even if a token is not valid', () => {
-    scheduler = new TokenScheduler(4, [invalidToken, jwtExpiresInThirtyDays, jwtExpiresInThirtyOneDays]);
-
-    const schedule = scheduler.schedule(task);
-
-    expect(schedule).toBeDefined();
-  });
-
-  it('shedules to refresh even if a token is not valid or does not expire', () => {
-    scheduler = new TokenScheduler(7, [jwtWithoutExpiration, jwtExpiresInThirtyDays, invalidToken, jwtExpiresInThirtyOneDays]);
-
-    const schedule = scheduler.schedule(task);
-
-    expect(schedule).toBeDefined();
-  });
-
-  it('does not schedule if any token expires', () => {
-    scheduler = new TokenScheduler(7, [jwtWithoutExpiration]);
+  it('should not schedule if the token expires', () => {
+    scheduler = new TokenScheduler(jwtWithoutExpiration);
 
     const schedule = scheduler.schedule(task);
 
     expect(schedule).not.toBeDefined();
   });
 
-  it('does not schedules if any token is valid', () => {
-    scheduler = new TokenScheduler(7, [invalidToken]);
+  it('should not schedule if the token is invalid', () => {
+    scheduler = new TokenScheduler(invalidToken);
 
     const schedule = scheduler.schedule(task);
 


### PR DESCRIPTION
## What

Since now we have removed `bearerToken` we can just use the default token `newToken` instead of working with an array of tokens.