### PR TITLE
Revert pull request #1437 

### DIFF
--- a/assets/context-menu-installer.nsh
+++ b/assets/context-menu-installer.nsh
@@ -3,8 +3,7 @@
   Pop $0
 
   ${If} $0 != 0
-    MessageBox MB_ICONSTOP "The Internxt Drive context-menu extension could not be registered."
-    Abort
+    DetailPrint "The Internxt Drive context-menu extension could not be registered. Continuing without context-menu integration."
   ${EndIf}
 !macroend
 

--- a/packages/context-menu/InternxtContextMenu.vcxproj
+++ b/packages/context-menu/InternxtContextMenu.vcxproj
@@ -36,6 +36,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <PreprocessorDefinitions>_WINDLL;WIN32_LEAN_AND_MEAN;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>Sync</ExceptionHandling>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level4</WarningLevel>
     </ClCompile>
     <Link>

--- a/packages/context-menu/InternxtContextMenuHost.vcxproj
+++ b/packages/context-menu/InternxtContextMenuHost.vcxproj
@@ -36,6 +36,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>Sync</ExceptionHandling>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level4</WarningLevel>
     </ClCompile>
     <Link>

--- a/packages/context-menu/register-context-menu-extension.ps1
+++ b/packages/context-menu/register-context-menu-extension.ps1
@@ -1,63 +1,241 @@
 $ErrorActionPreference = "Stop"
 
+$logsPath = Join-Path $env:APPDATA "internxt-drive\logs"
+$registrationLogPath = Join-Path $logsPath "context-menu.log"
+$registrationLogMaxBytes = 1MB
 $packageName = "com.internxt.drive.contextmenu"
 $packagePath = Join-Path $PSScriptRoot "InternxtContextMenu.msix"
 $certificatePath = Join-Path $PSScriptRoot "InternxtDevelopment.cer"
+$contextMenuDllPath = Join-Path $PSScriptRoot "internxt_context_menu.dll"
+$contextMenuClsid = "{F47A034D-852C-4F60-B721-C31C854183F2}"
+$contextMenuVerbId = "InternxtCopyShareLink"
+$contextMenuTitle = "Internxt Drive context menu"
+$minimumWindows10Build = 10240
+$minimumWindows11Build = 22000
 
