### PR TITLE
chore: fix token refresh scheduling for the new 12h backend token expiry

### DIFF
--- a/src/apps/main/auth/handlers.test.ts
+++ b/src/apps/main/auth/handlers.test.ts
@@ -5,7 +5,7 @@ import * as getUser from './service';
 
 describe('handlers', () => {
   const getUserMock = partialSpyOn(getUser, 'getUser');
-  const getMillisecondsToRenewMock = partialSpyOn(TokenScheduler, 'getMillisecondsToRenew');
+  const getMillisecondsToExpireMock = partialSpyOn(TokenScheduler, 'getMillisecondsToExpire');
 
   describe('checkUserIsLoggedIn', () => {
     beforeEach(() => {
@@ -23,7 +23,7 @@ describe('handlers', () => {
 
     it('should return undefined if token is expired', () => {
       // Given
-      getMillisecondsToRenewMock.mockReturnValue(-1);
+      getMillisecondsToExpireMock.mockReturnValue(-1);
       // When
       const res = checkIfUserIsLoggedIn();
       // Then
@@ -32,7 +32,7 @@ describe('handlers', () => {
 
     it('should return undefined if cannot get token', () => {
       // Given
-      getMillisecondsToRenewMock.mockReturnValue(null);
+      getMillisecondsToExpireMock.mockReturnValue(null);
       // When
       const res = checkIfUserIsLoggedIn();
       // Then
@@ -41,7 +41,16 @@ describe('handlers', () => {
 
     it('should return user if token is not expired', () => {
       // Given
-      getMillisecondsToRenewMock.mockReturnValue(100);
+      getMillisecondsToExpireMock.mockReturnValue(100);
+      // When
+      const res = checkIfUserIsLoggedIn();
+      // Then
+      expect(res).toStrictEqual({ uuid: 'uuid' });
+    });
+
+    it('should return user if token needs renewal but is not expired', () => {
+      // Given
+      getMillisecondsToExpireMock.mockReturnValue(3 * 60 * 60 * 1000);
       // When
       const res = checkIfUserIsLoggedIn();
       // Then

--- a/src/apps/main/auth/handlers.ts
+++ b/src/apps/main/auth/handlers.ts
@@ -47,8 +47,8 @@ export function checkIfUserIsLoggedIn() {
     return;
   }
 
-  const msToRenew = TokenScheduler.getMillisecondsToRenew();
-  if (msToRenew === null || msToRenew <= 0) {
+  const msToExpire = TokenScheduler.getMillisecondsToExpire();
+  if (msToExpire === null || msToExpire <= 0) {
     logger.debug({ tag: 'AUTH', msg: 'User token is expired' });
     saveConfig();
     resetConfig();

--- a/src/apps/main/token-scheduler/TokenScheduler.ts
+++ b/src/apps/main/token-scheduler/TokenScheduler.ts
@@ -3,20 +3,35 @@ import { logger } from '@/apps/shared/logger/logger';
 import { driveServerWip } from '@/infra/drive-server-wip/drive-server-wip.module';
 import { obtainToken, updateCredentials } from '../auth/service';
 
-const DAYS_BEFORE = 1;
+const TOKEN_RENEW_INTERVAL_4H_IN_MS = 4 * 60 * 60 * 1000;
 
 export class TokenScheduler {
   static timeout: NodeJS.Timeout | undefined;
 
+  private static getTokenExpirationTime() {
+    const token = obtainToken();
+    const decoded = jwtDecode<JwtPayload>(token);
+    if (!decoded.exp) throw new Error('Token does not have expiration time');
+
+    return decoded.exp * 1000;
+  }
+
+  static getMillisecondsToExpire() {
+    try {
+      return this.getTokenExpirationTime() - Date.now();
+    } catch (error) {
+      logger.error({ tag: 'AUTH', msg: 'Error getting token', error });
+      return null;
+    }
+  }
+
   static getMillisecondsToRenew() {
     try {
-      const token = obtainToken();
-      const decoded = jwtDecode<JwtPayload>(token);
-      if (!decoded.exp) throw new Error('Token does not have expiration time');
-
-      const expiresAt = decoded.exp * 1000;
-      const renewAt = expiresAt - DAYS_BEFORE * 24 * 60 * 60 * 1000;
-      const msToRenew = renewAt - Date.now();
+      const expiresAt = this.getTokenExpirationTime();
+      const now = Date.now();
+      const msToExpire = expiresAt - now;
+      const msToRenew = this.getMillisecondsUntilNextRenew(msToExpire);
+      const renewAt = now + msToRenew;
 
       logger.debug({
         tag: 'AUTH',
@@ -34,6 +49,8 @@ export class TokenScheduler {
   }
 
   static schedule() {
+    this.stop();
+
     const msToRenew = this.getMillisecondsToRenew();
     if (msToRenew === null) return;
 
@@ -49,5 +66,12 @@ export class TokenScheduler {
 
   static stop() {
     clearTimeout(this.timeout);
+  }
+
+  private static getMillisecondsUntilNextRenew(msToExpire: number) {
+    if (msToExpire <= 0) return msToExpire;
+    if (msToExpire <= TOKEN_RENEW_INTERVAL_4H_IN_MS) return 0;
+
+    return TOKEN_RENEW_INTERVAL_4H_IN_MS;
   }
 }

--- a/src/apps/main/token-scheduler/token-scheduler.test.ts
+++ b/src/apps/main/token-scheduler/token-scheduler.test.ts
@@ -54,12 +54,16 @@ describe('token-scheduler', () => {
     });
   });
 
-  it('should refresh if token is expired', async () => {
+  it('should renew tokens every 4 hours', async () => {
     // Given
-    obtainTokenMock.mockReturnValueOnce(createToken('1 day')).mockReturnValueOnce(createToken('31 day'));
+    obtainTokenMock.mockImplementationOnce(() => createToken('12 hours')).mockImplementationOnce(() => createToken('12 hours'));
     refreshMock.mockResolvedValue({ data: { newToken: 'token' } });
     // When
     TokenScheduler.schedule();
+    await vi.advanceTimersByTimeAsync(4 * 60 * 60 * 1000 - 1);
+    // Then
+    expect(refreshMock).not.toHaveBeenCalled();
+    // When
     await vi.runOnlyPendingTimersAsync();
     // Then
     expect(TokenScheduler.timeout).not.toBe(undefined);
@@ -67,14 +71,47 @@ describe('token-scheduler', () => {
     calls(loggerMock.debug).toMatchObject([
       {
         msg: 'Token renew date',
-        expiresAt: new Date('1970-01-02'),
-        renewAt: new Date('1970-01-01'),
+        expiresAt: new Date('1970-01-01T12:00:00.000Z'),
+        renewAt: new Date('1970-01-01T04:00:00.000Z'),
       },
       {
         msg: 'Token renew date',
-        expiresAt: new Date('1970-02-01'),
-        renewAt: new Date('1970-01-31'),
+        expiresAt: new Date('1970-01-01T16:00:00.000Z'),
+        renewAt: new Date('1970-01-01T08:00:00.000Z'),
       },
     ]);
+  });
+
+  it('should renew immediately if token expires in less than 4 hours', async () => {
+    // Given
+    obtainTokenMock.mockImplementationOnce(() => createToken('3 hours')).mockImplementationOnce(() => createToken('12 hours'));
+    refreshMock.mockResolvedValue({ data: { newToken: 'token' } });
+    // When
+    TokenScheduler.schedule();
+    await vi.runOnlyPendingTimersAsync();
+    // Then
+    call(updateCredentialsMock).toStrictEqual({ newToken: 'token' });
+    calls(loggerMock.debug).toMatchObject([
+      {
+        msg: 'Token renew date',
+        expiresAt: new Date('1970-01-01T03:00:00.000Z'),
+        renewAt: new Date('1970-01-01T00:00:00.000Z'),
+        msToRenew: 0,
+      },
+      {
+        msg: 'Token renew date',
+        expiresAt: new Date('1970-01-01T12:00:00.000Z'),
+        renewAt: new Date('1970-01-01T04:00:00.000Z'),
+      },
+    ]);
+  });
+
+  it('should return a negative delay if token is expired', () => {
+    // Given
+    obtainTokenMock.mockReturnValue(createToken('-1 second'));
+    // When
+    const result = TokenScheduler.getMillisecondsToRenew();
+    // Then
+    expect(result).toBeLessThan(0);
   });
 });


### PR DESCRIPTION
## What has been added/Changed
Fix token refresh scheduling for the new 12h backend token expiry.
The desktop app previously scheduled token renewal 1 day before token expiration. Since backend tokens now expire after 12h, the app repeatedly refresh the token on startup.

Now, we renew valid tokens every 4h instead of 1 day before expiry. We refresh immediately when a valid token has less than 4h remaining. We also clear any existing token renewal timeout before scheduling a new one to avoid duplicate refresh timers.

## Why
The new logic uses a fixed 4h refresh cadence while still preserving the existing expired-token reset behavior.