### PR TITLE
[BR-1308] Fix: Properly add original file modification and creation time

### DIFF
--- a/src/backend/features/sync/actions/services/create-file.test.ts
+++ b/src/backend/features/sync/actions/services/create-file.test.ts
@@ -21,13 +21,15 @@ describe('create-file', () => {
 
   const path = abs('/parent/file.txt');
   const size = 1024;
+  const mtime = new Date('2000-01-01T00:00:00.000Z');
+  const creationTime = new Date('1999-01-01T00:00:00.000Z');
   let props: Parameters<typeof createFile>[0];
 
   beforeEach(() => {
     props = mockProps<typeof createFile>({ path });
 
     isTemporaryFileMock.mockReturnValue(false);
-    uploadMock.mockResolvedValue({ contentsId: 'contentsId' as ContentsId, size });
+    uploadMock.mockResolvedValue({ contentsId: 'contentsId' as ContentsId, size, mtime, creationTime });
   });
 
   it('should not upload if the file is temporary', async () => {
@@ -74,7 +76,19 @@ describe('create-file', () => {
     await createFile(props);
     // Given
     call(uploadMock).toMatchObject({ path });
-    call(persistMock).toMatchObject({ context: { path, body: { fileId: 'contentsId', size, plainName: 'file', type: 'txt' } } });
+    call(persistMock).toMatchObject({
+      context: {
+        path,
+        body: {
+          fileId: 'contentsId',
+          size,
+          plainName: 'file',
+          type: 'txt',
+          modificationTime: '2000-01-01T00:00:00.000Z',
+          creationTime: '1999-01-01T00:00:00.000Z',
+        },
+      },
+    });
     call(addItemMock).toMatchObject({ action: 'UPLOADED', path });
     call(createAndUploadThumbnailMock).toMatchObject({ path, fileUuid: 'uuid' });
     call(createOrUpdateFileMock).toMatchObject({ fileDto: { uuid: 'uuid' } });

--- a/src/backend/features/sync/actions/services/create-file.ts
+++ b/src/backend/features/sync/actions/services/create-file.ts
@@ -40,6 +40,8 @@ export async function createFile({ ctx, path, parentUuid }: Props) {
     plainName: name,
     size: upload.size,
     type: extension,
+    modificationTime: upload.mtime.toISOString(),
+    creationTime: upload.creationTime.toISOString(),
   };
 
   let res = ctx.workspaceId

--- a/src/backend/features/sync/actions/services/replace-file.test.ts
+++ b/src/backend/features/sync/actions/services/replace-file.test.ts
@@ -19,13 +19,14 @@ describe('replace-file', () => {
 
   const path = abs('/file.txt');
   const size = 1024;
-  const mtime = new Date('2000-01-01');
+  const mtime = new Date('2000-01-01T00:00:00.000Z');
+  const creationTime = new Date('1999-01-01T00:00:00.000Z');
   let props: Parameters<typeof replaceFile>[0];
 
   beforeEach(() => {
     props = mockProps<typeof replaceFile>({ path });
 
-    uploadMock.mockResolvedValue({ contentsId: 'contentsId' as ContentsId, size, mtime });
+    uploadMock.mockResolvedValue({ contentsId: 'contentsId' as ContentsId, size, mtime, creationTime });
   });
 
   it('should not persist if the file upload fails', async () => {
@@ -63,7 +64,15 @@ describe('replace-file', () => {
     await replaceFile(props);
     // Given
     call(uploadMock).toMatchObject({ path });
-    call(persistMock).toMatchObject({ context: { path, contentsId: 'contentsId', size, modificationTime: '2000-01-01T00:00:00.000Z' } });
+    call(persistMock).toMatchObject({
+      context: {
+        path,
+        contentsId: 'contentsId',
+        size,
+        modificationTime: '2000-01-01T00:00:00.000Z',
+        creationTime: '1999-01-01T00:00:00.000Z',
+      },
+    });
     call(addItemMock).toMatchObject({ action: 'MODIFIED', path });
     call(createAndUploadThumbnailMock).toMatchObject({ path, fileUuid: 'uuid' });
     call(createOrUpdateFileMock).toMatchObject({ fileDto: { uuid: 'uuid' } });

--- a/src/backend/features/sync/actions/services/replace-file.ts
+++ b/src/backend/features/sync/actions/services/replace-file.ts
@@ -27,6 +27,7 @@ export async function replaceFile({ ctx, path, uuid }: Props) {
       contentsId: upload.contentsId,
       size: upload.size,
       modificationTime: upload.mtime.toISOString(),
+      creationTime: upload.creationTime.toISOString(),
     },
   });
 

--- a/src/backend/features/sync/actions/services/upload-file.test.ts
+++ b/src/backend/features/sync/actions/services/upload-file.test.ts
@@ -23,10 +23,12 @@ describe('upload-file', () => {
 
   const path = abs('/file.txt');
   const size = 1024;
+  const mtime = new Date('2000-01-01T00:00:00.000Z');
+  const birthtime = new Date('1999-01-01T00:00:00.000Z');
   let props: Parameters<typeof uploadFile>[0];
 
   beforeEach(() => {
-    statMock.mockResolvedValue({ size });
+    statMock.mockResolvedValue({ size, mtime, birthtime });
     isTemporaryFileMock.mockReturnValue(false);
     waitUntilReadyMock.mockResolvedValue(true);
     environmentFileUploadMock.mockResolvedValue('contentsId' as ContentsId);
@@ -51,17 +53,17 @@ describe('upload-file', () => {
 
   it('should return empty contents id if the file is empty', async () => {
     // Given
-    statMock.mockResolvedValue({ size: 0 });
+    statMock.mockResolvedValue({ size: 0, mtime, birthtime });
     // When
     const res = await uploadFile(props);
     // Then
-    expect(res).toMatchObject({ contentsId: undefined, size: 0 });
+    expect(res).toStrictEqual({ contentsId: undefined, size: 0, mtime, creationTime: birthtime });
     calls(environmentFileUploadMock).toHaveLength(0);
   });
 
   it('should return undefined if the file exceeds stored plan limit', async () => {
     // Given
-    statMock.mockResolvedValue({ size: 6 });
+    statMock.mockResolvedValue({ size: 6, mtime, birthtime });
     electronStoreGetMock.mockReturnValue(5);
     // When
     const res = await uploadFile(props);
@@ -82,7 +84,7 @@ describe('upload-file', () => {
 
   it('should return undefined if the file exceeds absolute upload cap', async () => {
     // Given
-    statMock.mockResolvedValue({ size: ABSOLUTE_UPLOAD_FILE_SIZE_LIMIT + 1 });
+    statMock.mockResolvedValue({ size: ABSOLUTE_UPLOAD_FILE_SIZE_LIMIT + 1, mtime, birthtime });
     // When
     const res = await uploadFile(props);
     // Then
@@ -126,7 +128,7 @@ describe('upload-file', () => {
     // When
     const res = await uploadFile(props);
     // Then
-    expect(res).toMatchObject({ contentsId: 'contentsId', size });
+    expect(res).toStrictEqual({ contentsId: 'contentsId', size, mtime, creationTime: birthtime });
     call(environmentFileUploadMock).toMatchObject({ path, size });
   });
 });

--- a/src/backend/features/sync/actions/services/upload-file.ts
+++ b/src/backend/features/sync/actions/services/upload-file.ts
@@ -20,10 +20,10 @@ export async function uploadFile({ ctx, path }: Props) {
     return;
   }
 
-  const { size, mtime } = await stat(path);
+  const { size, mtime, birthtime } = await stat(path);
 
   if (size === 0) {
-    return { contentsId: undefined, size, mtime };
+    return { contentsId: undefined, size, mtime, creationTime: birthtime };
   }
 
   const validation = validateUploadFileSize({ size, maxUploadFileSize: electronStore.get('maxUploadFileSizeInBytes') });
@@ -45,7 +45,7 @@ export async function uploadFile({ ctx, path }: Props) {
 
     if (!contentsId) return;
 
-    return { contentsId, size, mtime };
+    return { contentsId, size, mtime, creationTime: birthtime };
   } catch (error) {
     if (isBottleneckStop({ error })) return;
 

--- a/src/infra/drive-server-wip/services/files.service.ts
+++ b/src/infra/drive-server-wip/services/files.service.ts
@@ -60,6 +60,7 @@ async function replaceFile({
     contentsId: ContentsId | undefined;
     size: number;
     modificationTime: string;
+    creationTime: string;
   };
 }) {
   const method = 'PUT';
@@ -75,6 +76,7 @@ async function replaceFile({
         fileId: context.contentsId,
         size: context.size,
         modificationTime: context.modificationTime,
+        creationTime: context.creationTime,
       },
     });
 


### PR DESCRIPTION
## What is Changed / Added
Added original file creation and modification time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File synchronization now preserves and sends file creation dates alongside modification dates.
  * Uploaded, created, and replaced files retain accurate timestamp metadata.

* **Bug Fixes**
  * Improved timestamp handling for empty files and successfully uploaded files.
  * File replacement requests now include creation-time information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->