-# Keep the sparse package identity and its ACL changes isolated from Electron.
-# The manifest's host executable and COM DLL both live beside this script.
-$externalLocation = Resolve-Path $PSScriptRoot
+function Write-RegistrationLog {
+  param(
+    [Parameter(Mandatory)]
+    [string] $Message
+  )
 
-if (-not (Test-Path -LiteralPath $packagePath)) {
-  throw "Context-menu package was not found: $packagePath"
+  $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss.fff"
+  New-Item -ItemType Directory -Path $logsPath -Force | Out-Null
+
+  if (
+    (Test-Path -LiteralPath $registrationLogPath) -and
+    ((Get-Item -LiteralPath $registrationLogPath).Length -ge $registrationLogMaxBytes)
+  ) {
+    Clear-Content -LiteralPath $registrationLogPath
+  }
+
+  Add-Content -LiteralPath $registrationLogPath -Value "[$timestamp] $Message"
 }
 
-# Development builds include their public self-signed certificate so the QA
-# machine can trust the MSIX. Production signing is handled separately.
-if (Test-Path -LiteralPath $certificatePath) {
-  $certificate = New-Object `
-    System.Security.Cryptography.X509Certificates.X509Certificate2($certificatePath)
+function Get-WindowsBuild {
+  $windowsVersion = Get-ItemProperty `
+    -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion" `
+    -Name CurrentBuildNumber
 
-  $trustedCertificate = Get-ChildItem "Cert:\LocalMachine\TrustedPeople" |
-    Where-Object Thumbprint -eq $certificate.Thumbprint |
-    Select-Object -First 1
+  return [int] $windowsVersion.CurrentBuildNumber
+}
 
-  if (-not $trustedCertificate) {
-    $trustScriptPath = Join-Path $PSScriptRoot "trust-development-certificate.ps1"
+function Test-IsWindows10OrNewer {
+  param(
+    [Parameter(Mandatory)]
+    [int] $WindowsBuild
+  )
 
-    # LocalMachine certificate changes require administrator approval. RunAs
-    # displays the standard Windows elevation prompt only when trust is missing.
-    $trustProcess = Start-Process `
-      -FilePath "powershell.exe" `
-      -ArgumentList @(
-        "-NoLogo",
-        "-NoProfile",
-        "-ExecutionPolicy", "Bypass",
-        "-File", "`"$trustScriptPath`"",
-        "-CertificatePath", "`"$certificatePath`""
-      ) `
-      -Verb RunAs `
-      -WindowStyle Hidden `
-      -Wait `
-      -PassThru
+  return $WindowsBuild -ge $minimumWindows10Build
+}
 
-    if ($trustProcess.ExitCode -ne 0) {
-      throw "The context-menu development certificate could not be trusted."
-    }
+function Test-IsWindows11OrNewer {
+  param(
+    [Parameter(Mandatory)]
+    [int] $WindowsBuild
+  )
+
+  return $WindowsBuild -ge $minimumWindows11Build
+}
+
+function Test-ShouldRelaunchWithNativePowerShell {
+  return [Environment]::Is64BitOperatingSystem -and -not [Environment]::Is64BitProcess
+}
+
+function Invoke-NativePowerShellRegistration {
+  $nativePowerShellPath = Join-Path $env:WINDIR "sysnative\WindowsPowerShell\v1.0\powershell.exe"
+
+  if (-not (Test-Path -LiteralPath $nativePowerShellPath)) {
+    return $false
+  }
+
+  Write-RegistrationLog "Relaunching registration through native PowerShell: $nativePowerShellPath"
+
+  $nativePowerShell = Start-Process `
+    -FilePath $nativePowerShellPath `
+    -ArgumentList @(
+      "-NoLogo",
+      "-NoProfile",
+      "-ExecutionPolicy", "Bypass",
+      "-File", "`"$PSCommandPath`""
+    ) `
+    -Wait `
+    -PassThru
+
+  Write-RegistrationLog "Native PowerShell registration finished with exit code $($nativePowerShell.ExitCode)"
+  exit $nativePowerShell.ExitCode
+}
+
+function Set-CurrentUserRegistryValue {
+  param(
+    [Parameter(Mandatory)]
+    [string] $SubKeyPath,
+    [Parameter(Mandatory)]
+    [AllowEmptyString()]
+    [string] $Name,
+    [Parameter(Mandatory)]
+    [string] $Value
+  )
+
+  $registryKey = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey($SubKeyPath)
+  if (-not $registryKey) {
+    throw "Registry key could not be created: HKCU\$SubKeyPath"
+  }
+
+  try {
+    $registryKey.SetValue($Name, $Value, [Microsoft.Win32.RegistryValueKind]::String)
+    $displayName = if ($Name -eq "") { "(Default)" } else { $Name }
+    Write-RegistrationLog "Wrote HKCU\$SubKeyPath [$displayName] = $Value"
+  } finally {
+    $registryKey.Dispose()
   }
 }
 
-$installedPackage = Get-AppxPackage -Name $packageName
-if ($installedPackage) {
-  $installedPackage | Remove-AppxPackage
+function Register-Windows10ContextMenuExtension {
+  Write-RegistrationLog "Registering Windows 10 context-menu extension. DLL=$contextMenuDllPath"
+
+  if (-not (Test-Path -LiteralPath $contextMenuDllPath)) {
+    throw "Context-menu DLL was not found: $contextMenuDllPath"
+  }
+
+  Set-CurrentUserRegistryValue `
+    -SubKeyPath "Software\Classes\CLSID\$contextMenuClsid" `
+    -Name "" `
+    -Value $contextMenuTitle
+
+  Set-CurrentUserRegistryValue `
+    -SubKeyPath "Software\Classes\CLSID\$contextMenuClsid\InprocServer32" `
+    -Name "" `
+    -Value $contextMenuDllPath
+
+  Set-CurrentUserRegistryValue `
+    -SubKeyPath "Software\Classes\CLSID\$contextMenuClsid\InprocServer32" `
+    -Name "ThreadingModel" `
+    -Value "Apartment"
+
+  Set-CurrentUserRegistryValue `
+    -SubKeyPath "Software\Microsoft\Windows\CurrentVersion\Shell Extensions\Approved" `
+    -Name $contextMenuClsid `
+    -Value $contextMenuTitle
+
+  foreach ($itemType in @("*", "Directory", "AllFileSystemObjects")) {
+    Set-CurrentUserRegistryValue `
+      -SubKeyPath "Software\Classes\$itemType\shellex\ContextMenuHandlers\$contextMenuVerbId" `
+      -Name "" `
+      -Value $contextMenuClsid
+  }
+
+  Write-Host "Internxt Windows 10 context-menu extension registered."
+  Write-RegistrationLog "Windows 10 context-menu extension registered."
 }
 
-Add-AppxPackage `
-  -Path $packagePath `
-  -ExternalLocation $externalLocation.Path `
-  -ForceUpdateFromAnyVersion
+function Register-Windows11ContextMenuExtension {
+  if (-not (Test-Path -LiteralPath $packagePath)) {
+    throw "Context-menu package was not found: $packagePath"
+  }
 
-Write-Host "Internxt context-menu package registered."
+  # Keep the sparse package identity and its ACL changes isolated from Electron.
+  # The manifest's host executable and COM DLL both live beside this script.
+  $externalLocation = Resolve-Path $PSScriptRoot
+
+  Write-RegistrationLog "Registering Windows 11 context-menu package. Package=$packagePath; ExternalLocation=$($externalLocation.Path)"
+
+  # Development builds include their public self-signed certificate so the QA
+  # machine can trust the MSIX. Production signing is handled separately.
+  if (Test-Path -LiteralPath $certificatePath) {
+    $certificate = New-Object `
+      System.Security.Cryptography.X509Certificates.X509Certificate2($certificatePath)
+
+    $trustedCertificate = Get-ChildItem "Cert:\LocalMachine\TrustedPeople" |
+      Where-Object Thumbprint -eq $certificate.Thumbprint |
+      Select-Object -First 1
+
+    if (-not $trustedCertificate) {
+      $trustScriptPath = Join-Path $PSScriptRoot "trust-development-certificate.ps1"
+
+      # LocalMachine certificate changes require administrator approval. RunAs
+      # displays the standard Windows elevation prompt only when trust is missing.
+      $trustProcess = Start-Process `
+        -FilePath "powershell.exe" `
+        -ArgumentList @(
+          "-NoLogo",
+          "-NoProfile",
+          "-ExecutionPolicy", "Bypass",
+          "-File", "`"$trustScriptPath`"",
+          "-CertificatePath", "`"$certificatePath`""
+        ) `
+        -Verb RunAs `
+        -WindowStyle Hidden `
+        -Wait `
+        -PassThru
+
+      if ($trustProcess.ExitCode -ne 0) {
+        throw "The context-menu development certificate could not be trusted."
+      }
+    }
+  }
+
+  $installedPackage = Get-AppxPackage -Name $packageName
+  if ($installedPackage) {
+    $installedPackage | Remove-AppxPackage
+  }
+
+  Add-AppxPackage `
+    -Path $packagePath `
+    -ExternalLocation $externalLocation.Path `
+    -ForceUpdateFromAnyVersion
+
+  Write-Host "Internxt Windows 11 context-menu package registered."
+  Write-RegistrationLog "Windows 11 context-menu package registered."
+}
+
+trap {
+  Write-RegistrationLog "ERROR: $($_.Exception.Message)"
+  Write-RegistrationLog "ERROR_DETAILS: $($_ | Out-String)"
+  exit 1
+}
+
+Write-RegistrationLog "Starting context-menu registration. Is64BitOS=$([Environment]::Is64BitOperatingSystem); Is64BitProcess=$([Environment]::Is64BitProcess); Script=$PSCommandPath"
+
+if (Test-ShouldRelaunchWithNativePowerShell) {
+  Invoke-NativePowerShellRegistration | Out-Null
+}
+
+$windowsBuild = Get-WindowsBuild
+Write-RegistrationLog "Detected Windows build $windowsBuild"
+
+if (-not (Test-IsWindows10OrNewer -WindowsBuild $windowsBuild)) {
+  Write-Host "Internxt context-menu integration requires Windows 10 or newer. Current build is $windowsBuild; skipping registration."
+  Write-RegistrationLog "Skipping registration because Windows build is below $minimumWindows10Build"
+  exit 0
+}
+
+if (-not (Test-IsWindows11OrNewer -WindowsBuild $windowsBuild)) {
+  Register-Windows10ContextMenuExtension
+  exit 0
+}
+
+Register-Windows11ContextMenuExtension
 
 # Explorer may need to restart before showing a newly registered extension.
 # We deliberately avoid restarting it during installation because that closes

--- a/packages/context-menu/src/context_menu.cpp
+++ b/packages/context-menu/src/context_menu.cpp
@@ -1,5 +1,7 @@
 // Windows Shell interfaces such as IExplorerCommand and IShellItemArray.
 #include <shobjidl_core.h>
+// Shell drag-drop helpers used by the classic Windows 10 IContextMenu path.
+#include <shellapi.h>
 // Defines NTSTATUS, which is used by structures declared in cfapi.h.
 #include <winternl.h>
 // Cloud Files API. Windows uses this API to expose which sync provider owns
@@ -14,8 +16,8 @@
 #include <wrl/client.h>
 
 #include <array>
-#include <filesystem>
 #include <string>
+#include <vector>
 
 #include "resource.h"
 
@@ -32,6 +34,7 @@ namespace {
 constexpr WCHAR ContextMenuPipePath[] =
     L"\\\\.\\pipe\\internxt-drive-context-menu";
 HMODULE ContextMenuModule = nullptr;
+HBITMAP ContextMenuBitmap = nullptr;
 
 const WCHAR* GetLocalizedCommandTitle()
 {
@@ -71,16 +74,11 @@ bool TryGetSingleSelectedPath(IShellItemArray* items, std::wstring& path)
 // CfGetSyncRootInfoByPath returns the sync root's registered Id in ProviderName,
 // not its user-facing DisplayNameResource. Resolve that Id through the same
 // SyncRootManager metadata Windows creates when Internxt registers the root.
-bool IsInternxtProvider(const WCHAR* providerId)
+bool TryReadSyncRootDisplayName(HKEY rootKey, const std::wstring& registryPath, std::array<WCHAR, 256>& displayName)
 {
-    const std::wstring registryPath =
-        L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\SyncRootManager\\" +
-        std::wstring(providerId);
-
-    std::array<WCHAR, 256> displayName{};
     DWORD displayNameSize = static_cast<DWORD>(displayName.size() * sizeof(WCHAR));
     const LSTATUS result = RegGetValueW(
-        HKEY_LOCAL_MACHINE,
+        rootKey,
         registryPath.c_str(),
         L"DisplayNameResource",
         RRF_RT_REG_SZ,
@@ -88,10 +86,25 @@ bool IsInternxtProvider(const WCHAR* providerId)
         displayName.data(),
         &displayNameSize);
 
-    if (result != ERROR_SUCCESS) return false;
+    return result == ERROR_SUCCESS;
+}
 
-    return std::wstring(displayName.data()) == L"Internxt Drive" ||
-           std::wstring(displayName.data()) == L"Internxt Drive for Business";
+bool IsInternxtProvider(const WCHAR* providerId)
+{
+    const std::wstring registryPath =
+        L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\SyncRootManager\\" +
+        std::wstring(providerId);
+
+    std::array<WCHAR, 256> displayName{};
+    const bool foundDisplayName =
+        TryReadSyncRootDisplayName(HKEY_LOCAL_MACHINE, registryPath, displayName) ||
+        TryReadSyncRootDisplayName(HKEY_CURRENT_USER, registryPath, displayName);
+
+    if (!foundDisplayName) return false;
+
+    const std::wstring resolvedDisplayName(displayName.data());
+    return resolvedDisplayName == L"Internxt Drive" ||
+           resolvedDisplayName == L"Internxt Drive for Business";
 }
 
 // Asking Windows which sync root owns the path avoids relying on a hard-coded
@@ -116,11 +129,14 @@ bool IsInternxtSyncRootItem(const std::wstring& path)
 // therefore hides the command on the root without hard-coding its location.
 bool IsInternxtSyncRootDescendant(const std::wstring& path)
 {
-    if (!IsInternxtSyncRootItem(path)) return false;
+    std::array<WCHAR, 32768> parentPathBuffer{};
+    if (path.size() >= parentPathBuffer.size()) return false;
 
-    const std::wstring parentPath =
-        std::filesystem::path(path).parent_path().wstring();
-    return !parentPath.empty() && IsInternxtSyncRootItem(parentPath);
+    wcscpy_s(parentPathBuffer.data(), parentPathBuffer.size(), path.c_str());
+    if (!PathRemoveFileSpecW(parentPathBuffer.data())) return false;
+
+    const std::wstring parentPath(parentPathBuffer.data());
+    return !parentPath.empty() && parentPath != path && IsInternxtSyncRootItem(parentPath);
 }
 
 // Electron owns the named-pipe server. The command writes only the selected
@@ -151,6 +167,39 @@ void SendSelectedPathToElectron(const std::wstring& selectedPath)
     CloseHandle(pipe);
 }
 
+HBITMAP GetContextMenuBitmap()
+{
+    if (ContextMenuBitmap) return ContextMenuBitmap;
+
+    const int iconSize = GetSystemMetrics(SM_CXSMICON);
+    HICON icon = static_cast<HICON>(LoadImageW(
+        ContextMenuModule,
+        MAKEINTRESOURCEW(IDI_CONTEXT_MENU_ICON),
+        IMAGE_ICON,
+        iconSize,
+        iconSize,
+        LR_DEFAULTCOLOR));
+
+    if (!icon) return nullptr;
+
+    HDC screenDc = GetDC(nullptr);
+    HDC memoryDc = CreateCompatibleDC(screenDc);
+    HBITMAP bitmap = CreateCompatibleBitmap(screenDc, iconSize, iconSize);
+    HGDIOBJ previousBitmap = SelectObject(memoryDc, bitmap);
+
+    RECT rect{0, 0, iconSize, iconSize};
+    FillRect(memoryDc, &rect, reinterpret_cast<HBRUSH>(COLOR_MENU + 1));
+    DrawIconEx(memoryDc, 0, 0, icon, iconSize, iconSize, 0, nullptr, DI_NORMAL);
+
+    SelectObject(memoryDc, previousBitmap);
+    DeleteDC(memoryDc);
+    ReleaseDC(nullptr, screenDc);
+    DestroyIcon(icon);
+
+    ContextMenuBitmap = bitmap;
+    return ContextMenuBitmap;
+}
+
 } // namespace
 
 // The UUID is the permanent COM identity of this command. Windows registration
@@ -158,8 +207,101 @@ void SendSelectedPathToElectron(const std::wstring& selectedPath)
 class __declspec(uuid("F47A034D-852C-4F60-B721-C31C854183F2")) InternxtPublicLinkShareCommand final
     // RuntimeClass supplies COM lifetime/interface behavior. IExplorerCommand
     // is the contract Explorer calls to render and execute a menu command.
-    : public RuntimeClass<RuntimeClassFlags<ClassicCom>, IExplorerCommand> {
+    : public RuntimeClass<RuntimeClassFlags<ClassicCom>, IExplorerCommand, IShellExtInit, IContextMenu> {
 public:
+    // Windows 10 legacy shell path. Explorer calls Initialize before showing
+    // the classic context menu and provides the selected items through
+    // IDataObject/CF_HDROP rather than IShellItemArray.
+    IFACEMETHODIMP Initialize(LPCITEMIDLIST, IDataObject* dataObject, HKEY) override
+    {
+        legacySelectedPath_.clear();
+        legacyCommandVisible_ = false;
+
+        if (!dataObject) return S_OK;
+
+        FORMATETC format{};
+        format.cfFormat = CF_HDROP;
+        format.ptd = nullptr;
+        format.dwAspect = DVASPECT_CONTENT;
+        format.lindex = -1;
+        format.tymed = TYMED_HGLOBAL;
+
+        STGMEDIUM storage{};
+        if (FAILED(dataObject->GetData(&format, &storage))) return S_OK;
+
+        const HDROP drop = static_cast<HDROP>(GlobalLock(storage.hGlobal));
+        if (drop) {
+            const UINT count = DragQueryFileW(drop, 0xFFFFFFFF, nullptr, 0);
+            if (count == 1) {
+                const UINT pathLength = DragQueryFileW(drop, 0, nullptr, 0);
+                std::vector<WCHAR> buffer(static_cast<size_t>(pathLength) + 1);
+                if (DragQueryFileW(drop, 0, buffer.data(), static_cast<UINT>(buffer.size())) > 0) {
+                    legacySelectedPath_.assign(buffer.data());
+                    legacyCommandVisible_ = IsInternxtSyncRootDescendant(legacySelectedPath_);
+                }
+            }
+
+            GlobalUnlock(storage.hGlobal);
+        }
+
+        ReleaseStgMedium(&storage);
+        return S_OK;
+    }
+
+    // Windows 10 legacy shell path. Explorer gives us the menu handle and the
+    // insertion index; we add one command only when the selected item belongs
+    // to an Internxt sync-root child.
+    IFACEMETHODIMP QueryContextMenu(HMENU menu, UINT indexMenu, UINT commandIdFirst, UINT, UINT flags) override
+    {
+        if ((flags & CMF_DEFAULTONLY) || !legacyCommandVisible_) {
+            return MAKE_HRESULT(SEVERITY_SUCCESS, 0, 0);
+        }
+
+        if (!InsertMenuW(
+                menu,
+                indexMenu,
+                MF_BYPOSITION | MF_STRING,
+                commandIdFirst,
+                GetLocalizedCommandTitle())) {
+            return HRESULT_FROM_WIN32(GetLastError());
+        }
+
+        MENUITEMINFOW menuItemInfo{};
+        menuItemInfo.cbSize = sizeof(menuItemInfo);
+        menuItemInfo.fMask = MIIM_BITMAP;
+        menuItemInfo.hbmpItem = GetContextMenuBitmap();
+
+        if (menuItemInfo.hbmpItem) {
+            SetMenuItemInfoW(menu, commandIdFirst, FALSE, &menuItemInfo);
+        }
+
+        return MAKE_HRESULT(SEVERITY_SUCCESS, 0, 1);
+    }
+
+    // Windows 10 legacy shell path. Explorer calls this after the user clicks
+    // the inserted command. Command id 0 is the only verb this handler adds.
+    IFACEMETHODIMP InvokeCommand(LPCMINVOKECOMMANDINFO commandInfo) override
+    {
+        if (!commandInfo) return E_INVALIDARG;
+
+        if (HIWORD(commandInfo->lpVerb) != 0 || LOWORD(commandInfo->lpVerb) != 0) {
+            return E_FAIL;
+        }
+
+        if (!legacySelectedPath_.empty() && IsInternxtSyncRootDescendant(legacySelectedPath_)) {
+            SendSelectedPathToElectron(legacySelectedPath_);
+        }
+
+        return S_OK;
+    }
+
+    // Windows 10 legacy shell path. We do not expose status-bar help text or
+    // canonical verb strings for this command.
+    IFACEMETHODIMP GetCommandString(UINT_PTR, UINT, UINT*, LPSTR, UINT) override
+    {
+        return E_NOTIMPL;
+    }
+
     // Windows calls this to obtain the text displayed in the context menu.
     // The first parameter contains selected items but is not needed for a
     // constant title, so its variable name is intentionally omitted.
@@ -249,6 +391,10 @@ public:
         *commands = nullptr;
         return E_NOTIMPL;
     }
+
+private:
+    std::wstring legacySelectedPath_;
+    bool legacyCommandVisible_ = false;
 };
 
 // Adds this class to WRL's internal map of COM classes. When Explorer asks the
@@ -263,6 +409,9 @@ BOOL APIENTRY DllMain(HMODULE module, DWORD reason, LPVOID)
     if (reason == DLL_PROCESS_ATTACH) {
         ContextMenuModule = module;
         DisableThreadLibraryCalls(module);
+    } else if (reason == DLL_PROCESS_DETACH && ContextMenuBitmap) {
+        DeleteObject(ContextMenuBitmap);
+        ContextMenuBitmap = nullptr;
     }
 
     return TRUE;

--- a/packages/context-menu/unregister-context-menu-extension.ps1
+++ b/packages/context-menu/unregister-context-menu-extension.ps1
@@ -1,10 +1,90 @@
 $ErrorActionPreference = "Stop"
 
+function Test-ShouldRelaunchWithNativePowerShell {
+  return [Environment]::Is64BitOperatingSystem -and -not [Environment]::Is64BitProcess
+}
+
+function Invoke-NativePowerShellUnregistration {
+  $nativePowerShellPath = Join-Path $env:WINDIR "sysnative\WindowsPowerShell\v1.0\powershell.exe"
+
+  if (-not (Test-Path -LiteralPath $nativePowerShellPath)) {
+    return $false
+  }
+
+  $nativePowerShell = Start-Process `
+    -FilePath $nativePowerShellPath `
+    -ArgumentList @(
+      "-NoLogo",
+      "-NoProfile",
+      "-ExecutionPolicy", "Bypass",
+      "-File", "`"$PSCommandPath`""
+    ) `
+    -Wait `
+    -PassThru
+
+  exit $nativePowerShell.ExitCode
+}
+
+if (Test-ShouldRelaunchWithNativePowerShell) {
+  Invoke-NativePowerShellUnregistration | Out-Null
+}
+
 $packageName = "com.internxt.drive.contextmenu"
 $certificatePath = Join-Path $PSScriptRoot "InternxtDevelopment.cer"
