### PR TITLE
[PB-6324] Fix stuck partial hydrated files

### DIFF
--- a/src/apps/main/background-processes/sync-engine/services/load-virtual-drive.ts
+++ b/src/apps/main/background-processes/sync-engine/services/load-virtual-drive.ts
@@ -30,7 +30,6 @@ export async function loadVirtualDrive({ ctx }: Props) {
   } catch (error) {
     addSyncIssue({ error: 'CANNOT_REGISTER_VIRTUAL_DRIVE', name: rootPath });
     ctx.logger.error({ msg: 'Error loading virtual drive', error });
-    return;
   }
 }
 
@@ -41,6 +40,5 @@ async function getSyncRootFromPath(ctx: SyncContext) {
     return info;
   } catch (error) {
     ctx.logger.error({ msg: 'Error getting sync root from path', error });
-    return;
   }
 }

--- a/src/backend/features/remote-sync/file-explorer/update-file-placeholder.test.ts
+++ b/src/backend/features/remote-sync/file-explorer/update-file-placeholder.test.ts
@@ -3,28 +3,32 @@ import { FileUuid } from '@/apps/main/database/entities/DriveFile';
 import { AbsolutePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
 import * as validateWindowsName from '@/context/virtual-drive/items/validate-windows-name';
 import { Addon } from '@/node-win/addon-wrapper';
-import { loggerMock } from '@/tests/vitest/mocks.helper.test';
-import { call, mockProps, partialSpyOn } from '@/tests/vitest/utils.helper.test';
+import { PinState } from '@/node-win/types/placeholder.type';
+import { testLogger, testLoggerFn } from '@/tests/vitest/mocks.helper.test';
+import { call, calls, partialSpyOn, TestProps } from '@/tests/vitest/utils.helper.test';
 import * as needsToBeMoved from './needs-to-be-moved';
-import { FilePlaceholderUpdater } from './update-file-placeholder';
+import { updateFilePlaceholder } from './update-file-placeholder';
 
 vi.mock(import('node:fs/promises'));
 
 describe('update-file-placeholder', () => {
   const createFilePlaceholderMock = partialSpyOn(Addon, 'createFilePlaceholder');
   const updateSyncStatusMock = partialSpyOn(Addon, 'updateSyncStatus');
+  const setPinStateMock = partialSpyOn(Addon, 'setPinState');
   const validateWindowsNameMock = partialSpyOn(validateWindowsName, 'validateWindowsName');
   const needsToBeMovedMock = partialSpyOn(needsToBeMoved, 'needsToBeMoved');
   const renameMock = vi.mocked(rename);
 
   const date = '2000-01-01T00:00:00.000Z';
   const time = new Date(date).getTime();
-  let props: Parameters<typeof FilePlaceholderUpdater.update>[0];
+  let props: TestProps<typeof updateFilePlaceholder>;
 
   beforeEach(() => {
     validateWindowsNameMock.mockReturnValue({ isValid: true });
 
-    props = mockProps<typeof FilePlaceholderUpdater.update>({
+    props = {
+      ctx: { logger: testLogger },
+      isFirstExecution: false,
       files: new Map([['uuid' as FileUuid, { path: 'localPath' as AbsolutePath }]]),
       remote: {
         absolutePath: 'remotePath' as AbsolutePath,
@@ -33,27 +37,26 @@ describe('update-file-placeholder', () => {
         updatedAt: date,
         size: 1024,
       },
-    });
+    };
   });
 
   it('should do nothing if name is invalid', async () => {
     // Given
     validateWindowsNameMock.mockReturnValue({ isValid: false });
     // When
-    await FilePlaceholderUpdater.update(props);
+    await updateFilePlaceholder(props as any);
     // Then
-    expect(needsToBeMovedMock).toBeCalledTimes(0);
+    calls(needsToBeMovedMock).toHaveLength(0);
   });
 
   it('should create placeholder if file does not exist locally', async () => {
     // Given
     props.files = new Map();
     // When
-    await FilePlaceholderUpdater.update(props);
+    await updateFilePlaceholder(props as any);
     // Then
-    expect(needsToBeMovedMock).toBeCalledTimes(0);
-    expect(createFilePlaceholderMock).toBeCalledTimes(1);
-    expect(createFilePlaceholderMock).toBeCalledWith({
+    calls(needsToBeMovedMock).toHaveLength(0);
+    call(createFilePlaceholderMock).toStrictEqual({
       path: 'remotePath',
       placeholderId: 'FILE:uuid',
       size: 1024,
@@ -62,15 +65,30 @@ describe('update-file-placeholder', () => {
     });
   });
 
+  it('should reset pin state if file is partially hydrated', async () => {
+    // Given
+    props.isFirstExecution = true;
+    props.files = new Map([
+      [
+        'uuid' as FileUuid,
+        { path: 'remotePath' as AbsolutePath, stats: { size: 1024 }, placeholder: { pinState: PinState.AlwaysLocal, onDiskSize: 512 } },
+      ],
+    ]);
+    // When
+    await updateFilePlaceholder(props as any);
+    // Then
+    call(testLoggerFn).toStrictEqual({ msg: 'File stuck in hydrated state', onDiskSize: 512, size: 1024, path: 'remotePath' });
+    call(setPinStateMock).toStrictEqual({ path: 'remotePath', pinState: PinState.Unspecified });
+  });
+
   it('should move placeholder if it has been moved', async () => {
     // Given
     needsToBeMovedMock.mockResolvedValue(true);
     // When
-    await FilePlaceholderUpdater.update(props);
+    await updateFilePlaceholder(props as any);
     // Then
-    expect(createFilePlaceholderMock).toBeCalledTimes(0);
-    expect(renameMock).toBeCalledTimes(1);
-    expect(renameMock).toBeCalledWith('localPath', 'remotePath');
+    calls(createFilePlaceholderMock).toHaveLength(0);
+    call(renameMock).toStrictEqual(['localPath', 'remotePath']);
     call(updateSyncStatusMock).toStrictEqual({ path: 'remotePath' });
   });
 
@@ -78,10 +96,10 @@ describe('update-file-placeholder', () => {
     // Given
     needsToBeMovedMock.mockResolvedValue(false);
     // When
-    await FilePlaceholderUpdater.update(props);
+    await updateFilePlaceholder(props as any);
     // Then
-    expect(createFilePlaceholderMock).toBeCalledTimes(0);
-    expect(renameMock).toBeCalledTimes(0);
+    calls(createFilePlaceholderMock).toHaveLength(0);
+    calls(renameMock).toHaveLength(0);
   });
 
   it('should capture exception if something fails', async () => {
@@ -90,9 +108,9 @@ describe('update-file-placeholder', () => {
       throw new Error('Something failed');
     });
     // When
-    await FilePlaceholderUpdater.update(props);
+    await updateFilePlaceholder(props as any);
     // Then
-    expect(needsToBeMovedMock).toBeCalledTimes(0);
-    expect(loggerMock.error).toBeCalledTimes(1);
+    calls(needsToBeMovedMock).toHaveLength(0);
+    call(testLoggerFn).toMatchObject({ msg: 'Error updating file placeholder' });
   });
 });

--- a/src/backend/features/remote-sync/file-explorer/update-file-placeholder.ts
+++ b/src/backend/features/remote-sync/file-explorer/update-file-placeholder.ts
@@ -14,48 +14,46 @@ type Props = {
   isFirstExecution: boolean;
 };
 
-export class FilePlaceholderUpdater {
-  static async update({ ctx, remote, files, isFirstExecution }: Props) {
-    const path = remote.absolutePath;
+export async function updateFilePlaceholder({ ctx, remote, files, isFirstExecution }: Props) {
+  const path = remote.absolutePath;
+  const { size } = remote;
 
-    try {
-      const { isValid } = validateWindowsName({ path, name: remote.name });
-      if (!isValid) return;
+  try {
+    const { isValid } = validateWindowsName({ path, name: remote.name });
+    if (!isValid) return;
 
-      const local = files.get(remote.uuid);
+    const local = files.get(remote.uuid);
 
-      if (!local) {
-        await Addon.createFilePlaceholder({
-          path,
-          placeholderId: `FILE:${remote.uuid}`,
-          size: remote.size,
-          creationTime: new Date(remote.createdAt).getTime(),
-          lastWriteTime: new Date(remote.updatedAt).getTime(),
-        });
-
-        return;
-      } else if (isFirstExecution) {
-        // This situation can happen when the user performed an hydration of a folder with files inside and the
-        // files didn't complete the hydration before the app closes. The files stay in a stuck state forever.
-        // One option could be to resume the hydration, however, since when you hydrate a folder there is no way
-        // to cancel the hydration, maybe the user has forced the close of the app to finish it. It can be also
-        // the opposite, that the user wants to continue after opening the app again. We will keep the first use
-        // case since it's easier to implement, consumes less resources and in case the user wants to hydrate the
-        // folder he can perform the action again.
-        if (local.placeholder.pinState === PinState.AlwaysLocal && local.placeholder.onDiskSize < remote.size) {
-          ctx.logger.debug({ msg: 'File stuck in hydrated state', path });
-          await Addon.setPinState({ path, pinState: PinState.Unspecified });
-        }
-      }
-
-      await checkIfMoved({ ctx, type: 'file', remote, localPath: local.path });
-      await checkIfModified({ ctx, local, remote, isFirstExecution });
-    } catch (exc) {
-      ctx.logger.error({
-        msg: 'Error updating file placeholder',
+    if (!local) {
+      await Addon.createFilePlaceholder({
         path,
-        exc,
+        placeholderId: `FILE:${remote.uuid}`,
+        size,
+        creationTime: new Date(remote.createdAt).getTime(),
+        lastWriteTime: new Date(remote.updatedAt).getTime(),
       });
+
+      return;
     }
+
+    await checkIfMoved({ ctx, type: 'file', remote, localPath: local.path });
+    await checkIfModified({ ctx, local, remote, isFirstExecution });
+
+    if (isFirstExecution) {
+      // This situation can happen when the user performed an hydration of a folder with files inside and the
+      // files didn't complete the hydration before the app closes. The files stay in a stuck state forever.
+      // One option could be to resume the hydration, however, since when you hydrate a folder there is no way
+      // to cancel the hydration, maybe the user has forced the close of the app to finish it. It can also be
+      // the opposite, that the user wants to continue after opening the app again. We will keep the first use
+      // case since it's easier to implement, consumes less resources and in case the user wants to hydrate the
+      // folder he can perform the action again.
+      const { onDiskSize } = local.placeholder;
+      if (local.placeholder.pinState === PinState.AlwaysLocal && onDiskSize < size) {
+        ctx.logger.debug({ msg: 'File stuck in hydrated state', onDiskSize, size, path });
+        await Addon.setPinState({ path, pinState: PinState.Unspecified });
+      }
+    }
+  } catch (error) {
+    ctx.logger.error({ msg: 'Error updating file placeholder', path, error });
   }
 }

--- a/src/backend/features/remote-sync/file-explorer/update-file-placeholder.ts
+++ b/src/backend/features/remote-sync/file-explorer/update-file-placeholder.ts
@@ -2,6 +2,7 @@ import { ExtendedDriveFile } from '@/apps/main/database/entities/DriveFile';
 import { SyncContext } from '@/apps/sync-engine/config';
 import { validateWindowsName } from '@/context/virtual-drive/items/validate-windows-name';
 import { Addon } from '@/node-win/addon-wrapper';
+import { PinState } from '@/node-win/types/placeholder.type';
 import { FileExplorerFiles } from '../sync-items-by-checkpoint/load-in-memory-paths';
 import { checkIfModified } from './check-if-modified';
 import { checkIfMoved } from './check-if-moved';
@@ -33,6 +34,18 @@ export class FilePlaceholderUpdater {
         });
 
         return;
+      } else if (isFirstExecution) {
+        // This situation can happen when the user performed an hydration of a folder with files inside and the
+        // files didn't complete the hydration before the app closes. The files stay in a stuck state forever.
+        // One option could be to resume the hydration, however, since when you hydrate a folder there is no way
+        // to cancel the hydration, maybe the user has forced the close of the app to finish it. It can be also
+        // the opposite, that the user wants to continue after opening the app again. We will keep the first use
+        // case since it's easier to implement, consumes less resources and in case the user wants to hydrate the
+        // folder he can perform the action again.
+        if (local.placeholder.pinState === PinState.AlwaysLocal && local.placeholder.onDiskSize < remote.size) {
+          ctx.logger.debug({ msg: 'File stuck in hydrated state', path });
+          await Addon.setPinState({ path, pinState: PinState.Unspecified });
+        }
       }
 
       await checkIfMoved({ ctx, type: 'file', remote, localPath: local.path });

--- a/src/backend/features/remote-sync/file-explorer/update-folder-placeholder.test.ts
+++ b/src/backend/features/remote-sync/file-explorer/update-folder-placeholder.test.ts
@@ -6,7 +6,7 @@ import { Addon } from '@/node-win/addon-wrapper';
 import { loggerMock } from '@/tests/vitest/mocks.helper.test';
 import { call, mockProps, partialSpyOn } from '@/tests/vitest/utils.helper.test';
 import * as needsToBeMoved from './needs-to-be-moved';
-import { FolderPlaceholderUpdater } from './update-folder-placeholder';
+import { updateFolderPlaceholder } from './update-folder-placeholder';
 
 vi.mock(import('node:fs/promises'));
 
@@ -20,12 +20,12 @@ describe('update-folder-placeholder', () => {
   const date = '2000-01-01T00:00:00.000Z';
   const time = new Date(date).getTime();
 
-  let props: Parameters<typeof FolderPlaceholderUpdater.update>[0];
+  let props: Parameters<typeof updateFolderPlaceholder>[0];
 
   beforeEach(() => {
     validateWindowsNameMock.mockReturnValue({ isValid: true });
 
-    props = mockProps<typeof FolderPlaceholderUpdater.update>({
+    props = mockProps<typeof updateFolderPlaceholder>({
       folders: new Map([['uuid' as FolderUuid, { path: 'localPath' as AbsolutePath }]]),
       remote: {
         absolutePath: 'remotePath' as AbsolutePath,
@@ -40,7 +40,7 @@ describe('update-folder-placeholder', () => {
     // Given
     validateWindowsNameMock.mockReturnValue({ isValid: false });
     // When
-    const res = await FolderPlaceholderUpdater.update(props);
+    const res = await updateFolderPlaceholder(props);
     // Then
     expect(res).toBe(false);
     expect(needsToBeMovedMock).toBeCalledTimes(0);
@@ -50,7 +50,7 @@ describe('update-folder-placeholder', () => {
     // Given
     props.folders = new Map();
     // When
-    const res = await FolderPlaceholderUpdater.update(props);
+    const res = await updateFolderPlaceholder(props);
     // Then
     expect(res).toBe(true);
     expect(needsToBeMovedMock).toBeCalledTimes(0);
@@ -67,7 +67,7 @@ describe('update-folder-placeholder', () => {
     // Given
     needsToBeMovedMock.mockResolvedValue(true);
     // When
-    const res = await FolderPlaceholderUpdater.update(props);
+    const res = await updateFolderPlaceholder(props);
     // Then
     expect(res).toBe(true);
     expect(createFolderPlaceholderMock).toBeCalledTimes(0);
@@ -80,7 +80,7 @@ describe('update-folder-placeholder', () => {
     // Given
     needsToBeMovedMock.mockResolvedValue(false);
     // When
-    const res = await FolderPlaceholderUpdater.update(props);
+    const res = await updateFolderPlaceholder(props);
     // Then
     expect(res).toBe(true);
     expect(createFolderPlaceholderMock).toBeCalledTimes(0);
@@ -93,7 +93,7 @@ describe('update-folder-placeholder', () => {
       throw new Error('Something failed');
     });
     // When
-    const res = await FolderPlaceholderUpdater.update(props);
+    const res = await updateFolderPlaceholder(props);
     // Then
     expect(res).toBe(false);
     expect(needsToBeMovedMock).toBeCalledTimes(0);

--- a/src/backend/features/remote-sync/file-explorer/update-folder-placeholder.ts
+++ b/src/backend/features/remote-sync/file-explorer/update-folder-placeholder.ts
@@ -5,32 +5,36 @@ import { Addon } from '@/node-win/addon-wrapper';
 import { FileExplorerFolders } from '../sync-items-by-checkpoint/load-in-memory-paths';
 import { checkIfMoved } from './check-if-moved';
 
-export class FolderPlaceholderUpdater {
-  static async update({ ctx, remote, folders }: { ctx: SyncContext; remote: ExtendedDriveFolder; folders: FileExplorerFolders }) {
-    const path = remote.absolutePath;
+type Props = {
+  ctx: SyncContext;
+  remote: ExtendedDriveFolder;
+  folders: FileExplorerFolders;
+};
 
-    try {
-      const { isValid } = validateWindowsName({ path, name: remote.name });
-      if (!isValid) return false;
+export async function updateFolderPlaceholder({ ctx, remote, folders }: Props) {
+  const path = remote.absolutePath;
 
-      const local = folders.get(remote.uuid);
+  try {
+    const { isValid } = validateWindowsName({ path, name: remote.name });
+    if (!isValid) return false;
 
-      if (!local) {
-        await Addon.createFolderPlaceholder({
-          path,
-          placeholderId: `FOLDER:${remote.uuid}`,
-          creationTime: new Date(remote.createdAt).getTime(),
-          lastWriteTime: new Date(remote.updatedAt).getTime(),
-        });
+    const local = folders.get(remote.uuid);
 
-        return true;
-      }
+    if (!local) {
+      await Addon.createFolderPlaceholder({
+        path,
+        placeholderId: `FOLDER:${remote.uuid}`,
+        creationTime: new Date(remote.createdAt).getTime(),
+        lastWriteTime: new Date(remote.updatedAt).getTime(),
+      });
 
-      await checkIfMoved({ ctx, type: 'folder', remote, localPath: local.path });
       return true;
-    } catch (exc) {
-      ctx.logger.error({ msg: 'Error updating folder placeholder', path, exc });
-      return false;
     }
+
+    await checkIfMoved({ ctx, type: 'folder', remote, localPath: local.path });
+    return true;
+  } catch (exc) {
+    ctx.logger.error({ msg: 'Error updating folder placeholder', path, exc });
+    return false;
   }
 }

--- a/src/backend/features/remote-sync/sync-items-by-checkpoint/load-in-memory-paths.ts
+++ b/src/backend/features/remote-sync/sync-items-by-checkpoint/load-in-memory-paths.ts
@@ -5,8 +5,9 @@ import { SyncContext } from '@/apps/sync-engine/config';
 import { AbsolutePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
 import { statReaddir } from '@/infra/file-system/services/stat-readdir';
 import { NodeWin } from '@/infra/node-win/node-win.module';
+import { FilePlaceholder } from '@/infra/node-win/services/get-file-info';
 
-export type FileExplorerFiles = Map<FileUuid, { path: AbsolutePath; stats: Stats }>;
+export type FileExplorerFiles = Map<FileUuid, { path: AbsolutePath; stats: Stats; placeholder: FilePlaceholder }>;
 export type FileExplorerFolders = Map<FolderUuid, { path: AbsolutePath }>;
 
 type Props = {
@@ -21,16 +22,16 @@ export async function loadInMemoryPaths({ ctx }: Props) {
     const items = await statReaddir({ folder: parentPath });
 
     const filePromises = items.files.map(async ({ path, stats }) => {
-      const { data: fileInfo } = await NodeWin.getFileInfo({ path });
-      if (fileInfo) {
-        files.set(fileInfo.uuid, { stats, path });
+      const { data: placeholder } = await NodeWin.getFileInfo({ path });
+      if (placeholder) {
+        files.set(placeholder.uuid, { stats, path, placeholder });
       }
     });
 
     const folderPromises = items.folders.map(async ({ path }) => {
-      const { data: folderInfo } = await NodeWin.getFolderInfo({ ctx, path });
-      if (folderInfo) {
-        folders.set(folderInfo.uuid, { path });
+      const { data: placeholder } = await NodeWin.getFolderInfo({ ctx, path });
+      if (placeholder) {
+        folders.set(placeholder.uuid, { path });
         await walk(path);
       }
     });

--- a/src/context/virtual-drive/items/application/Traverser.test.ts
+++ b/src/context/virtual-drive/items/application/Traverser.test.ts
@@ -1,15 +1,15 @@
 import { calls, mockProps, partialSpyOn } from 'tests/vitest/utils.helper.test';
 import { FolderUuid } from '@/apps/main/database/entities/DriveFolder';
 import * as deleteItemPlaceholder from '@/backend/features/remote-sync/file-explorer/delete-item-placeholder';
-import { FilePlaceholderUpdater } from '@/backend/features/remote-sync/file-explorer/update-file-placeholder';
-import { FolderPlaceholderUpdater } from '@/backend/features/remote-sync/file-explorer/update-folder-placeholder';
+import * as updateFilePlaceholder from '@/backend/features/remote-sync/file-explorer/update-file-placeholder';
+import * as updateFolderPlaceholder from '@/backend/features/remote-sync/file-explorer/update-folder-placeholder';
 import { abs } from '@/context/local/localFile/infrastructure/AbsolutePath';
 import { traverse } from './Traverser';
 
 describe('traverse', () => {
   const deleteItemPlaceholderMock = partialSpyOn(deleteItemPlaceholder, 'deleteItemPlaceholder');
-  const updateFilePlaceholderMock = partialSpyOn(FilePlaceholderUpdater, 'update');
-  const updateFolderPlaceholderMock = partialSpyOn(FolderPlaceholderUpdater, 'update');
+  const updateFilePlaceholderMock = partialSpyOn(updateFilePlaceholder, 'updateFilePlaceholder');
+  const updateFolderPlaceholderMock = partialSpyOn(updateFolderPlaceholder, 'updateFolderPlaceholder');
 
   let props: Parameters<typeof traverse>[0];
 
@@ -58,7 +58,7 @@ describe('traverse', () => {
     calls(updateFilePlaceholderMock).toMatchObject([{ remote: { absolutePath: '/drive/child1' } }]);
   });
 
-  it('should include some childreen if first parent succeed', async () => {
+  it('should include some children if first parent succeed', async () => {
     // Given
     updateFolderPlaceholderMock.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
     // When
@@ -84,7 +84,7 @@ describe('traverse', () => {
     ]);
   });
 
-  it('should include all childreen if all parents succeed', async () => {
+  it('should include all children if all parents succeed', async () => {
     // Given
     updateFolderPlaceholderMock.mockResolvedValue(true);
     // When

--- a/src/context/virtual-drive/items/application/Traverser.ts
+++ b/src/context/virtual-drive/items/application/Traverser.ts
@@ -2,8 +2,8 @@ import { SimpleDriveFile } from '@/apps/main/database/entities/DriveFile';
 import { ExtendedDriveFolder, SimpleDriveFolder } from '@/apps/main/database/entities/DriveFolder';
 import { ProcessSyncContext } from '@/apps/sync-engine/config';
 import { deleteItemPlaceholder } from '@/backend/features/remote-sync/file-explorer/delete-item-placeholder';
-import { FilePlaceholderUpdater } from '@/backend/features/remote-sync/file-explorer/update-file-placeholder';
-import { FolderPlaceholderUpdater } from '@/backend/features/remote-sync/file-explorer/update-folder-placeholder';
+import { updateFilePlaceholder } from '@/backend/features/remote-sync/file-explorer/update-file-placeholder';
+import { updateFolderPlaceholder } from '@/backend/features/remote-sync/file-explorer/update-folder-placeholder';
 import { FileExplorerFiles, FileExplorerFolders } from '@/backend/features/remote-sync/sync-items-by-checkpoint/load-in-memory-paths';
 import { join } from '@/context/local/localFile/infrastructure/AbsolutePath';
 
@@ -31,7 +31,7 @@ export async function traverse({ ctx, database, fileExplorer, currentFolder, isF
     if (file.status === 'DELETED' || file.status === 'TRASHED') {
       await deleteItemPlaceholder({ ctx, type: 'file', remote, locals: fileExplorer.files });
     } else {
-      await FilePlaceholderUpdater.update({ ctx, remote, files: fileExplorer.files, isFirstExecution });
+      await updateFilePlaceholder({ ctx, remote, files: fileExplorer.files, isFirstExecution });
     }
   });
 
@@ -42,7 +42,7 @@ export async function traverse({ ctx, database, fileExplorer, currentFolder, isF
     if (folder.status === 'DELETED' || folder.status === 'TRASHED') {
       await deleteItemPlaceholder({ ctx, type: 'folder', remote, locals: fileExplorer.folders });
     } else {
-      const success = await FolderPlaceholderUpdater.update({ ctx, remote, folders: fileExplorer.folders });
+      const success = await updateFolderPlaceholder({ ctx, remote, folders: fileExplorer.folders });
       if (success) {
         await traverse({ ctx, database, fileExplorer, currentFolder: remote, isFirstExecution });
       }

--- a/src/infra/node-win/services/get-file-info.ts
+++ b/src/infra/node-win/services/get-file-info.ts
@@ -3,6 +3,8 @@ import { FileUuid } from '@/apps/main/database/entities/DriveFile';
 import { FilePlaceholderId } from '@/context/virtual-drive/files/domain/PlaceholderId';
 import { Addon } from '@/node-win/addon-wrapper';
 
+export type FilePlaceholder = NonNullable<Awaited<ReturnType<typeof getFileInfo>>['data']>;
+
 export class GetFileInfoError extends Error {
   constructor(
     public readonly code: 'NOT_A_PLACEHOLDER' | 'UNKNOWN',
@@ -12,11 +14,7 @@ export class GetFileInfoError extends Error {
   }
 }
 
-type TProps = {
-  path: AbsolutePath;
-};
-
-export async function getFileInfo({ path }: TProps) {
+export async function getFileInfo({ path }: { path: AbsolutePath }) {
   try {
     const data = await Addon.getPlaceholderState({ path });
 

--- a/tests/vitest/mocks.helper.test.ts
+++ b/tests/vitest/mocks.helper.test.ts
@@ -6,3 +6,9 @@ import { abs, join } from '@/context/local/localFile/infrastructure/AbsolutePath
 export const TEST_FILES = join(abs(cwd()), 'test-files');
 export const loggerMock = vi.mocked(logger);
 export const clientMock = vi.mocked(client);
+export const testLoggerFn = vi.fn();
+export const testLogger = {
+  debug: testLoggerFn,
+  warn: testLoggerFn,
+  error: testLoggerFn,
+};


### PR DESCRIPTION
## What

This situation can happen when the user performed an hydration of a folder with files inside and the files didn't complete the hydration before the app closes. The files stay in a stuck state forever. One option could be to resume the hydration, however, since when you hydrate a folder there is no way to cancel the hydration, maybe the user has forced the close of the app to finish it. It can also be the opposite, that the user wants to continue after opening the app again. We will keep the first use case since it's easier to implement, consumes less resources and in case the user wants to hydrate the folder he can perform the action again.