### PR TITLE
Fix rename operation

### DIFF
--- a/src/backend/features/remote-sync/file-explorer/check-if-moved.test.ts
+++ b/src/backend/features/remote-sync/file-explorer/check-if-moved.test.ts
@@ -1,43 +1,41 @@
 import { AbsolutePath } from '@internxt/drive-desktop-core/build/backend';
 import { rename } from 'node:fs/promises';
-import { FolderUuid } from '@/apps/main/database/entities/DriveFolder';
 import { Addon } from '@/node-win/addon-wrapper';
 import { loggerFn, loggerMock } from '@/tests/vitest/mocks.helper.test';
 import { call, calls, deepMocked, partialSpyOn, TestProps } from '@/tests/vitest/utils.helper.test';
 import { checkIfMoved } from './check-if-moved';
+import * as needsToBeMoved from './needs-to-be-moved';
 
 vi.mock(import('node:fs/promises'));
 
 describe('check-if-moved', () => {
+  const needsToBeMovedMock = partialSpyOn(needsToBeMoved, 'needsToBeMoved');
   const renameMock = deepMocked(rename);
   const updateSyncStatusMock = partialSpyOn(Addon, 'updateSyncStatus');
 
   const props: TestProps<typeof checkIfMoved> = {
     ctx: { logger: loggerMock },
     local: { path: 'localPath' as AbsolutePath },
-    remote: {
-      absolutePath: 'remotePath' as AbsolutePath,
-      parentUuid: 'parentUuid' as FolderUuid,
-    },
+    remote: { absolutePath: 'remotePath' as AbsolutePath },
   };
 
-  it('should move if different parentUuid', async () => {
+  it('should not rename if does not need to be moved', async () => {
     // Given
-    props.local!.parentUuid = 'otherParentUuid' as FolderUuid;
+    needsToBeMovedMock.mockReturnValue(false);
+    // When
+    await checkIfMoved(props as any);
+    // Then
+    calls(loggerFn).toHaveLength(0);
+  });
+
+  it('should rename if needs to be moved', async () => {
+    // Given
+    needsToBeMovedMock.mockReturnValue(true);
     // When
     await checkIfMoved(props as any);
     // Then
     call(loggerFn).toMatchObject({ msg: 'Moving placeholder' });
     call(renameMock).toStrictEqual(['localPath', 'remotePath']);
     call(updateSyncStatusMock).toStrictEqual({ path: 'remotePath' });
-  });
-
-  it('should not move if same parentUuid', async () => {
-    // Given
-    props.local!.parentUuid = 'parentUuid' as FolderUuid;
-    // When
-    await checkIfMoved(props as any);
-    // Then
-    calls(loggerFn).toHaveLength(0);
   });
 });

--- a/src/backend/features/remote-sync/file-explorer/check-if-moved.ts
+++ b/src/backend/features/remote-sync/file-explorer/check-if-moved.ts
@@ -4,6 +4,7 @@ import { ExtendedDriveFolder } from '@/apps/main/database/entities/DriveFolder';
 import { SyncContext } from '@/apps/sync-engine/config';
 import { Addon } from '@/node-win/addon-wrapper';
 import { FileExplorerItem } from '../sync-items-by-checkpoint/load-in-memory-paths';
+import { needsToBeMoved } from './needs-to-be-moved';
 
 type Props = {
   ctx: SyncContext;
@@ -13,7 +14,9 @@ type Props = {
 };
 
 export async function checkIfMoved({ ctx, type, remote, local }: Props) {
-  if (remote.parentUuid !== local.parentUuid) {
+  const isMoved = needsToBeMoved({ remote, local });
+
+  if (isMoved) {
     const remotePath = remote.absolutePath;
     const localPath = local.path;
 

--- a/src/backend/features/remote-sync/file-explorer/needs-to-be-moved.test.ts
+++ b/src/backend/features/remote-sync/file-explorer/needs-to-be-moved.test.ts
@@ -1,0 +1,77 @@
+import { FolderUuid } from '@/apps/main/database/entities/DriveFolder';
+import { abs } from '@/context/local/localFile/infrastructure/AbsolutePath';
+import { mockProps } from '@/tests/vitest/utils.helper.test';
+import { needsToBeMoved } from './needs-to-be-moved';
+
+describe('needs-to-be-moved', () => {
+  const remotePath = abs('/drive/folder1/current');
+  const localPath = abs('/drive/folder2/current');
+
+  let props: Parameters<typeof needsToBeMoved>[0];
+
+  beforeEach(() => {
+    props = mockProps<typeof needsToBeMoved>({
+      remote: { absolutePath: remotePath },
+      local: { path: localPath },
+    });
+  });
+
+  it('should return false if path is the same', () => {
+    // Given
+    props.remote.absolutePath = props.local.path;
+    // When
+    const isMoved = needsToBeMoved(props);
+    // Then
+    expect(isMoved).toBe(false);
+  });
+
+  it('should return false if both parents have the same uuid', () => {
+    // Given
+    props.remote.parentUuid = 'uuid' as FolderUuid;
+    props.local.parentUuid = 'uuid' as FolderUuid;
+    // When
+    const isMoved = needsToBeMoved(props);
+    // Then
+    expect(isMoved).toBe(false);
+  });
+
+  it('should return true if both parents have different uuid', () => {
+    // Given
+    props.remote.parentUuid = 'uuid1' as FolderUuid;
+    props.local.parentUuid = 'uuid2' as FolderUuid;
+    // When
+    const isMoved = needsToBeMoved(props);
+    // Then
+    expect(isMoved).toBe(true);
+  });
+
+  it('should return true if item has been renamed but not moved', () => {
+    // Given
+    props.remote.absolutePath = abs('/drive/folder/old');
+    props.local.path = abs('/drive/folder/new');
+    // When
+    const isMoved = needsToBeMoved(props);
+    // Then
+    expect(isMoved).toBe(true);
+  });
+
+  /**
+   * v2.5.6 Daniel Jiménez
+   * This is a use case that we cannot handle right now. Basically we cannot rename
+   * an item if the move event is in another folder because we cannot move an inner
+   * item. What will happen is that in the first sync iteration we will call move from
+   * folder1 to folder3 and in the second sync iteration now the path will be the same
+   * so we will rename the inner folder.
+   */
+  it('should return false if item has been renamed but both parents have the same uuid', () => {
+    // Given
+    props.remote.absolutePath = abs('/drive/folder1/folder2/old');
+    props.local.path = abs('/drive/folder3/folder2/new');
+    props.remote.parentUuid = 'uuid' as FolderUuid;
+    props.local.parentUuid = 'uuid' as FolderUuid;
+    // When
+    const isMoved = needsToBeMoved(props);
+    // Then
+    expect(isMoved).toBe(false);
+  });
+});

--- a/src/backend/features/remote-sync/file-explorer/needs-to-be-moved.ts
+++ b/src/backend/features/remote-sync/file-explorer/needs-to-be-moved.ts
@@ -1,0 +1,22 @@
+import { ExtendedDriveFile } from '@/apps/main/database/entities/DriveFile';
+import { ExtendedDriveFolder } from '@/apps/main/database/entities/DriveFolder';
+import { dirname } from '@/context/local/localFile/infrastructure/AbsolutePath';
+import { FileExplorerItem } from '../sync-items-by-checkpoint/load-in-memory-paths';
+
+type Props = {
+  remote: ExtendedDriveFile | ExtendedDriveFolder;
+  local: FileExplorerItem;
+};
+
+export function needsToBeMoved({ remote, local }: Props) {
+  if (remote.absolutePath === local.path) return false;
+
+  const remoteParentPath = dirname(remote.absolutePath);
+  const localParentPath = dirname(local.path);
+
+  const isRenamed = remoteParentPath === localParentPath;
+  if (isRenamed) return true;
+
+  const isMoved = remote.parentUuid !== local.parentUuid;
+  return isMoved;
+}


### PR DESCRIPTION
## What

Some days ago I made this PR (https://github.com/internxt/drive-desktop/pull/1380) simplifying the move operation, however, for some reason, I forgot about the rename operation. I've reverted the changes but used the `parentUuid` that we have available in the in memory file explorer instead of getting it through C++.