+$contextMenuClsid = "{F47A034D-852C-4F60-B721-C31C854183F2}"
+$contextMenuVerbId = "InternxtCopyShareLink"
+
+function Remove-CurrentUserRegistryTree {
+  param(
+    [Parameter(Mandatory)]
+    [string] $SubKeyPath
+  )
+
+  $currentUserKey = [Microsoft.Win32.Registry]::CurrentUser
+  $existingKey = $currentUserKey.OpenSubKey($SubKeyPath)
+
+  if (-not $existingKey) {
+    return
+  }
+
+  $existingKey.Dispose()
+  $currentUserKey.DeleteSubKeyTree($SubKeyPath)
+}
+
+function Unregister-Windows10ContextMenuExtension {
+  foreach ($itemType in @("*", "Directory", "AllFileSystemObjects")) {
+    Remove-CurrentUserRegistryTree `
+      -SubKeyPath "Software\Classes\$itemType\shellex\ContextMenuHandlers\$contextMenuVerbId"
+
+    Remove-CurrentUserRegistryTree `
+      -SubKeyPath "Software\Classes\$itemType\shell\$contextMenuVerbId"
+  }
+
+  Remove-CurrentUserRegistryTree `
+    -SubKeyPath "Software\Classes\AllFileSystemObjects\shell\$contextMenuVerbId"
+
+  $approvedShellExtensionsKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey(
+    "Software\Microsoft\Windows\CurrentVersion\Shell Extensions\Approved",
+    $true)
+
+  if ($approvedShellExtensionsKey) {
+    try {
+      $approvedShellExtensionsKey.DeleteValue($contextMenuClsid, $false)
+    } finally {
+      $approvedShellExtensionsKey.Dispose()
+    }
+  }
+
+  Remove-CurrentUserRegistryTree `
+    -SubKeyPath "Software\Classes\CLSID\$contextMenuClsid"
+
+  Write-Host "Internxt Windows 10 context-menu extension unregistered."
+}
 
 # Remove the context-menu registration for the current Windows user before
 # NSIS deletes the external DLL and host executable from the installation.
