### PR TITLE
Remove rename operation

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "init:ci": "npm ci --ignore-scripts && node node_modules/electron/install.js",
     "init:dev": "npm install && node node_modules/electron/install.js && npm run build:dll && npm run reload-native-deps",
     "========== Code style ==========": "",
-    "lint": "eslint . --ext .ts,.tsx --max-warnings 406",
+    "lint": "eslint . --ext .ts,.tsx --max-warnings 408",
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier src tests --check",
     "format:fix": "prettier src tests --write",

--- a/src/apps/main/windows/broadcast-to-windows.d.ts
+++ b/src/apps/main/windows/broadcast-to-windows.d.ts
@@ -16,9 +16,6 @@ export type SyncInfoUpdateEvent = {
       | 'DOWNLOADING'
       | 'MOVE_ERROR'
       | 'MOVED'
-      | 'RENAME_ERROR'
-      | 'RENAMED'
-      | 'RENAMING'
       | 'UPLOAD_ERROR'
       | 'UPLOADED'
       | 'UPLOADING';

--- a/src/apps/renderer/localize/locales/en.json
+++ b/src/apps/renderer/localize/locales/en.json
@@ -167,8 +167,7 @@
           "uploaded": "Uploaded",
           "deleting": "Moving to trash",
           "deleted": "Moved to trash",
-          "renaming": "Renaming",
-          "renamed": "Renamed"
+          "moved": "Moved"
         }
       },
       "no-activity": {

--- a/src/apps/renderer/localize/locales/es.json
+++ b/src/apps/renderer/localize/locales/es.json
@@ -167,8 +167,7 @@
           "uploaded": "Subido",
           "deleting": "Moviendo a la papelera",
           "deleted": "Movido a la papelera",
-          "renaming": "Renombrando",
-          "renamed": "Renombrado"
+          "moved": "Movido"
         }
       },
       "no-activity": {

--- a/src/apps/renderer/localize/locales/fr.json
+++ b/src/apps/renderer/localize/locales/fr.json
@@ -167,8 +167,7 @@
           "uploaded": "Téléchargé",
           "deleting": "Déplacement vers les poubelles",
           "deleted": "Déplacé vers la poubelle",
-          "renaming": "Renommer",
-          "renamed": "Renommé"
+          "moved": "Déplacé"
         }
       },
       "no-activity": {

--- a/src/apps/renderer/pages/Widget/Item.tsx
+++ b/src/apps/renderer/pages/Widget/Item.tsx
@@ -29,10 +29,8 @@ export function Item({
     description = translate('widget.body.activity.operation.uploaded');
   } else if (action === 'DELETED') {
     description = translate('widget.body.activity.operation.deleted');
-  } else if (action === 'RENAMING') {
-    description = translate('widget.body.activity.operation.renaming');
-  } else if (action === 'RENAMED') {
-    description = translate('widget.body.activity.operation.renamed');
+  } else if (action === 'MOVED') {
+    description = translate('widget.body.activity.operation.moved');
   }
 
   return (
@@ -46,12 +44,12 @@ export function Item({
           </p>
           <p
             className={`truncate text-xs text-gray-50 ${
-              action && (action === 'DELETE_ERROR' || action === 'DOWNLOAD_ERROR' || action === 'UPLOAD_ERROR' || action === 'RENAME_ERROR')
+              action && (action === 'DELETE_ERROR' || action === 'DOWNLOAD_ERROR' || action === 'UPLOAD_ERROR' || action === 'MOVE_ERROR')
                 ? 'text-red'
                 : undefined
             }`}
             title={
-              action && (action === 'DELETE_ERROR' || action === 'DOWNLOAD_ERROR' || action === 'UPLOAD_ERROR' || action === 'RENAME_ERROR')
+              action && (action === 'DELETE_ERROR' || action === 'DOWNLOAD_ERROR' || action === 'UPLOAD_ERROR' || action === 'MOVE_ERROR')
                 ? description
                 : undefined
             }>
@@ -61,7 +59,7 @@ export function Item({
 
         <div className="flex w-7 items-center justify-center">
           {/* PROGRESS */}
-          {action && (action === 'UPLOADING' || action === 'DOWNLOADING' || action === 'RENAMING') && (
+          {action && (action === 'UPLOADING' || action === 'DOWNLOADING') && (
             <CircularProgressbar
               value={progress ?? 0}
               minValue={0}
@@ -82,13 +80,12 @@ export function Item({
               action === 'DOWNLOADED' ||
               action === 'DOWNLOAD_CANCEL' ||
               action === 'UPLOADED' ||
-              action === 'RENAMED') && <Check size={24} className="text-green" weight="bold" />}
+              action === 'MOVED') && <Check size={24} className="text-green" weight="bold" />}
 
           {/* ERROR */}
-          {action &&
-            (action === 'DELETE_ERROR' || action === 'DOWNLOAD_ERROR' || action === 'UPLOAD_ERROR' || action === 'RENAME_ERROR') && (
-              <WarningCircle size={24} className="text-red" weight="regular" />
-            )}
+          {action && (action === 'DELETE_ERROR' || action === 'DOWNLOAD_ERROR' || action === 'UPLOAD_ERROR' || action === 'MOVE_ERROR') && (
+            <WarningCircle size={24} className="text-red" weight="regular" />
+          )}
         </div>
       </div>
     </div>

--- a/src/apps/shared/HttpClient/schema.ts
+++ b/src/apps/shared/HttpClient/schema.ts
@@ -2669,6 +2669,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/auth/cli/login/access': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** CLI platform login access */
+    post: operations['AuthController_cliLoginAccess'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/links': {
     parameters: {
       query?: never;
@@ -4715,6 +4732,11 @@ export interface components {
        * @example 123456
        */
       maxSpaceBytes: number;
+      /**
+       * @description Tier ID to update user tier (optional)
+       * @example a1b2c3d4-e5f6-7890-abcd-ef1234567890
+       */
+      tierId?: string;
     };
   };
   responses: never;
@@ -6451,12 +6473,12 @@ export interface operations {
   };
   WorkspacesController_getFiles: {
     parameters: {
-      query: {
+      query?: {
         /** @description Items per page */
         limit?: number;
         /** @description Offset for pagination */
         offset?: number;
-        status: string;
+        status?: 'EXISTS' | 'TRASHED' | 'DELETED' | 'ALL';
         bucket?: string;
         sort?: string;
         order?: string;
@@ -6513,6 +6535,7 @@ export interface operations {
         limit?: number;
         /** @description Offset for pagination */
         offset?: number;
+        status?: 'EXISTS' | 'TRASHED' | 'DELETED' | 'ALL';
       };
       header?: never;
       path: {
@@ -8880,6 +8903,37 @@ export interface operations {
     responses: {
       /** @description Credentials are correct */
       200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  AuthController_cliLoginAccess: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LoginAccessDto'];
+      };
+    };
+    responses: {
+      /** @description CLI user successfully accessed their account */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['LoginAccessResponseDto'];
+        };
+      };
+      /** @description This user current tier does not allow CLI access */
+      402: {
         headers: {
           [name: string]: unknown;
         };

--- a/src/backend/features/local-sync/watcher/events/rename-or-move/get-parent-uuid.test.ts
+++ b/src/backend/features/local-sync/watcher/events/rename-or-move/get-parent-uuid.test.ts
@@ -9,11 +9,6 @@ import { loggerMock } from '@/tests/vitest/mocks.helper.test';
 describe('get-parent-uuid', () => {
   const getFolderUuidMock = partialSpyOn(NodeWin, 'getFolderUuid');
 
-  const item = {
-    oldName: 'oldName.exe',
-    oldParentUuid: 'oldParentUuid',
-  };
-
   let props: Parameters<typeof getParentUuid>[0];
 
   beforeEach(() => {
@@ -22,7 +17,7 @@ describe('get-parent-uuid', () => {
     props = mockProps<typeof getParentUuid>({
       self: { logger: loggerMock },
       path: createRelativePath('folder', 'file.txt'),
-      item,
+      item: {},
     });
   });
 
@@ -47,13 +42,13 @@ describe('get-parent-uuid', () => {
     expect(loggerMock.error).toBeCalledTimes(1);
   });
 
-  it('should call return parentUuid if parent is found', () => {
+  it('should return parentUuid if parent is found', () => {
     // Given
     getFolderUuidMock.mockReturnValue({ data: 'newParentUuid' as FolderUuid });
     // When
     const parentUuid = getParentUuid(props);
     // Then
     expect(getFolderUuidMock).toBeCalledWith(expect.objectContaining({ path: '/folder' }));
-    expect(parentUuid).toStrictEqual({ parentUuid: 'newParentUuid', existingItem: item });
+    expect(parentUuid).toBe('newParentUuid');
   });
 });

--- a/src/backend/features/local-sync/watcher/events/rename-or-move/get-parent-uuid.ts
+++ b/src/backend/features/local-sync/watcher/events/rename-or-move/get-parent-uuid.ts
@@ -1,3 +1,5 @@
+import { SimpleDriveFile } from '@/apps/main/database/entities/DriveFile';
+import { SimpleDriveFolder } from '@/apps/main/database/entities/DriveFolder';
 import { ProcessSyncContext } from '@/apps/sync-engine/config';
 import { pathUtils, RelativePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
 import { NodeWin } from '@/infra/node-win/node-win.module';
@@ -6,22 +8,19 @@ import { Watcher } from '@/node-win/watcher/watcher';
 type TProps = {
   ctx: ProcessSyncContext;
   self: Watcher;
+  type: 'file' | 'folder';
   path: RelativePath;
-  props: Record<string, string>;
-  item?: {
-    oldName: string;
-    oldParentUuid: string | undefined;
-  };
+  item?: SimpleDriveFile | SimpleDriveFolder;
 };
 
-export function getParentUuid({ ctx, self, path, props, item }: TProps) {
+export function getParentUuid({ ctx, self, type, path, item }: TProps) {
   const parentPath = pathUtils.dirname(path);
   const { data: parentUuid, error } = NodeWin.getFolderUuid({ ctx, path: parentPath });
 
   if (!item || error) {
-    self.logger.error({ msg: 'Error moving item', ...props, item, error });
+    self.logger.error({ msg: 'Error moving item', type, path, error });
     return;
   }
 
-  return { existingItem: item, parentUuid };
+  return parentUuid;
 }

--- a/src/backend/features/local-sync/watcher/events/rename-or-move/move-file.test.ts
+++ b/src/backend/features/local-sync/watcher/events/rename-or-move/move-file.test.ts
@@ -28,8 +28,8 @@ describe('move-file', () => {
       expect.objectContaining({
         type: 'file',
         item: {
-          oldName: 'plainName.exe',
-          oldParentUuid: 'folderUuid',
+          name: 'plainName.exe',
+          parentUuid: 'folderUuid',
         },
       }),
     );

--- a/src/backend/features/local-sync/watcher/events/rename-or-move/move-file.test.ts
+++ b/src/backend/features/local-sync/watcher/events/rename-or-move/move-file.test.ts
@@ -28,7 +28,7 @@ describe('move-file', () => {
       expect.objectContaining({
         type: 'file',
         item: {
-          name: 'plainName.exe',
+          nameWithExtension: 'plainName.exe',
           parentUuid: 'folderUuid',
         },
       }),

--- a/src/backend/features/local-sync/watcher/events/rename-or-move/move-file.ts
+++ b/src/backend/features/local-sync/watcher/events/rename-or-move/move-file.ts
@@ -14,15 +14,19 @@ type TProps = {
 };
 
 export async function moveFile({ ctx, self, path, absolutePath, uuid }: TProps) {
-  const { data: item } = await ipcRendererSqlite.invoke('fileGetByUuid', { uuid });
+  try {
+    const { data: item } = await ipcRendererSqlite.invoke('fileGetByUuid', { uuid });
 
-  await moveItem({
-    ctx,
-    self,
-    path,
-    absolutePath,
-    uuid,
-    item,
-    type: 'file',
-  });
+    await moveItem({
+      ctx,
+      self,
+      path,
+      absolutePath,
+      uuid,
+      item,
+      type: 'file',
+    });
+  } catch (exc) {
+    self.logger.error({ msg: 'Error moving file', path, uuid, exc });
+  }
 }

--- a/src/backend/features/local-sync/watcher/events/rename-or-move/move-file.ts
+++ b/src/backend/features/local-sync/watcher/events/rename-or-move/move-file.ts
@@ -14,13 +14,15 @@ type TProps = {
 };
 
 export async function moveFile({ ctx, self, path, absolutePath, uuid }: TProps) {
-  try {
-    const { data: file } = await ipcRendererSqlite.invoke('fileGetByUuid', { uuid });
+  const { data: item } = await ipcRendererSqlite.invoke('fileGetByUuid', { uuid });
 
-    const item = file ? { oldParentUuid: file.parentUuid, oldName: file.nameWithExtension } : undefined;
-
-    await moveItem({ ctx, self, path, absolutePath, uuid, item, type: 'file' });
-  } catch (exc) {
-    self.logger.error({ msg: 'Error moving file', path, uuid, exc });
-  }
+  await moveItem({
+    ctx,
+    self,
+    path,
+    absolutePath,
+    uuid,
+    item,
+    type: 'file',
+  });
 }

--- a/src/backend/features/local-sync/watcher/events/rename-or-move/move-folder.test.ts
+++ b/src/backend/features/local-sync/watcher/events/rename-or-move/move-folder.test.ts
@@ -27,7 +27,7 @@ describe('move-folder', () => {
         type: 'folder',
         item: {
           name: 'plainName',
-          ParentUuid: 'folderUuid',
+          parentUuid: 'folderUuid',
         },
       }),
     );

--- a/src/backend/features/local-sync/watcher/events/rename-or-move/move-folder.test.ts
+++ b/src/backend/features/local-sync/watcher/events/rename-or-move/move-folder.test.ts
@@ -26,8 +26,8 @@ describe('move-folder', () => {
       expect.objectContaining({
         type: 'folder',
         item: {
-          oldName: 'plainName',
-          oldParentUuid: 'folderUuid',
+          name: 'plainName',
+          ParentUuid: 'folderUuid',
         },
       }),
     );

--- a/src/backend/features/local-sync/watcher/events/rename-or-move/move-folder.ts
+++ b/src/backend/features/local-sync/watcher/events/rename-or-move/move-folder.ts
@@ -14,13 +14,15 @@ type TProps = {
 };
 
 export async function moveFolder({ ctx, self, path, absolutePath, uuid }: TProps) {
-  try {
-    const { data: folder } = await ipcRendererSqlite.invoke('folderGetByUuid', { uuid });
+  const { data: item } = await ipcRendererSqlite.invoke('folderGetByUuid', { uuid });
 
-    const item = folder ? { oldParentUuid: folder.parentUuid, oldName: folder.name } : undefined;
-
-    await moveItem({ ctx, self, path, absolutePath, uuid, item, type: 'folder' });
-  } catch (exc) {
-    self.logger.error({ msg: 'Error moving folder', path, uuid, exc });
-  }
+  await moveItem({
+    ctx,
+    self,
+    path,
+    absolutePath,
+    uuid,
+    item,
+    type: 'folder',
+  });
 }

--- a/src/backend/features/local-sync/watcher/events/rename-or-move/move-folder.ts
+++ b/src/backend/features/local-sync/watcher/events/rename-or-move/move-folder.ts
@@ -14,15 +14,19 @@ type TProps = {
 };
 
 export async function moveFolder({ ctx, self, path, absolutePath, uuid }: TProps) {
-  const { data: item } = await ipcRendererSqlite.invoke('folderGetByUuid', { uuid });
+  try {
+    const { data: item } = await ipcRendererSqlite.invoke('folderGetByUuid', { uuid });
 
-  await moveItem({
-    ctx,
-    self,
-    path,
-    absolutePath,
-    uuid,
-    item,
-    type: 'folder',
-  });
+    await moveItem({
+      ctx,
+      self,
+      path,
+      absolutePath,
+      uuid,
+      item,
+      type: 'folder',
+    });
+  } catch (exc) {
+    self.logger.error({ msg: 'Error moving folder', path, uuid, exc });
+  }
 }

--- a/src/backend/features/local-sync/watcher/events/rename-or-move/move-item.ts
+++ b/src/backend/features/local-sync/watcher/events/rename-or-move/move-item.ts
@@ -1,8 +1,8 @@
 import { AbsolutePath, RelativePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
 import { basename } from 'node:path';
 import { Watcher } from '@/node-win/watcher/watcher';
-import { FileUuid } from '@/apps/main/database/entities/DriveFile';
-import { FolderUuid } from '@/apps/main/database/entities/DriveFolder';
+import { FileUuid, SimpleDriveFile } from '@/apps/main/database/entities/DriveFile';
+import { FolderUuid, SimpleDriveFolder } from '@/apps/main/database/entities/DriveFolder';
 import { ipcRendererDriveServerWip } from '@/infra/drive-server-wip/out/ipc-renderer';
 import { getParentUuid } from './get-parent-uuid';
 import { ProcessSyncContext } from '@/apps/sync-engine/config';
@@ -14,60 +14,27 @@ type TProps = {
   self: Watcher;
   path: RelativePath;
   absolutePath: AbsolutePath;
-  item?: {
-    oldName: string;
-    oldParentUuid: string | undefined;
-  };
+  item?: SimpleDriveFile | SimpleDriveFolder;
 } & ({ type: 'file'; uuid: FileUuid } | { type: 'folder'; uuid: FolderUuid });
 
 export async function moveItem({ ctx, self, path, absolutePath, uuid, item, type }: TProps) {
-  const props = { path, type, uuid };
-
-  const res = getParentUuid({ ctx, self, path, props, item });
-  if (!res) return;
-
-  const {
-    parentUuid,
-    existingItem: { oldName, oldParentUuid },
-  } = res;
-
-  const name = basename(path);
-  const isRenamed = oldName !== name;
-  /**
-   * v2.5.6 Daniel Jiménez
-   * We need to take into account that oldParentUuid can be undefined because
-   * for old items it has not been migrated yet in drive-server-wip. In this case
-   * we are going to mark it also as moved and we will help to the migration.
-   */
-  const isMoved = oldParentUuid !== parentUuid;
+  const parentUuid = getParentUuid({ ctx, self, type, path, item });
+  if (!parentUuid) return;
 
   const workspaceToken = ctx.workspaceToken;
+  const name = basename(path);
 
-  if (isRenamed) {
-    self.logger.debug({ msg: 'Item renamed', ...props, oldName, name });
+  self.logger.debug({ msg: 'Item moved', type, path });
 
-    if (type === 'file') {
-      await ipcRendererDriveServerWip.invoke('renameFileByUuid', { uuid, nameWithExtension: name, workspaceToken });
-    } else {
-      await ipcRendererDriveServerWip.invoke('renameFolderByUuid', { uuid, name, workspaceToken });
-    }
+  if (type === 'file') {
+    await ipcRendererDriveServerWip.invoke('moveFileByUuid', { uuid, parentUuid, nameWithExtension: name, workspaceToken });
+  } else {
+    await ipcRendererDriveServerWip.invoke('moveFolderByUuid', { uuid, parentUuid, name, workspaceToken });
   }
 
-  if (isMoved) {
-    self.logger.debug({ msg: 'Item moved', ...props, oldParentUuid, parentUuid });
-
-    if (type === 'file') {
-      await ipcRendererDriveServerWip.invoke('moveFileByUuid', { uuid, parentUuid, nameWithExtension: name, workspaceToken });
-    } else {
-      await ipcRendererDriveServerWip.invoke('moveFolderByUuid', { uuid, parentUuid, name, workspaceToken });
-    }
-  }
-
-  if (isRenamed || isMoved) {
-    if (type === 'file') {
-      updateFileStatus({ ctx, path });
-    } else {
-      await updateFolderStatus({ ctx, path, absolutePath });
-    }
+  if (type === 'file') {
+    updateFileStatus({ ctx, path });
+  } else {
+    await updateFolderStatus({ ctx, path, absolutePath });
   }
 }

--- a/src/context/virtual-drive/files/infrastructure/restore-parent-folder.test.ts
+++ b/src/context/virtual-drive/files/infrastructure/restore-parent-folder.test.ts
@@ -10,8 +10,7 @@ import { loggerMock } from '@/tests/vitest/mocks.helper.test';
 describe('restoreParentFolder', () => {
   const dirnameSpy = partialSpyOn(pathUtils, 'dirname');
   const getFolderUuidSpy = partialSpyOn(NodeWin, 'getFolderUuid');
-  const moveSpy = partialSpyOn(driveServerWip.folders, 'moveFolder');
-  const renameSpy = partialSpyOn(driveServerWip.folders, 'renameFolder');
+  const moveSpy = partialSpyOn(driveServerWip.folders, 'move');
 
   const props = mockProps<typeof restoreParentFolder>({
     offline: { path: '/gp/child/file.txt' as RelativePath, folderUuid: 'offline-folder-uuid' },
@@ -22,42 +21,33 @@ describe('restoreParentFolder', () => {
     dirnameSpy.mockReturnValueOnce('/gp/child' as RelativePath).mockReturnValueOnce('/gp' as RelativePath);
     getFolderUuidSpy.mockReturnValue({ data: 'parent-uuid' as FolderUuid });
     moveSpy.mockResolvedValue({ error: undefined });
-    renameSpy.mockResolvedValue({ error: undefined });
   });
 
-  it('moves and renames when remote parent does not exist', async () => {
+  it('should move when remote parent does not exist', async () => {
     await restoreParentFolder(props);
 
     expect(moveSpy).toBeCalledTimes(1);
-    expect(renameSpy).toBeCalledTimes(1);
 
     const [moveArgs] = getMockCalls(moveSpy);
     expect(moveArgs).toMatchObject({
       parentUuid: 'parent-uuid',
-      workspaceToken: 'WT',
-      uuid: 'offline-folder-uuid',
-    });
-
-    const [renameArgs] = getMockCalls(renameSpy);
-    expect(renameArgs).toMatchObject({
       name: 'child',
       workspaceToken: 'WT',
       uuid: 'offline-folder-uuid',
     });
   });
 
-  it('throws if move or rename fail, logging the error', async () => {
+  it('should throw if move fails, logging the error', async () => {
     moveSpy.mockResolvedValue({ error: {} });
 
     await expect(restoreParentFolder(props)).rejects.toThrow();
 
     expect(moveSpy).toBeCalledTimes(1);
-    expect(renameSpy).toBeCalledTimes(1);
 
     expect(loggerMock.error).toBeCalledWith(expect.objectContaining({ msg: 'Error restoring parent folder' }));
   });
 
-  it('throws and logs when parentUuid is missing', async () => {
+  it('should throw and log if parentUuid is missing', async () => {
     getFolderUuidSpy.mockReturnValue({ data: undefined });
 
     await expect(restoreParentFolder(props)).rejects.toThrow();
@@ -70,6 +60,5 @@ describe('restoreParentFolder', () => {
     );
 
     expect(moveSpy).not.toBeCalled();
-    expect(renameSpy).not.toBeCalled();
   });
 });

--- a/src/context/virtual-drive/files/infrastructure/restore-parent-folder.ts
+++ b/src/context/virtual-drive/files/infrastructure/restore-parent-folder.ts
@@ -21,20 +21,18 @@ export async function restoreParentFolder({ ctx, offline }: TProps) {
     throw logger.error({ msg: 'Could not restore parent folder, parentUuid not found', path: offline.path });
   }
 
-  const [{ error: moveError }, { error: renameError }] = await Promise.all([
-    driveServerWip.folders.moveFolder({
-      parentUuid,
-      workspaceToken: ctx.workspaceToken,
-      uuid: offline.folderUuid,
-    }),
-    driveServerWip.folders.renameFolder({
-      name: targetFolderName,
-      workspaceToken: ctx.workspaceToken,
-      uuid: offline.folderUuid,
-    }),
-  ]);
+  const { error } = await driveServerWip.folders.move({
+    parentUuid,
+    name: targetFolderName,
+    workspaceToken: ctx.workspaceToken,
+    uuid: offline.folderUuid,
+  });
 
-  if (moveError || (renameError && renameError.code !== 'FOLDER_ALREADY_EXISTS')) {
-    throw logger.error({ msg: 'Error restoring parent folder', path: offline.path, moveError, renameError });
+  if (error && error.code !== 'FOLDER_ALREADY_EXISTS') {
+    throw logger.error({
+      msg: 'Error restoring parent folder',
+      path: offline.path,
+      error,
+    });
   }
 }

--- a/src/infra/drive-server-wip/out/ipc-main.ts
+++ b/src/infra/drive-server-wip/out/ipc-main.ts
@@ -35,55 +35,28 @@ export function setupIpcDriveServerWip() {
     return res;
   });
 
-  ipcMainDriveServerWip.handle('renameFileByUuid', async (_, { uuid, workspaceToken, nameWithExtension }) => {
-    const { name, extension } = getNameAndExtension({ nameWithExtension });
-
-    const res = await driveServerWip.files.renameFile({ uuid, workspaceToken, name, extension });
-
-    if (res.error) {
-      broadcastToWindows({ name: 'sync-info-update', data: { action: 'RENAME_ERROR', name: nameWithExtension, key: uuid } });
-    } else {
-      broadcastToWindows({ name: 'sync-info-update', data: { action: 'RENAMED', name: nameWithExtension, key: uuid } });
-      await SqliteModule.FileModule.updateByUuid({ uuid, payload: { name, extension } });
-    }
-
-    return res;
-  });
-
-  ipcMainDriveServerWip.handle('renameFolderByUuid', async (_, { uuid, workspaceToken, name }) => {
-    const res = await driveServerWip.folders.renameFolder({ uuid, workspaceToken, name });
-
-    if (res.error) {
-      broadcastToWindows({ name: 'sync-info-update', data: { action: 'RENAME_ERROR', name, key: uuid } });
-    } else {
-      broadcastToWindows({ name: 'sync-info-update', data: { action: 'RENAMED', name, key: uuid } });
-      await SqliteModule.FolderModule.updateByUuid({ uuid, payload: { name } });
-    }
-
-    return res;
-  });
-
   ipcMainDriveServerWip.handle('moveFileByUuid', async (_, { uuid, workspaceToken, parentUuid, nameWithExtension }) => {
-    const res = await driveServerWip.files.moveFile({ uuid, parentUuid, workspaceToken });
+    const { name, extension } = getNameAndExtension({ nameWithExtension });
+    const res = await driveServerWip.files.move({ uuid, parentUuid, name, extension, workspaceToken });
 
     if (res.error) {
       broadcastToWindows({ name: 'sync-info-update', data: { action: 'MOVE_ERROR', name: nameWithExtension, key: uuid } });
     } else {
       broadcastToWindows({ name: 'sync-info-update', data: { action: 'MOVED', name: nameWithExtension, key: uuid } });
-      await SqliteModule.FileModule.updateByUuid({ uuid, payload: { parentUuid } });
+      await SqliteModule.FileModule.updateByUuid({ uuid, payload: { parentUuid, name, extension, status: 'EXISTS' } });
     }
 
     return res;
   });
 
   ipcMainDriveServerWip.handle('moveFolderByUuid', async (_, { uuid, workspaceToken, parentUuid, name }) => {
-    const res = await driveServerWip.folders.moveFolder({ uuid, parentUuid, workspaceToken });
+    const res = await driveServerWip.folders.move({ uuid, parentUuid, name, workspaceToken });
 
     if (res.error) {
       broadcastToWindows({ name: 'sync-info-update', data: { action: 'MOVE_ERROR', name, key: uuid } });
     } else {
       broadcastToWindows({ name: 'sync-info-update', data: { action: 'MOVED', name, key: uuid } });
-      await SqliteModule.FolderModule.updateByUuid({ uuid, payload: { parentUuid } });
+      await SqliteModule.FolderModule.updateByUuid({ uuid, payload: { parentUuid, name, status: 'EXISTS' } });
     }
 
     return res;

--- a/src/infra/drive-server-wip/out/ipc.ts
+++ b/src/infra/drive-server-wip/out/ipc.ts
@@ -13,28 +13,18 @@ export type FromProcess = {
     workspaceToken: string;
     name: string;
   }) => Awaited<ReturnType<typeof driveServerWip.storage.deleteFolderByUuid>>;
-  renameFileByUuid: (props: {
-    uuid: FileUuid;
-    workspaceToken: string;
-    nameWithExtension: string;
-  }) => Awaited<ReturnType<typeof driveServerWip.files.renameFile>>;
-  renameFolderByUuid: (props: {
-    uuid: FolderUuid;
-    workspaceToken: string;
-    name: string;
-  }) => Awaited<ReturnType<typeof driveServerWip.folders.renameFolder>>;
   moveFileByUuid: (props: {
     uuid: FileUuid;
     workspaceToken: string;
     parentUuid: FolderUuid;
     nameWithExtension: string;
-  }) => Awaited<ReturnType<typeof driveServerWip.files.moveFile>>;
+  }) => Awaited<ReturnType<typeof driveServerWip.files.move>>;
   moveFolderByUuid: (props: {
     uuid: FolderUuid;
     workspaceToken: string;
     parentUuid: FolderUuid;
     name: string;
-  }) => Awaited<ReturnType<typeof driveServerWip.folders.moveFolder>>;
+  }) => Awaited<ReturnType<typeof driveServerWip.folders.move>>;
 };
 
 export type FromMain = {};

--- a/src/infra/drive-server-wip/services/files.service.ts
+++ b/src/infra/drive-server-wip/services/files.service.ts
@@ -1,19 +1,19 @@
 import { paths } from '@/apps/shared/HttpClient/schema';
 import { clientWrapper } from '../in/client-wrapper.service';
-import { client, getWorkspaceHeader } from '@/apps/shared/HttpClient/client';
+import { client } from '@/apps/shared/HttpClient/client';
 import { getRequestKey } from '../in/get-in-flight-request';
 import { getByUuid } from './files/get-by-uuid';
 import { createFile } from './files/create-file';
 import { getByPath } from './files/get-by-path';
 import { checkExistence } from './files/check-existance';
+import { move } from './files/move';
 
 export const files = {
   getFiles,
   getByUuid,
   getByPath,
   createFile,
-  moveFile,
-  renameFile,
+  move,
   replaceFile,
   createThumbnail,
   checkExistence,
@@ -37,58 +37,6 @@ async function getFiles(context: { query: TGetFilesQuery }) {
     key,
     loggerBody: {
       msg: 'Get files request',
-      context,
-      attributes: {
-        method,
-        endpoint,
-      },
-    },
-  });
-}
-
-async function moveFile(context: { uuid: string; parentUuid: string; workspaceToken: string }) {
-  const method = 'PATCH';
-  const endpoint = '/files/{uuid}';
-  const key = getRequestKey({ method, endpoint, context });
-
-  const promiseFn = () =>
-    client.PATCH(endpoint, {
-      headers: getWorkspaceHeader({ workspaceToken: context.workspaceToken }),
-      body: { destinationFolder: context.parentUuid },
-      params: { path: { uuid: context.uuid } },
-    });
-
-  return await clientWrapper({
-    promiseFn,
-    key,
-    loggerBody: {
-      msg: 'Move file request',
-      context,
-      attributes: {
-        method,
-        endpoint,
-      },
-    },
-  });
-}
-
-async function renameFile(context: { uuid: string; name: string; extension: string; workspaceToken: string }) {
-  const method = 'PUT';
-  const endpoint = '/files/{uuid}/meta';
-  const key = getRequestKey({ method, endpoint, context });
-
-  const promiseFn = () =>
-    client.PUT(endpoint, {
-      headers: getWorkspaceHeader({ workspaceToken: context.workspaceToken }),
-      body: { plainName: context.name, type: context.extension },
-      params: { path: { uuid: context.uuid } },
-    });
-
-  return await clientWrapper({
-    promiseFn,
-    key,
-    loggerBody: {
-      msg: 'Rename file request',
       context,
       attributes: {
         method,

--- a/src/infra/drive-server-wip/services/files.service.ts
+++ b/src/infra/drive-server-wip/services/files.service.ts
@@ -1,6 +1,6 @@
 import { paths } from '@/apps/shared/HttpClient/schema';
 import { clientWrapper } from '../in/client-wrapper.service';
-import { client } from '@/apps/shared/HttpClient/client';
+import { client, getWorkspaceHeader } from '@/apps/shared/HttpClient/client';
 import { getRequestKey } from '../in/get-in-flight-request';
 import { getByUuid } from './files/get-by-uuid';
 import { createFile } from './files/create-file';
@@ -37,6 +37,51 @@ async function getFiles(context: { query: TGetFilesQuery }) {
     key,
     loggerBody: {
       msg: 'Get files request',
+      context,
+      attributes: {
+        method,
+        endpoint,
+      },
+    },
+  });
+}
+
+async function moveFile(context: { uuid: string; parentUuid: string; workspaceToken: string }) {
+  const method = 'PATCH';
+  const endpoint = '/files/{uuid}';
+  const key = getRequestKey({ method, endpoint, context });
+
+  const promiseFn = () =>
+    client.PATCH(endpoint, {
+      headers: getWorkspaceHeader({ workspaceToken: context.workspaceToken }),
+      body: { destinationFolder: context.parentUuid },
+      params: { path: { uuid: context.uuid } },
+    });
+
+  return await clientWrapper({
+    promiseFn,
+    key,
+    loggerBody: { msg: 'Move file request', context },
+  });
+}
+
+async function renameFile(context: { uuid: string; name: string; extension: string; workspaceToken: string }) {
+  const method = 'PUT';
+  const endpoint = '/files/{uuid}/meta';
+  const key = getRequestKey({ method, endpoint, context });
+
+  const promiseFn = () =>
+    client.PUT(endpoint, {
+      headers: getWorkspaceHeader({ workspaceToken: context.workspaceToken }),
+      body: { plainName: context.name, type: context.extension },
+      params: { path: { uuid: context.uuid } },
+    });
+
+  return await clientWrapper({
+    promiseFn,
+    key,
+    loggerBody: {
+      msg: 'Rename file request',
       context,
       attributes: {
         method,

--- a/src/infra/drive-server-wip/services/files/move.ts
+++ b/src/infra/drive-server-wip/services/files/move.ts
@@ -1,0 +1,44 @@
+import { client, getWorkspaceHeader } from '@/apps/shared/HttpClient/client';
+import { getRequestKey } from '../../in/get-in-flight-request';
+import { clientWrapper } from '../../in/client-wrapper.service';
+import { DriveServerWipError, TDriveServerWipError } from '../../out/error.types';
+import { parseFileDto } from '../../out/dto';
+
+class MoveFileError extends DriveServerWipError {
+  constructor(
+    public readonly code: TDriveServerWipError | 'FILE_ALREADY_EXISTS',
+    cause: unknown,
+  ) {
+    super(code, cause);
+  }
+}
+
+export async function move(context: { uuid: string; parentUuid: string; name: string; extension: string; workspaceToken: string }) {
+  const method = 'PATCH';
+  const endpoint = '/files/{uuid}';
+  const key = getRequestKey({ method, endpoint, context });
+
+  const promiseFn = () =>
+    client.PATCH(endpoint, {
+      headers: getWorkspaceHeader({ workspaceToken: context.workspaceToken }),
+      body: { destinationFolder: context.parentUuid, name: context.name, type: context.extension },
+      params: { path: { uuid: context.uuid } },
+    });
+
+  const { data, error } = await clientWrapper({
+    promiseFn,
+    key,
+    loggerBody: { msg: 'Move file request', context },
+  });
+
+  if (error) {
+    switch (true) {
+      case error.response?.status === 409:
+        return { error: new MoveFileError('FILE_ALREADY_EXISTS', error.cause) };
+      default:
+        return { error };
+    }
+  }
+
+  return { data: parseFileDto({ fileDto: data }) };
+}

--- a/src/infra/drive-server-wip/services/files/move.ts
+++ b/src/infra/drive-server-wip/services/files/move.ts
@@ -32,11 +32,10 @@ export async function move(context: { uuid: string; parentUuid: string; name: st
   });
 
   if (error) {
-    switch (true) {
-      case error.response?.status === 409:
-        return { error: new MoveFileError('FILE_ALREADY_EXISTS', error.cause) };
-      default:
-        return { error };
+    if (error.response?.status === 409) {
+      return { error: new MoveFileError('FILE_ALREADY_EXISTS', error.cause) };
+    } else {
+      return { error };
     }
   }
 

--- a/src/infra/drive-server-wip/services/folders.service.ts
+++ b/src/infra/drive-server-wip/services/folders.service.ts
@@ -1,12 +1,12 @@
-import { client, getWorkspaceHeader } from '@/apps/shared/HttpClient/client';
+import { client } from '@/apps/shared/HttpClient/client';
 import { paths } from '@/apps/shared/HttpClient/schema';
 import { clientWrapper } from '../in/client-wrapper.service';
 import { createFolder } from './folders/create-folder';
 import { getRequestKey } from '../in/get-in-flight-request';
 import { parseFileDto, parseFolderDto } from '../out/dto';
 import { getByUuid } from './folders/get-by-uuid';
-import { renameFolder } from './folders/rename-folder';
 import { checkExistence } from './folders/check-existence';
+import { move } from './folders/move';
 
 export const folders = {
   getByUuid,
@@ -15,8 +15,7 @@ export const folders = {
   getFolders,
   getFoldersByFolder,
   getFilesByFolder,
-  moveFolder,
-  renameFolder,
+  move,
   checkExistence,
 };
 
@@ -137,30 +136,4 @@ async function getFilesByFolder(
   } else {
     return { error: res.error };
   }
-}
-
-async function moveFolder(context: { uuid: string; parentUuid: string; workspaceToken: string }) {
-  const method = 'PATCH';
-  const endpoint = '/folders/{uuid}';
-  const key = getRequestKey({ method, endpoint, context });
-
-  const promiseFn = () =>
-    client.PATCH(endpoint, {
-      headers: getWorkspaceHeader({ workspaceToken: context.workspaceToken }),
-      params: { path: { uuid: context.uuid } },
-      body: { destinationFolder: context.parentUuid },
-    });
-
-  return await clientWrapper({
-    promiseFn,
-    key,
-    loggerBody: {
-      msg: 'Move folder request',
-      context,
-      attributes: {
-        method,
-        endpoint,
-      },
-    },
-  });
 }

--- a/src/infra/drive-server-wip/services/folders/move.ts
+++ b/src/infra/drive-server-wip/services/folders/move.ts
@@ -32,11 +32,10 @@ export async function move(context: { uuid: string; parentUuid: string; name: st
   });
 
   if (error) {
-    switch (true) {
-      case error.response?.status === 409:
-        return { error: new MoveFolderError('FOLDER_ALREADY_EXISTS', error.cause) };
-      default:
-        return { error };
+    if (error.response?.status === 409) {
+      return { error: new MoveFolderError('FOLDER_ALREADY_EXISTS', error.cause) };
+    } else {
+      return { error };
     }
   }
 

--- a/src/infra/drive-server-wip/services/folders/move.ts
+++ b/src/infra/drive-server-wip/services/folders/move.ts
@@ -4,7 +4,7 @@ import { clientWrapper } from '../../in/client-wrapper.service';
 import { DriveServerWipError, TDriveServerWipError } from '../../out/error.types';
 import { parseFolderDto } from '../../out/dto';
 
-class RenameFolderError extends DriveServerWipError {
+class MoveFolderError extends DriveServerWipError {
   constructor(
     public readonly code: TDriveServerWipError | 'FOLDER_ALREADY_EXISTS',
     cause: unknown,
@@ -13,32 +13,32 @@ class RenameFolderError extends DriveServerWipError {
   }
 }
 
-export async function renameFolder(context: { uuid: string; name: string; workspaceToken: string }) {
-  const method = 'PUT';
-  const endpoint = '/folders/{uuid}/meta';
+export async function move(context: { uuid: string; parentUuid: string; name: string; workspaceToken: string }) {
+  const method = 'PATCH';
+  const endpoint = '/folders/{uuid}';
   const key = getRequestKey({ method, endpoint, context });
 
   const promiseFn = () =>
-    client.PUT(endpoint, {
+    client.PATCH(endpoint, {
       headers: getWorkspaceHeader({ workspaceToken: context.workspaceToken }),
+      body: { destinationFolder: context.parentUuid, name: context.name },
       params: { path: { uuid: context.uuid } },
-      body: { plainName: context.name },
     });
 
-  const res = await clientWrapper({
+  const { data, error } = await clientWrapper({
     promiseFn,
     key,
-    loggerBody: { msg: 'Rename folder request', context },
+    loggerBody: { msg: 'Move folder request', context },
   });
 
-  if (res.error) {
+  if (error) {
     switch (true) {
-      case res.error.response?.status === 409:
-        return { error: new RenameFolderError('FOLDER_ALREADY_EXISTS', res.error.cause) };
+      case error.response?.status === 409:
+        return { error: new MoveFolderError('FOLDER_ALREADY_EXISTS', error.cause) };
       default:
-        return { error: res.error };
+        return { error };
     }
   }
 
-  return { data: parseFolderDto({ folderDto: res.data }) };
+  return { data: parseFolderDto({ folderDto: data }) };
 }


### PR DESCRIPTION
## What

Now the move endpoint also accepts the name and extension for files and the name for folders, so we can move and rename with just one endpoint which makes the code simpler. Previously we were checking if an items was moved, renamed, both or none, now we just call move and that handles it.