### PR TITLE
[BR-1995] Fix: backup file not updated after modified

### DIFF
--- a/src/apps/backups/backups.test.ts
+++ b/src/apps/backups/backups.test.ts
@@ -1,6 +1,6 @@
 import Bottleneck from 'bottleneck';
 import { randomUUID } from 'node:crypto';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, stat, writeFile } from 'node:fs/promises';
 import { beforeAll } from 'vitest';
 import { Sync } from '@/backend/features/sync';
 import { join } from '@/context/local/localFile/infrastructure/AbsolutePath';
@@ -51,6 +51,8 @@ describe('backups', () => {
 
   it('should perform a complete backup', async () => {
     // Given
+    const unmodifiedFileStats = await stat(unmodifiedFile);
+
     getFoldersMock.mockResolvedValue({
       data: [
         { uuid: 'folder' as FolderUuid, parentUuid: rootUuid, name: 'folder', status: 'EXISTS' },
@@ -61,7 +63,14 @@ describe('backups', () => {
 
     getFilesMock.mockResolvedValue({
       data: [
-        { uuid: 'unmodifiedFile' as FileUuid, parentUuid: rootUuid, name: 'unmodifiedFile', size: 7, status: 'EXISTS' },
+        {
+          uuid: 'unmodifiedFile' as FileUuid,
+          parentUuid: rootUuid,
+          name: 'unmodifiedFile',
+          size: 7,
+          modificationTime: unmodifiedFileStats.mtime.toISOString(),
+          status: 'EXISTS',
+        },
         { uuid: 'modifiedFile' as FileUuid, parentUuid: rootUuid, name: 'modifiedFile', size: 12, status: 'EXISTS' },
         { uuid: 'deletedFile' as FileUuid, parentUuid: 'folder', name: 'deleted', status: 'EXISTS' },
         { status: 'DELETED' },

--- a/src/apps/backups/diff/calculate-files-diff.test.ts
+++ b/src/apps/backups/diff/calculate-files-diff.test.ts
@@ -7,7 +7,7 @@ describe('calculate-files-diff', () => {
   const props = mockProps<typeof calculateFilesDiff>({
     local: {
       files: {
-        [abs('/file1')]: { path: abs('/file1'), stats: {} },
+        [abs('/file1')]: { path: abs('/file1'), stats: { size: 7, mtime: date('2026-06-30T12:00:01.100Z') } },
         [abs('/file2')]: { path: abs('/file2'), stats: {} },
         [abs('/file6')]: { path: abs('/file6'), stats: { size: 12 } },
       },
@@ -15,7 +15,7 @@ describe('calculate-files-diff', () => {
     },
     remote: {
       files: new Map([
-        [abs('/file1'), { absolutePath: abs('/file1') }],
+        [abs('/file1'), { absolutePath: abs('/file1'), size: 7, modificationTime: '2026-06-30T12:00:01.100Z' }],
         [abs('/file3'), { absolutePath: abs('/file3') }],
         [abs('/file6'), { absolutePath: abs('/file6'), size: 10 }],
       ]),

--- a/src/apps/backups/diff/calculate-files-diff.test.ts
+++ b/src/apps/backups/diff/calculate-files-diff.test.ts
@@ -61,7 +61,7 @@ describe('calculate-files-diff', () => {
     expect(diff.unmodified).toStrictEqual([]);
   });
 
-  it('should not mark same-size files as modified when remote modification time is newer', () => {
+  it('should not mark same-size files as modified when remote and local modification time are the same', () => {
     // Given
     const props = mockProps<typeof calculateFilesDiff>({
       local: {
@@ -76,7 +76,7 @@ describe('calculate-files-diff', () => {
             {
               absolutePath: abs('/file'),
               size: 7,
-              modificationTime: '2026-06-30T12:00:02.900Z',
+              modificationTime: '2026-06-30T12:00:01.100Z',
             },
           ],
         ]),

--- a/src/apps/backups/diff/calculate-files-diff.test.ts
+++ b/src/apps/backups/diff/calculate-files-diff.test.ts
@@ -3,6 +3,7 @@ import { abs } from '@/context/local/localFile/infrastructure/AbsolutePath';
 import { calculateFilesDiff } from './calculate-files-diff';
 
 describe('calculate-files-diff', () => {
+  const date = (value: string) => new Date(value);
   const props = mockProps<typeof calculateFilesDiff>({
     local: {
       files: {
@@ -30,5 +31,61 @@ describe('calculate-files-diff', () => {
     expect(diff.added.map((file) => file.path)).toStrictEqual(['/file2']);
     expect(diff.deleted.map((file) => file.absolutePath)).toStrictEqual(['/file3']);
     expect(diff.modified.map(({ remote }) => remote.absolutePath)).toStrictEqual(['/file6']);
+  });
+
+  it('should mark same-size files as modified when local modification time is newer', () => {
+    // Given
+    const props = mockProps<typeof calculateFilesDiff>({
+      local: {
+        files: {
+          [abs('/file')]: { path: abs('/file'), stats: { size: 7, mtime: date('2026-06-30T12:00:02.900Z') } },
+        },
+      },
+      remote: {
+        files: new Map([
+          [
+            abs('/file'),
+            {
+              absolutePath: abs('/file'),
+              size: 7,
+              modificationTime: '2026-06-30T12:00:01.100Z',
+            },
+          ],
+        ]),
+      },
+    });
+    // When
+    const diff = calculateFilesDiff(props);
+    // Then
+    expect(diff.modified.map(({ remote }) => remote.absolutePath)).toStrictEqual(['/file']);
+    expect(diff.unmodified).toStrictEqual([]);
+  });
+
+  it('should not mark same-size files as modified when remote modification time is newer', () => {
+    // Given
+    const props = mockProps<typeof calculateFilesDiff>({
+      local: {
+        files: {
+          [abs('/file')]: { path: abs('/file'), stats: { size: 7, mtime: date('2026-06-30T12:00:01.100Z') } },
+        },
+      },
+      remote: {
+        files: new Map([
+          [
+            abs('/file'),
+            {
+              absolutePath: abs('/file'),
+              size: 7,
+              modificationTime: '2026-06-30T12:00:02.900Z',
+            },
+          ],
+        ]),
+      },
+    });
+    // When
+    const diff = calculateFilesDiff(props);
+    // Then
+    expect(diff.modified).toStrictEqual([]);
+    expect(diff.unmodified.map((file) => file.path)).toStrictEqual(['/file']);
   });
 });

--- a/src/apps/backups/diff/calculate-files-diff.ts
+++ b/src/apps/backups/diff/calculate-files-diff.ts
@@ -30,7 +30,7 @@ export function calculateFilesDiff({ local, remote }: TProps) {
       return;
     }
 
-    if (remoteFile.size !== local.stats.size) {
+    if (remoteFile.size !== local.stats.size || isLocalFileNewer({ local, remote: remoteFile })) {
       modified.push({ local, remote: remoteFile });
       return;
     }
@@ -53,4 +53,13 @@ export function calculateFilesDiff({ local, remote }: TProps) {
     unmodified,
     total,
   };
+}
+
+function isLocalFileNewer({ local, remote }: { local: StatItem; remote: ExtendedDriveFile }) {
+  const remoteTime = remote.modificationTime || remote.updatedAt;
+  if (!remoteTime) return true;
+  const remoteModificationTime = Math.trunc(new Date(remoteTime).getTime() / 1000);
+  const localModificationTime = Math.trunc(local.stats.mtime.getTime() / 1000);
+  if (Number.isNaN(remoteModificationTime) || Number.isNaN(localModificationTime)) return true;
+  return remoteModificationTime < localModificationTime;
 }

--- a/src/apps/backups/diff/calculate-files-diff.ts
+++ b/src/apps/backups/diff/calculate-files-diff.ts
@@ -56,7 +56,7 @@ export function calculateFilesDiff({ local, remote }: TProps) {
 }
 
 function isLocalFileNewer({ local, remote }: { local: StatItem; remote: ExtendedDriveFile }) {
-  const remoteTime = remote.modificationTime || remote.updatedAt;
+  const remoteTime = remote.modificationTime ?? remote.updatedAt;
   if (!remoteTime) return true;
   const remoteModificationTime = Math.trunc(new Date(remoteTime).getTime() / 1000);
   const localModificationTime = Math.trunc(local.stats.mtime.getTime() / 1000);


### PR DESCRIPTION
## What has been Added/ Changed
In this pull request we modify the heuristic in which we determine if a local file has to be uploaded again to the backup because it has been modified or no, we now have into account the local file modification time and compare it with the remote one, if the local file has a modification time newer than the remote, then we add it into the "modified" list so that we upload it again.

## Why
Using only the file size comparison is not enough, small modifications on a backup file would not trigger since the file size would not change and not trigger the "backup" upload, hence why the modification time is a more precise way to check if a file was modified or not