### PR TITLE
Get file explorer state

### DIFF
--- a/src/apps/sync-engine/file-explorer-state/file-explorer-state.types.ts
+++ b/src/apps/sync-engine/file-explorer-state/file-explorer-state.types.ts
@@ -1,0 +1,14 @@
+import { FileUuid, SimpleDriveFile } from '@/apps/main/database/entities/DriveFile';
+import { AbsolutePath, RelativePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
+import { Stats } from 'fs';
+
+export type PendingFileExplorerItem = { path: RelativePath; absolutePath: AbsolutePath; stats: Stats };
+export type FileExplorerFile = PendingFileExplorerItem & { uuid: FileUuid };
+export type FileExplorerState = {
+  createFiles: PendingFileExplorerItem[];
+  createFolders: PendingFileExplorerItem[];
+  hydrateFiles: FileExplorerFile[];
+  modifiedFiles: FileExplorerFile[];
+};
+
+export type RemoteFilesMap = Record<FileUuid, SimpleDriveFile>;

--- a/src/apps/sync-engine/file-explorer-state/get-file-explorer-state.ts
+++ b/src/apps/sync-engine/file-explorer-state/get-file-explorer-state.ts
@@ -1,0 +1,43 @@
+import { logger } from '@/apps/shared/logger/logger';
+import { fileSystem } from '@/infra/file-system/file-system.module';
+import { ProcessSyncContext } from '../config';
+import { processItem } from './process-item';
+import { getExistingFiles } from '@/context/virtual-drive/items/application/RemoteItemsGenerator';
+import { FileExplorerState } from './file-explorer-state.types';
+
+type TProps = {
+  ctx: ProcessSyncContext;
+};
+
+export async function getFileExplorerState({ ctx }: TProps) {
+  const rootFolder = ctx.virtualDrive.syncRootPath;
+
+  logger.debug({ tag: 'SYNC-ENGINE', msg: 'Get file explorer state', rootFolder });
+
+  const state: FileExplorerState = {
+    createFiles: [],
+    createFolders: [],
+    hydrateFiles: [],
+    modifiedFiles: [],
+  };
+
+  const remoteFiles = await getExistingFiles({ ctx });
+  const remoteFilesMap = Object.fromEntries(remoteFiles.map((file) => [file.uuid, file]));
+
+  const localItems = await fileSystem.syncWalk({ rootFolder });
+
+  for (const localItem of localItems) {
+    processItem({ ctx, localItem, state, remoteFilesMap });
+  }
+
+  logger.debug({
+    tag: 'SYNC-ENGINE',
+    msg: 'File explorer state',
+    createFiles: state.createFiles.map((file) => file.path),
+    createFolders: state.createFolders.map((file) => file.path),
+    hydrateFiles: state.hydrateFiles.map((file) => file.path),
+    modifiedFiles: state.modifiedFiles.map((file) => file.path),
+  });
+
+  return state;
+}

--- a/src/apps/sync-engine/file-explorer-state/is-hydration-pending.test.ts
+++ b/src/apps/sync-engine/file-explorer-state/is-hydration-pending.test.ts
@@ -1,0 +1,53 @@
+import { mockProps } from '@/tests/vitest/utils.helper.test';
+import { isHydrationPending } from './is-hydration-pending';
+import { PinState } from '@/node-win/types/placeholder.type';
+
+describe('is-hydration-pending', () => {
+  let props: Parameters<typeof isHydrationPending>[0];
+
+  beforeEach(() => {
+    props = mockProps<typeof isHydrationPending>({
+      pinState: PinState.AlwaysLocal,
+      stats: {
+        blocks: 2,
+        size: 8 * 512,
+      },
+    });
+  });
+
+  it('should return false if pinState not AlwaysLocal', () => {
+    // Given
+    props.pinState = PinState.OnlineOnly;
+    // When
+    const res = isHydrationPending(props);
+    // Then
+    expect(res).toBe(false);
+  });
+
+  it('should return false if blocks match size', () => {
+    // Given
+    props.stats.blocks = 8;
+    // When
+    const res = isHydrationPending(props);
+    // Then
+    expect(res).toBe(false);
+  });
+
+  it('should return false if blocks are more than size', () => {
+    // Given
+    props.stats.blocks = 9;
+    // When
+    const res = isHydrationPending(props);
+    // Then
+    expect(res).toBe(false);
+  });
+
+  it('should return false if blocks are less than size', () => {
+    // Given
+    props.stats.blocks = 7;
+    // When
+    const res = isHydrationPending(props);
+    // Then
+    expect(res).toBe(true);
+  });
+});

--- a/src/apps/sync-engine/file-explorer-state/is-hydration-pending.test.ts
+++ b/src/apps/sync-engine/file-explorer-state/is-hydration-pending.test.ts
@@ -42,7 +42,7 @@ describe('is-hydration-pending', () => {
     expect(res).toBe(false);
   });
 
-  it('should return false if blocks are less than size', () => {
+  it('should return true if blocks are less than size', () => {
     // Given
     props.stats.blocks = 7;
     // When

--- a/src/apps/sync-engine/file-explorer-state/is-hydration-pending.ts
+++ b/src/apps/sync-engine/file-explorer-state/is-hydration-pending.ts
@@ -1,0 +1,18 @@
+import { PinState } from '@/node-win/types/placeholder.type';
+import { Stats } from 'fs';
+
+type Props = {
+  stats: Stats;
+  pinState: PinState;
+};
+
+export function isHydrationPending({ stats, pinState }: Props) {
+  if (pinState === PinState.AlwaysLocal) {
+    const expectedBlocks = Math.ceil(stats.size / 512);
+    const actualBlocks = stats.blocks;
+    const ratio = actualBlocks / expectedBlocks;
+    return ratio < 1;
+  }
+
+  return false;
+}

--- a/src/apps/sync-engine/file-explorer-state/is-modified.test.ts
+++ b/src/apps/sync-engine/file-explorer-state/is-modified.test.ts
@@ -1,0 +1,63 @@
+import { mockProps } from '@/tests/vitest/utils.helper.test';
+import { isModified } from './is-modified';
+import { PinState } from '@/node-win/types/placeholder.type';
+import { v4 } from 'uuid';
+import { FileUuid } from '@/apps/main/database/entities/DriveFile';
+
+describe('is-modified', () => {
+  const uuid = v4() as FileUuid;
+  let props: Parameters<typeof isModified>[0];
+
+  beforeEach(() => {
+    props = mockProps<typeof isModified>({
+      pinState: PinState.AlwaysLocal,
+      localFile: { uuid, stats: { size: 1000, mtime: new Date('2000-01-02T00:00:00.000Z') } },
+      remoteFilesMap: {
+        [uuid]: { size: 1500, updatedAt: '2000-01-01T00:00:00.000Z' },
+      },
+    });
+  });
+
+  it('should not update if remote file is not found', () => {
+    // Given
+    props.remoteFilesMap = {};
+    // When
+    const res = isModified(props);
+    // Then
+    expect(res).toBe(false);
+  });
+
+  it('should not update if sizes are equal', () => {
+    // Given
+    props.remoteFilesMap[uuid].size = 1000;
+    // When
+    const res = isModified(props);
+    // Then
+    expect(res).toBe(false);
+  });
+
+  it('should not update if local is not hydrated', () => {
+    // Given
+    props.pinState = PinState.OnlineOnly;
+    // When
+    const res = isModified(props);
+    // Then
+    expect(res).toBe(false);
+  });
+
+  it('should not update if remote is newer', () => {
+    // Given
+    props.remoteFilesMap[uuid].updatedAt = '2000-01-03T00:00:00.000Z';
+    // When
+    const res = isModified(props);
+    // Then
+    expect(res).toBe(false);
+  });
+
+  it('should update', () => {
+    // When
+    const res = isModified(props);
+    // Then
+    expect(res).toBe(true);
+  });
+});

--- a/src/apps/sync-engine/file-explorer-state/is-modified.ts
+++ b/src/apps/sync-engine/file-explorer-state/is-modified.ts
@@ -1,0 +1,40 @@
+import { logger } from '@/apps/shared/logger/logger';
+import { PinState } from '@/node-win/types/placeholder.type';
+import { FileExplorerFile, RemoteFilesMap } from './file-explorer-state.types';
+
+type Props = {
+  remoteFilesMap: RemoteFilesMap;
+  localFile: FileExplorerFile;
+  pinState: PinState;
+};
+
+export function isModified({ remoteFilesMap, localFile, pinState }: Props) {
+  const remoteFile = remoteFilesMap[localFile.uuid];
+
+  if (!remoteFile) return false;
+
+  const { path } = localFile;
+  const localSize = localFile.stats.size;
+  const remoteSize = remoteFile.size;
+
+  if (localSize !== remoteSize) {
+    logger.debug({ tag: 'SYNC-ENGINE', msg: 'File has been modified', path, localSize, remoteSize });
+
+    const localDate = localFile.stats.mtime;
+    const remoteDate = new Date(remoteFile.updatedAt);
+
+    if (remoteDate > localDate) {
+      logger.debug({ tag: 'SYNC-ENGINE', msg: 'Remote file is newer, skipping', path, remoteDate, localDate });
+      return false;
+    }
+
+    if (pinState !== PinState.AlwaysLocal) {
+      logger.debug({ tag: 'SYNC-ENGINE', msg: 'Cannot update file contents id, not hydrated', path, pinState });
+      return false;
+    }
+
+    return true;
+  }
+
+  return false;
+}

--- a/src/apps/sync-engine/file-explorer-state/process-item.test.ts
+++ b/src/apps/sync-engine/file-explorer-state/process-item.test.ts
@@ -1,0 +1,117 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+import { mockProps, partialSpyOn } from '@/tests/vitest/utils.helper.test';
+import { processItem } from './process-item';
+import { NodeWin } from '@/infra/node-win/node-win.module';
+import { GetFolderIdentityError } from '@/infra/node-win/services/item-identity/get-folder-identity';
+import { pathUtils, RelativePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
+import { FolderUuid } from '@/apps/main/database/entities/DriveFolder';
+import { GetFileIdentityError } from '@/infra/node-win/services/item-identity/get-file-identity';
+import { FileUuid } from '@/apps/main/database/entities/DriveFile';
+import { PinState } from '@/node-win/types/placeholder.type';
+import * as isModified from './is-modified';
+import * as isHydrationPending from './is-hydration-pending';
+
+describe('process-item', () => {
+  const getFolderUuidMock = partialSpyOn(NodeWin, 'getFolderUuid');
+  const getFileUuidMock = partialSpyOn(NodeWin, 'getFileUuid');
+  const absoluteToRelativeMock = partialSpyOn(pathUtils, 'absoluteToRelative');
+  const isModifiedMock = partialSpyOn(isModified, 'isModified');
+  const isHydrationPendingMock = partialSpyOn(isHydrationPending, 'isHydrationPending');
+
+  let props: Parameters<typeof processItem>[0];
+
+  beforeEach(() => {
+    absoluteToRelativeMock.mockReturnValue('/item' as RelativePath);
+
+    props = mockProps<typeof processItem>({
+      ctx: { virtualDrive: {} },
+      localItem: { stats: { isDirectory: () => false, isFile: () => false } },
+      state: { createFolders: [], createFiles: [], modifiedFiles: [], hydrateFiles: [] },
+    });
+  });
+
+  describe('for folders', () => {
+    beforeEach(() => {
+      props.localItem.stats!.isDirectory = () => true;
+    });
+
+    it('should be added to create folders if not exists', () => {
+      // Given
+      getFolderUuidMock.mockReturnValue({ error: new GetFolderIdentityError('NON_EXISTS') });
+      // When
+      processItem(props);
+      // Then
+      expect(props.state).toStrictEqual({
+        createFolders: [expect.objectContaining({ path: '/item' })],
+        createFiles: [],
+        modifiedFiles: [],
+        hydrateFiles: [],
+      });
+    });
+
+    it('should not be added to create folders if exists', () => {
+      // Given
+      getFolderUuidMock.mockReturnValue({ data: 'uuid' as FolderUuid });
+      // When
+      processItem(props);
+      // Then
+      expect(props.state).toStrictEqual({
+        createFolders: [],
+        createFiles: [],
+        modifiedFiles: [],
+        hydrateFiles: [],
+      });
+    });
+  });
+
+  describe('for files', () => {
+    beforeEach(() => {
+      props.localItem.stats!.isFile = () => true;
+      props.ctx.virtualDrive.getPlaceholderState = () => ({ pinState: PinState.AlwaysLocal });
+      getFileUuidMock.mockReturnValue({ data: 'uuid' as FileUuid });
+    });
+
+    it('should be added to create files if not exists', () => {
+      // Given
+      getFileUuidMock.mockReturnValue({ error: new GetFileIdentityError('NON_EXISTS') });
+      // When
+      processItem(props);
+      // Then
+      expect(props.state).toStrictEqual({
+        createFolders: [],
+        createFiles: [expect.objectContaining({ path: '/item' })],
+        modifiedFiles: [],
+        hydrateFiles: [],
+      });
+    });
+
+    it('should be added to modified files if modified', () => {
+      // Given
+      isModifiedMock.mockReturnValue(true);
+      // When
+      processItem(props);
+      // Then
+      expect(props.state).toStrictEqual({
+        createFolders: [],
+        createFiles: [],
+        modifiedFiles: [expect.objectContaining({ path: '/item' })],
+        hydrateFiles: [],
+      });
+    });
+
+    it('should be added to hydrate files if hydration is pending', () => {
+      // Given
+      isHydrationPendingMock.mockReturnValue(true);
+      // When
+      processItem(props);
+      // Then
+      expect(props.state).toStrictEqual({
+        createFolders: [],
+        createFiles: [],
+        modifiedFiles: [],
+        hydrateFiles: [expect.objectContaining({ path: '/item' })],
+      });
+    });
+  });
+});

--- a/src/apps/sync-engine/file-explorer-state/process-item.ts
+++ b/src/apps/sync-engine/file-explorer-state/process-item.ts
@@ -1,0 +1,50 @@
+import { NodeWin } from '@/infra/node-win/node-win.module';
+import { ProcessSyncContext } from '../config';
+import { SyncWalkItem } from '@/infra/file-system/services/sync-walk';
+import { isHydrationPending } from './is-hydration-pending';
+import { pathUtils } from '@/context/local/localFile/infrastructure/AbsolutePath';
+import { isModified } from './is-modified';
+import { FileExplorerState, RemoteFilesMap } from './file-explorer-state.types';
+
+type Props = {
+  ctx: ProcessSyncContext;
+  localItem: SyncWalkItem;
+  state: FileExplorerState;
+  remoteFilesMap: RemoteFilesMap;
+};
+
+export function processItem({ ctx, localItem, state, remoteFilesMap }: Props) {
+  const { absolutePath, stats } = localItem;
+
+  if (!stats) return;
+
+  const path = pathUtils.absoluteToRelative({ base: ctx.virtualDrive.syncRootPath, path: absolutePath });
+  const pendingFileExplorerItem = { path, absolutePath, stats };
+
+  if (stats.isDirectory()) {
+    const { error } = NodeWin.getFolderUuid({ ctx, path });
+
+    if (error && error.code === 'NON_EXISTS') {
+      state.createFolders.push(pendingFileExplorerItem);
+    }
+  }
+
+  if (stats.isFile()) {
+    const { data: uuid, error } = NodeWin.getFileUuid({ drive: ctx.virtualDrive, path });
+
+    if (uuid) {
+      const { pinState } = ctx.virtualDrive.getPlaceholderState({ path });
+      const localFile = { ...pendingFileExplorerItem, uuid };
+
+      if (isHydrationPending({ stats, pinState })) {
+        state.hydrateFiles.push(localFile);
+      } else if (isModified({ localFile, remoteFilesMap, pinState })) {
+        state.modifiedFiles.push(localFile);
+      }
+    }
+
+    if (error && error.code === 'NON_EXISTS') {
+      state.createFiles.push(pendingFileExplorerItem);
+    }
+  }
+}

--- a/src/infra/file-system/services/sync-walk.test.ts
+++ b/src/infra/file-system/services/sync-walk.test.ts
@@ -1,0 +1,40 @@
+import { deepMocked, mockProps, partialSpyOn } from '@/tests/vitest/utils.helper.test';
+import { readdir } from 'fs/promises';
+import { fileSystem } from '@/infra/file-system/file-system.module';
+import { Dirent } from 'fs';
+import { AbsolutePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
+import { syncWalk } from './sync-walk';
+
+vi.mock(import('fs/promises'));
+
+describe('sync-walk', () => {
+  const readdirMock = deepMocked(readdir);
+  const statMock = partialSpyOn(fileSystem, 'stat');
+
+  const rootFolder = 'C:/Users/user/InternxtDrive' as AbsolutePath;
+  const props = mockProps<typeof syncWalk>({ rootFolder });
+
+  it('should return files and folders', async () => {
+    // Given
+    readdirMock
+      .mockResolvedValueOnce(['file1', 'folder1', 'folder2'] as unknown as Dirent<Buffer>[])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(['file2'] as unknown as Dirent<Buffer>[]);
+
+    statMock
+      .mockResolvedValueOnce({ data: { isDirectory: () => false, isFile: () => true } })
+      .mockResolvedValueOnce({ data: { isDirectory: () => true, isFile: () => false } })
+      .mockResolvedValueOnce({ data: { isDirectory: () => true, isFile: () => false } })
+      .mockResolvedValueOnce({ data: { isDirectory: () => false, isFile: () => true } });
+
+    // When
+    const results = await syncWalk(props);
+    // Then
+    expect(results).toMatchObject([
+      { absolutePath: 'C:\\Users\\user\\InternxtDrive\\file1' },
+      { absolutePath: 'C:\\Users\\user\\InternxtDrive\\folder1' },
+      { absolutePath: 'C:\\Users\\user\\InternxtDrive\\folder2' },
+      { absolutePath: 'C:\\Users\\user\\InternxtDrive\\folder1\\file2' },
+    ]);
+  });
+});

--- a/src/infra/file-system/services/sync-walk.ts
+++ b/src/infra/file-system/services/sync-walk.ts
@@ -5,7 +5,7 @@ import { join } from 'path';
 import { StatError } from './stat';
 import { fileSystem } from '../file-system.module';
 
-type Results = Array<{ absolutePath: AbsolutePath } & ({ stats: Stats; error?: undefined } | { error: StatError; stats?: undefined })>;
+export type SyncWalkItem = { absolutePath: AbsolutePath } & ({ stats: Stats; error?: undefined } | { error: StatError; stats?: undefined });
 type Props = { rootFolder: string };
 
 /**
@@ -15,7 +15,7 @@ type Props = { rootFolder: string };
  */
 export async function syncWalk({ rootFolder }: Props) {
   const stack = [rootFolder];
-  const results: Results = [];
+  const results: SyncWalkItem[] = [];
 
   while (stack.length > 0) {
     const folder = stack.pop();


### PR DESCRIPTION
## What

This is the first of 3 PRs that are going to simplify the way we read the current file explorer state and perform actions based on that on the sync process start. Currently we were checking if a file or folder did not have a placeholder and in that case we were creating them. We were also checking if the size of the remote file was different from the local one and update contents id in that case. And finally we were using a queue mananger to keep track of files that were pending for hydration so we can hydrate them when the app starts again.

Now, we are going to join all 4 into the same function so we just iterate the sync folder just one time. Also, we are going to stop using the queue manager since we are going to check the PinState of a file in the explorer and the number of blocks it have to know if the file is hydrated or not and if it should.