### PR TITLE
chore: Enable debug for vscode

### DIFF
--- a/.erb/configs/webpack.config.renderer.dev.ts
+++ b/.erb/configs/webpack.config.renderer.dev.ts
@@ -162,8 +162,12 @@ const configuration: Configuration = {
     static: { publicPath: '/' },
     historyApiFallback: { verbose: true },
     setupMiddlewares: (middlewares) => {
+      if (process.env.DEBUG_MODE === 'true') {
+        return middlewares;
+      }
+
       console.log('Starting Main Process...');
-      spawn('npm', ['run', 'start:nodemon'], {
+      spawn('npm', ['run', process.env.ELECTRON_START_SCRIPT || 'start:nodemon'], {
         shell: true,
         env: process.env,
         stdio: 'inherit',

--- a/.erb/scripts/electron-launcher-debug.js
+++ b/.erb/scripts/electron-launcher-debug.js
@@ -1,0 +1,17 @@
+const { app } = require('electron');
+
+require('tsx/cjs');
+require('tsconfig-paths').register();
+
+if (process.env.DEBUG_USER_DATA_PATH) {
+  app.setPath('userData', process.env.DEBUG_USER_DATA_PATH);
+}
+
+if (process.env.DEBUG_DISABLE_HARDWARE_ACCELERATION === 'true') {
+  app.disableHardwareAcceleration();
+  app.commandLine.appendSwitch('disable-gpu');
+  app.commandLine.appendSwitch('disable-gpu-compositing');
+  app.commandLine.appendSwitch('disable-gpu-sandbox');
+}
+
+require('../../src/apps/main/main.ts');

--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,16 @@
 /.erb/dll
 /.github/copilot-instructions.md
 /.idea
-/.vscode
+/.vscode/*
+!/.vscode/launch.json
+!/.vscode/tasks.json
+/.zed
 /build
 /clamAV/*
 /CLAUDE.md
 /coverage
 /dist
+/.debug
 /node_modules
 /test-files
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,41 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Electron App",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd",
+      "args": ["--disable-gpu", ".erb/scripts/electron-launcher-debug.js"],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "NODE_ENV": "development",
+        "TS_NODE_TRANSPILE_ONLY": "true",
+        "E2E_TEST": "true",
+        "E2E_HOME_PATH": "${workspaceFolder}/.debug/home",
+        "E2E_APPDATA_PATH": "${workspaceFolder}/.debug/appdata",
+        "DEBUG_USER_DATA_PATH": "${workspaceFolder}/.debug/userData",
+        "DEBUG_DISABLE_HARDWARE_ACCELERATION": "true"
+      },
+      "console": "integratedTerminal",
+      "skipFiles": ["<node_internals>/**"],
+      "sourceMaps": true,
+      "pauseForSourceMap": true,
+      "smartStep": false,
+      "sourceMapPathOverrides": {
+        "src/*": "${workspaceFolder}/src/*",
+        "./src/*": "${workspaceFolder}/src/*",
+        "webpack:///src/*": "${workspaceFolder}/src/*",
+        "file:///${workspaceFolder}/src/*": "${workspaceFolder}/src/*",
+        "${workspaceFolder}/src/*": "${workspaceFolder}/src/*"
+      },
+      "autoAttachChildProcesses": true,
+      "preLaunchTask": "Start Renderer (Debug Mode)",
+      "postDebugTask": "Kill Existing Electron",
+      "presentation": {
+        "group": "main",
+        "order": 1
+      }
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,57 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Kill Existing Electron",
+      "type": "process",
+      "command": "powershell.exe",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        "try { Get-Process electron -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue } catch {}; exit 0"
+      ],
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "never",
+        "echo": false,
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": false
+      }
+    },
+    {
+      "label": "Start Renderer (Debug Mode)",
+      "type": "process",
+      "command": "npm.cmd",
+      "args": ["run", "start:renderer:only"],
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "DEBUG_MODE": "true"
+        }
+      },
+      "isBackground": true,
+      "dependsOn": ["Kill Existing Electron"],
+      "problemMatcher": {
+        "owner": "custom",
+        "pattern": {
+          "regexp": "zzzzzzzzzzzzz"
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": ".*",
+          "endsPattern": ".*(Project is running at:|Loopback:|compiled successfully|webpack compiled successfully|Compiled successfully).*"
+        }
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "clear": true,
+        "group": "dev"
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "start:reload": "npm run build:preload && npm run start:main",
     "start:main": "cross-env NODE_ENV=development electron .erb/scripts/electron-launcher.js",
     "start:renderer": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack serve --config .erb/configs/webpack.config.renderer.dev.ts",
+    "start:renderer:only": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true DEBUG_MODE=true webpack serve --config .erb/configs/webpack.config.renderer.dev.ts",
     "========== Testing ==========": "",
     "test": "vitest",
     "test:one": "vitest --watch related x",


### PR DESCRIPTION
## What is Changed / Added
Added the feature to start the app in debug mode for vscode


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated renderer-only development mode for faster iteration.
  * Added configurable Electron debugging with custom application data locations and optional hardware acceleration disablement.
  * Added development launch and task configurations for streamlined debugging.

* **Bug Fixes**
  * Prevented the Electron process from starting when renderer-only debug mode is enabled.
  * Improved support for alternate Electron startup commands during development.

* **Chores**
  * Expanded repository exclusions for generated builds, coverage reports, debug files, and tooling artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->