### PR TITLE
feat: allow users to choose custom sync folder location

### DIFF
--- a/src/apps/main/preload.ts
+++ b/src/apps/main/preload.ts
@@ -157,6 +157,9 @@ const api = {
   chooseSyncRootWithDialog(): ReturnType<typeof chooseSyncRootWithDialog> {
     return ipcRenderer.invoke('choose-sync-root-with-dialog');
   },
+  getSyncRoot(): Promise<string> {
+    return ipcRenderer.invoke('get-sync-root');
+  },
   getOrCreateDevice(): ReturnType<typeof getOrCreateDevice> {
     return ipcRenderer.invoke('get-or-create-device');
   },

--- a/src/apps/main/virtual-root-folder/handlers.ts
+++ b/src/apps/main/virtual-root-folder/handlers.ts
@@ -1,9 +1,10 @@
 import { ipcMain } from 'electron';
 
-import { chooseSyncRootWithDialog, openVirtualDriveRootFolder } from './service';
+import { chooseSyncRootWithDialog, getRootVirtualDrive, openVirtualDriveRootFolder } from './service';
 
 export function setupVirtualDriveHandlers() {
   ipcMain.handle('choose-sync-root-with-dialog', chooseSyncRootWithDialog);
   ipcMain.handle('open-virtual-drive-folder', openVirtualDriveRootFolder);
+  ipcMain.handle('get-sync-root', async () => getRootVirtualDrive());
   ipcMain.handle('retry-virtual-drive-mount', chooseSyncRootWithDialog);
 }

--- a/src/apps/main/virtual-root-folder/service.ts
+++ b/src/apps/main/virtual-root-folder/service.ts
@@ -32,9 +32,9 @@ export function getRootVirtualDrive(): string {
     current,
   });
 