+Unregister-Windows10ContextMenuExtension
+
 $installedPackage = Get-AppxPackage -Name $packageName
 if ($installedPackage) {
   $installedPackage | Remove-AppxPackage

--- a/src/apps/backups/backups.test.ts
+++ b/src/apps/backups/backups.test.ts
@@ -1,6 +1,6 @@
 import Bottleneck from 'bottleneck';
 import { randomUUID } from 'node:crypto';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, stat, writeFile } from 'node:fs/promises';
 import { beforeAll } from 'vitest';
 import { Sync } from '@/backend/features/sync';
 import { join } from '@/context/local/localFile/infrastructure/AbsolutePath';
@@ -51,6 +51,8 @@ describe('backups', () => {
 
   it('should perform a complete backup', async () => {
     // Given
+    const unmodifiedFileStats = await stat(unmodifiedFile);
+
     getFoldersMock.mockResolvedValue({
       data: [
         { uuid: 'folder' as FolderUuid, parentUuid: rootUuid, name: 'folder', status: 'EXISTS' },
@@ -61,7 +63,14 @@ describe('backups', () => {
 
     getFilesMock.mockResolvedValue({
       data: [
-        { uuid: 'unmodifiedFile' as FileUuid, parentUuid: rootUuid, name: 'unmodifiedFile', size: 7, status: 'EXISTS' },
+        {
+          uuid: 'unmodifiedFile' as FileUuid,
+          parentUuid: rootUuid,
+          name: 'unmodifiedFile',
+          size: 7,
+          modificationTime: unmodifiedFileStats.mtime.toISOString(),
+          status: 'EXISTS',
+        },
         { uuid: 'modifiedFile' as FileUuid, parentUuid: rootUuid, name: 'modifiedFile', size: 12, status: 'EXISTS' },
         { uuid: 'deletedFile' as FileUuid, parentUuid: 'folder', name: 'deleted', status: 'EXISTS' },
         { status: 'DELETED' },

--- a/src/apps/backups/diff/calculate-files-diff.test.ts
+++ b/src/apps/backups/diff/calculate-files-diff.test.ts
@@ -3,10 +3,11 @@ import { abs } from '@/context/local/localFile/infrastructure/AbsolutePath';
 import { calculateFilesDiff } from './calculate-files-diff';
 
 describe('calculate-files-diff', () => {
+  const date = (value: string) => new Date(value);
   const props = mockProps<typeof calculateFilesDiff>({
     local: {
       files: {
-        [abs('/file1')]: { path: abs('/file1'), stats: {} },
+        [abs('/file1')]: { path: abs('/file1'), stats: { size: 7, mtime: date('2026-06-30T12:00:01.100Z') } },
         [abs('/file2')]: { path: abs('/file2'), stats: {} },
         [abs('/file6')]: { path: abs('/file6'), stats: { size: 12 } },
       },
@@ -14,7 +15,7 @@ describe('calculate-files-diff', () => {
     },
     remote: {
       files: new Map([
-        [abs('/file1'), { absolutePath: abs('/file1') }],
+        [abs('/file1'), { absolutePath: abs('/file1'), size: 7, modificationTime: '2026-06-30T12:00:01.100Z' }],
         [abs('/file3'), { absolutePath: abs('/file3') }],
         [abs('/file6'), { absolutePath: abs('/file6'), size: 10 }],
       ]),
@@ -30,5 +31,61 @@ describe('calculate-files-diff', () => {
     expect(diff.added.map((file) => file.path)).toStrictEqual(['/file2']);
     expect(diff.deleted.map((file) => file.absolutePath)).toStrictEqual(['/file3']);
     expect(diff.modified.map(({ remote }) => remote.absolutePath)).toStrictEqual(['/file6']);
+  });
+
+  it('should mark same-size files as modified when local modification time is newer', () => {
+    // Given
+    const props = mockProps<typeof calculateFilesDiff>({
+      local: {
+        files: {
+          [abs('/file')]: { path: abs('/file'), stats: { size: 7, mtime: date('2026-06-30T12:00:02.900Z') } },
+        },
+      },
+      remote: {
+        files: new Map([
+          [
+            abs('/file'),
+            {
+              absolutePath: abs('/file'),
+              size: 7,
+              modificationTime: '2026-06-30T12:00:01.100Z',
+            },
+          ],
+        ]),
+      },
+    });
+    // When
+    const diff = calculateFilesDiff(props);
+    // Then
+    expect(diff.modified.map(({ remote }) => remote.absolutePath)).toStrictEqual(['/file']);
+    expect(diff.unmodified).toStrictEqual([]);
+  });
+
+  it('should not mark same-size files as modified when remote and local modification time are the same', () => {
+    // Given
+    const props = mockProps<typeof calculateFilesDiff>({
+      local: {
+        files: {
+          [abs('/file')]: { path: abs('/file'), stats: { size: 7, mtime: date('2026-06-30T12:00:01.100Z') } },
+        },
+      },
+      remote: {
+        files: new Map([
+          [
+            abs('/file'),
+            {
+              absolutePath: abs('/file'),
+              size: 7,
+              modificationTime: '2026-06-30T12:00:01.100Z',
+            },
+          ],
+        ]),
+      },
+    });
+    // When
+    const diff = calculateFilesDiff(props);
+    // Then
+    expect(diff.modified).toStrictEqual([]);
+    expect(diff.unmodified.map((file) => file.path)).toStrictEqual(['/file']);
   });
 });

--- a/src/apps/backups/diff/calculate-files-diff.ts
+++ b/src/apps/backups/diff/calculate-files-diff.ts
@@ -30,7 +30,7 @@ export function calculateFilesDiff({ local, remote }: TProps) {
       return;
     }
 
-    if (remoteFile.size !== local.stats.size) {
+    if (remoteFile.size !== local.stats.size || isLocalFileNewer({ local, remote: remoteFile })) {
       modified.push({ local, remote: remoteFile });
       return;
     }
@@ -53,4 +53,13 @@ export function calculateFilesDiff({ local, remote }: TProps) {
     unmodified,
     total,
   };
+}
+
+function isLocalFileNewer({ local, remote }: { local: StatItem; remote: ExtendedDriveFile }) {
+  const remoteTime = remote.modificationTime ?? remote.updatedAt;
+  if (!remoteTime) return true;
+  const remoteModificationTime = Math.trunc(new Date(remoteTime).getTime() / 1000);
+  const localModificationTime = Math.trunc(local.stats.mtime.getTime() / 1000);
+  if (Number.isNaN(remoteModificationTime) || Number.isNaN(localModificationTime)) return true;
+  return remoteModificationTime < localModificationTime;
 }


### PR DESCRIPTION
This pr reverts #1437 so we add back #1433 and #1430

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved context-menu support across Windows versions, including better installation and removal behavior.
  * Added support for the legacy Windows 10 shell context-menu flow alongside newer Windows handling.

* **Bug Fixes**
  * Context-menu setup now continues past non-critical registration issues instead of stopping the installer.
  * Backup file comparison now recognizes changes based on file timestamps, not just file size, reducing missed updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->