-  if (!current.includes(user.uuid)) {
+  if (!current) {
     logger.debug({
-      msg: 'Root virtual drive not found for user',
+      msg: 'Root virtual drive not set, setting up default',
     });
     setupRootFolder(user);
     const newRoot = configStore.get('syncRoot');

--- a/src/apps/renderer/localize/locales/en.json
+++ b/src/apps/renderer/localize/locales/en.json
@@ -59,6 +59,13 @@
         "title": "Keep your computer safe from virus",
         "description": "Internxt's Desktop app now also features the brand new Internxt Antivirus, with which you can scan and remove any potential malware from your device."
       },
+      "sync-folder": {
+        "title": "Choose your sync folder location",
+        "description": "Select where you want to store your Internxt Drive files on your computer.",
+        "current-path": "Selected location:",
+        "default-path": "Default: C:\\Users\\<username>\\InternxtDrive",
+        "choose-folder": "Choose folder"
+      },
       "backups": {
         "title": "Backup your device on the cloud",
         "description": "With Internxt's upgraded backup feature, you can now safely backup folders on the cloud in order to free up space locally."

--- a/src/apps/renderer/localize/locales/es.json
+++ b/src/apps/renderer/localize/locales/es.json
@@ -59,6 +59,13 @@
         "title": "Mantén tu ordenador protegido contra virus",
         "description": "La aplicación de escritorio de Internxt ahora también cuenta con el nuevo Internxt Antivirus, con el que puedes escanear y eliminar cualquier posible malware de tu dispositivo."
       },
+      "sync-folder": {
+        "title": "Elige la ubicación de tu carpeta de sincronización",
+        "description": "Selecciona dónde quieres almacenar tus archivos de Internxt Drive en tu computadora.",
+        "current-path": "Ubicación seleccionada:",
+        "default-path": "Predeterminado: C:\\Users\\<usuario>\\InternxtDrive",
+        "choose-folder": "Elegir carpeta"
+      },
       "backups": {
         "title": "Haz copias de seguridad de tu dispositivo en la nube",
         "description": "Con la función mejorada de copias de seguridad de Internxt, ahora puedes hacer copias de seguridad de tus carpetas en la nube de manera segura para liberar espacio localmente."

--- a/src/apps/renderer/localize/locales/fr.json
+++ b/src/apps/renderer/localize/locales/fr.json
@@ -59,6 +59,13 @@
         "title": "Protégez votre ordinateur contre les virus",
         "description": "L'application de bureau d'Internxt intègre désormais le tout nouveau Internxt Antivirus, qui vous permet d'analyser et de supprimer tout malware potentiel de votre appareil."
       },
+      "sync-folder": {
+        "title": "Choisissez l'emplacement de votre dossier de synchronisation",
+        "description": "Sélectionnez où vous souhaitez stocker vos fichiers Internxt Drive sur votre ordinateur.",
+        "current-path": "Emplacement sélectionné :",
+        "default-path": "Par défaut : C:\\Users\\<utilisateur>\\InternxtDrive",
+        "choose-folder": "Choisir un dossier"
+      },
       "backups": {
         "title": "Sauvegardez votre appareil sur le cloud",
         "description": "Avec la fonction de sauvegarde améliorée d'Internxt, vous pouvez désormais sauvegarder vos dossiers en toute sécurité sur le cloud afin de libérer de l'espace localement."

--- a/src/apps/renderer/pages/Onboarding/config.tsx
+++ b/src/apps/renderer/pages/Onboarding/config.tsx
@@ -21,6 +21,7 @@ import ContextMenuSvg from '../../assets/onboarding/context-menu.svg';
 import BackupsSvg from '../../assets/onboarding/backups.svg';
 import BackupsDarkSvg from '../../assets/onboarding/backups-dark.svg';
 import { OnboardingCompletedSlide } from './slides/OnboardingCompletedSlide';
+import { SyncFolderSlide } from './slides/SyncFolderSlide';
 import Button from '../../components/Button';
 import { useTranslationContext } from '../../context/LocalContext';
 import { BackupsSlide } from './slides/BackupsSlide';
@@ -291,6 +292,41 @@ export const SLIDES: OnboardingSlide[] = [
       return (
         <div className="flex h-full w-full items-center justify-center">
           <BackupsImage />
+        </div>
+      );
+    },
+  },
+  {
+    name: 'Sync Folder',
+    component: (props) => {
+      return (
+        <div className="flex h-full w-full">
+          <SideTextAnimation display>
+            <SyncFolderSlide {...props} />
+          </SideTextAnimation>
+        </div>
+      );
+    },
+    footer: (props) => {
+      const { translate } = useTranslationContext();
+      return (
+        <div className="flex w-full flex-1 items-end justify-center">
+          <Button onClick={props.onGoNextSlide} variant="primary" size="lg">
+            {translate('onboarding.common.continue')}
+          </Button>
+          <span className="ml-auto text-gray-50">
+            {translate('onboarding.common.onboarding-progress', {
+              current_slide: props.currentSlide,
+              total_slides: props.totalSlides,
+            })}
+          </span>
+        </div>
+      );
+    },
+    image: () => {
+      return (
+        <div className="relative ml-20 mt-20">
+          <WindowsFinderImage />
         </div>
       );
     },

--- a/src/apps/renderer/pages/Onboarding/slides/SyncFolderSlide.tsx
+++ b/src/apps/renderer/pages/Onboarding/slides/SyncFolderSlide.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { useTranslationContext } from '../../../context/LocalContext';
+
+interface Props {
+  onGoNextSlide: () => void;
+  currentSlide: number;
+  totalSlides: number;
+}
+
+export function SyncFolderSlide({ onGoNextSlide, currentSlide, totalSlides }: Props) {
+  const { translate } = useTranslationContext();
+  const [chosenPath, setChosenPath] = useState<string | null>(null);
+
+  const handleChooseFolder = async () => {
+    try {
+      const path = await window.electron.chooseSyncRootWithDialog();
+      if (path) {
+        setChosenPath(path);
+      }
+    } catch (error) {
+      console.error('Error choosing sync root:', error);
+    }
+  };
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      <h1 className="mb-6 text-3xl font-semibold text-gray-100">
+        {translate('onboarding.slides.sync-folder.title')}
+      </h1>
+      <h3 className="font-regular mb-4 text-lg leading-[22px] text-gray-100">
+        {translate('onboarding.slides.sync-folder.description')}
+      </h3>
+      <div className="mb-6">
+        <p className="text-sm text-gray-50 mb-2">
+          {translate('onboarding.slides.sync-folder.current-path')}
+        </p>
+        <p className="text-sm text-gray-100 bg-gray-5 px-3 py-2 rounded">
+          {chosenPath || translate('onboarding.slides.sync-folder.default-path')}
+        </p>
+      </div>
+      <button
+        onClick={handleChooseFolder}
+        className="mb-6 bg-primary text-white px-4 py-2 rounded hover:bg-primary-dark"
+      >
+        {translate('onboarding.slides.sync-folder.choose-folder')}
+      </button>
+    </div>
+  );
+}

--- a/src/apps/renderer/pages/Settings/General/SyncFolder.tsx
+++ b/src/apps/renderer/pages/Settings/General/SyncFolder.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { useTranslationContext } from '../../../context/LocalContext';
+
+export default function SyncFolder() {
+  const { translate } = useTranslationContext();
+  const [syncRoot, setSyncRoot] = useState<string>('');
+
+  useEffect(() => {
+    const fetchSyncRoot = async () => {
+      try {
+        const path = await window.electron.getSyncRoot();
+        setSyncRoot(path);
+      } catch (error) {
+        console.error('Error getting sync root:', error);
+      }
+    };
+    fetchSyncRoot();
+  }, []);
+
+  const handleChangeFolder = async () => {
+    try {
+      const newPath = await window.electron.chooseSyncRootWithDialog();
+      if (newPath) {
+        setSyncRoot(newPath);
+      }
+    } catch (error) {
+      console.error('Error changing sync root:', error);
+    }
+  };
+
+  return (
+    <section>
+      <p className="text-sm font-medium leading-4 text-gray-80">
+        {translate('settings.general.sync.folder')}
+      </p>
+      <div className="mt-2 flex items-center space-x-3">
+        <p className="flex-1 text-sm text-gray-100 bg-gray-5 px-3 py-2 rounded truncate">
+          {syncRoot}
+        </p>
+        <button
+          onClick={handleChangeFolder}
+          className="text-primary hover:text-primary-dark text-sm underline"
+        >
+          {translate('settings.general.sync.change-folder')}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/apps/renderer/pages/Settings/General/index.tsx
+++ b/src/apps/renderer/pages/Settings/General/index.tsx
@@ -1,6 +1,7 @@
 import AppInfo from './AppInfo';
 import DeviceName from './DeviceName';
 import LanguagePicker from './LanguagePicker';
+import SyncFolder from './SyncFolder';
 import ThemePicker from './ThemePicker';
 import StartAutomatically from './StartAutomatically';
 
@@ -16,6 +17,8 @@ export default function GeneralSection({ active }: { active: boolean }) {
           <LanguagePicker />
           <ThemePicker />
         </div>
+
+        <SyncFolder />
       </div>
       <div className="relative flex h-12 before:absolute before:inset-x-0 before:top-1/2 before:h-px before:-translate-y-1/2 before:bg-gray-10" />
       <AppInfo />


### PR DESCRIPTION
- Add onboarding slide for selecting sync folder during initial setup
- Display current sync root path in General settings with change option
- Modify sync root logic to persist custom paths instead of always defaulting
- Add IPC handlers for getting and setting sync root path
- Add translations for new UI elements in EN, ES, FR

Resolves [#835](https://github.com/internxt/drive-desktop/issues/835)