### PR TITLE
Fix/improve traversal on app startup

### DIFF
--- a/src/backend/features/drive/actions/services/create-pending-files.ts
+++ b/src/backend/features/drive/actions/services/create-pending-files.ts
@@ -11,8 +11,7 @@ type Props = {
 };
 
 export async function createPendingFiles({ ctx, files, parentUuid }: Props) {
-  // TODO PB-6612: Bound pending file processing. Large local folders can fan out
-  // too many NodeWin/upload/config reads and hit EMFILE before bottlenecks apply.
+  /* TODO PB-6612: When adding 250k+ folder, this method starts to throw: EMFILE too many files open. */
   await Promise.all(
     files.map(async ({ path }) => {
       const { error } = await NodeWin.getFileInfo({ path });

--- a/src/backend/features/drive/actions/services/create-pending-files.ts
+++ b/src/backend/features/drive/actions/services/create-pending-files.ts
@@ -11,6 +11,8 @@ type Props = {
 };
 
 export async function createPendingFiles({ ctx, files, parentUuid }: Props) {
+  // TODO PB-6612: Bound pending file processing. Large local folders can fan out
+  // too many NodeWin/upload/config reads and hit EMFILE before bottlenecks apply.
   await Promise.all(
     files.map(async ({ path }) => {
       const { error } = await NodeWin.getFileInfo({ path });

--- a/src/context/virtual-drive/items/application/Traverser.ts
+++ b/src/context/virtual-drive/items/application/Traverser.ts
@@ -23,6 +23,27 @@ type StackItem =
   | { folder: Pick<ExtendedDriveFolder, 'absolutePath' | 'uuid'>; requiresPlaceholderUpdate: false }
   | { folder: ExtendedDriveFolder; requiresPlaceholderUpdate: true };
 export async function traverse({ ctx, database, fileExplorer, currentFolder, isFirstExecution, limit }: Props) {
+  const filesByParentUuid = new Map<string | undefined, SimpleDriveFile[]>();
+  const foldersByParentUuid = new Map<string | undefined, SimpleDriveFolder[]>();
+
+  for (const file of database.files) {
+    const files = filesByParentUuid.get(file.parentUuid);
+    if (files) {
+      files.push(file);
+    } else {
+      filesByParentUuid.set(file.parentUuid, [file]);
+    }
+  }
+
+  for (const folder of database.folders) {
+    const folders = foldersByParentUuid.get(folder.parentUuid);
+    if (folders) {
+      folders.push(folder);
+    } else {
+      foldersByParentUuid.set(folder.parentUuid, [folder]);
+    }
+  }
+
   const stack: StackItem[] = [{ folder: currentFolder, requiresPlaceholderUpdate: false }];
 
   while (stack.length > 0) {
@@ -42,8 +63,8 @@ export async function traverse({ ctx, database, fileExplorer, currentFolder, isF
     }
 
     const { folder } = item;
-    const filesInThisFolder = database.files.filter((file) => file.parentUuid === folder.uuid);
-    const foldersInThisFolder = database.folders.filter((child) => child.parentUuid === folder.uuid);
+    const filesInThisFolder = filesByParentUuid.get(folder.uuid) ?? [];
+    const foldersInThisFolder = foldersByParentUuid.get(folder.uuid) ?? [];
 
     await Promise.all(
       filesInThisFolder.map((file) =>

--- a/src/context/virtual-drive/items/application/Traverser.ts
+++ b/src/context/virtual-drive/items/application/Traverser.ts
@@ -110,6 +110,7 @@ async function processFilesInFolder({
 
   async function processNextFile() {
     while (nextFileIndex < files.length) {
+      if (ctx.abortController.signal.aborted) return;
       const file = files[nextFileIndex];
       nextFileIndex += 1;
       await processFile({ ctx, folder, file, fileExplorer, isFirstExecution });

--- a/src/context/virtual-drive/items/application/Traverser.ts
+++ b/src/context/virtual-drive/items/application/Traverser.ts
@@ -23,27 +23,6 @@ type StackItem =
   | { folder: Pick<ExtendedDriveFolder, 'absolutePath' | 'uuid'>; requiresPlaceholderUpdate: false }
   | { folder: ExtendedDriveFolder; requiresPlaceholderUpdate: true };
 export async function traverse({ ctx, database, fileExplorer, currentFolder, isFirstExecution, limit }: Props) {
-  const filesByParentUuid = new Map<string | undefined, SimpleDriveFile[]>();
-  const foldersByParentUuid = new Map<string | undefined, SimpleDriveFolder[]>();
-
-  for (const file of database.files) {
-    const files = filesByParentUuid.get(file.parentUuid);
-    if (files) {
-      files.push(file);
-    } else {
-      filesByParentUuid.set(file.parentUuid, [file]);
-    }
-  }
-
-  for (const folder of database.folders) {
-    const folders = foldersByParentUuid.get(folder.parentUuid);
-    if (folders) {
-      folders.push(folder);
-    } else {
-      foldersByParentUuid.set(folder.parentUuid, [folder]);
-    }
-  }
-
   const stack: StackItem[] = [{ folder: currentFolder, requiresPlaceholderUpdate: false }];
 
   while (stack.length > 0) {
@@ -63,8 +42,8 @@ export async function traverse({ ctx, database, fileExplorer, currentFolder, isF
     }
 
     const { folder } = item;
-    const filesInThisFolder = filesByParentUuid.get(folder.uuid) ?? [];
-    const foldersInThisFolder = foldersByParentUuid.get(folder.uuid) ?? [];
+    const filesInThisFolder = database.files.filter((file) => file.parentUuid === folder.uuid);
+    const foldersInThisFolder = database.folders.filter((child) => child.parentUuid === folder.uuid);
 
     await Promise.all(
       filesInThisFolder.map((file) =>

--- a/src/context/virtual-drive/items/application/Traverser.ts
+++ b/src/context/virtual-drive/items/application/Traverser.ts
@@ -105,13 +105,18 @@ async function processFilesInFolder({
   isFirstExecution: boolean;
   limit: LimitFunction;
 }) {
-  await Promise.all(
-    files.map((file) =>
-      limit(async () => {
-        await processFile({ ctx, folder, file, fileExplorer, isFirstExecution });
-      }),
-    ),
-  );
+  let nextFileIndex = 0;
+  const workerCount = getFileProcessingWorkerCount({ limit, fileCount: files.length });
+
+  async function processNextFile() {
+    while (nextFileIndex < files.length) {
+      const file = files[nextFileIndex];
+      nextFileIndex += 1;
+      await processFile({ ctx, folder, file, fileExplorer, isFirstExecution });
+    }
+  }
+
+  await Promise.all(Array.from({ length: workerCount }, () => limit(processNextFile)));
 }
 
 async function processFile({
@@ -155,4 +160,9 @@ function pushChildFoldersToStack({
 
 function isDeletedOrTrashed(status: SimpleDriveFile['status'] | SimpleDriveFolder['status']) {
   return status === 'DELETED' || status === 'TRASHED';
+}
+
+function getFileProcessingWorkerCount({ limit, fileCount }: { limit: LimitFunction; fileCount: number }) {
+  const concurrency = Number.isFinite(limit.concurrency) ? limit.concurrency : fileCount;
+  return Math.min(concurrency, fileCount);
 }

--- a/src/context/virtual-drive/items/application/Traverser.ts
+++ b/src/context/virtual-drive/items/application/Traverser.ts
@@ -19,39 +19,51 @@ type Props = {
   isFirstExecution: boolean;
   limit: LimitFunction;
 };
-
+type StackItem =
+  | { folder: Pick<ExtendedDriveFolder, 'absolutePath' | 'uuid'>; requiresPlaceholderUpdate: false }
+  | { folder: ExtendedDriveFolder; requiresPlaceholderUpdate: true };
 export async function traverse({ ctx, database, fileExplorer, currentFolder, isFirstExecution, limit }: Props) {
-  if (ctx.abortController.signal.aborted) return;
+  const stack: StackItem[] = [{ folder: currentFolder, requiresPlaceholderUpdate: false }];
 
-  const filesInThisFolder = database.files.filter((file) => file.parentUuid === currentFolder.uuid);
-  const foldersInThisFolder = database.folders.filter((folder) => folder.parentUuid === currentFolder.uuid);
+  while (stack.length > 0) {
+    if (ctx.abortController.signal.aborted) return;
 
-  await Promise.all(
-    filesInThisFolder.map((file) =>
-      limit(async () => {
-        const absolutePath = join(currentFolder.absolutePath, file.name);
-        const remote = { ...file, absolutePath };
+    const item = stack.pop();
+    if (!item) return;
 
-        if (file.status === 'DELETED' || file.status === 'TRASHED') {
-          await deleteItemPlaceholder({ ctx, type: 'file', remote, locals: fileExplorer.files });
-        } else {
-          await updateFilePlaceholder({ ctx, remote, files: fileExplorer.files, isFirstExecution });
-        }
-      }),
-    ),
-  );
-
-  for (const folder of foldersInThisFolder) {
-    const absolutePath = join(currentFolder.absolutePath, folder.name);
-    const remote = { ...folder, absolutePath };
-
-    if (folder.status === 'DELETED' || folder.status === 'TRASHED') {
-      await deleteItemPlaceholder({ ctx, type: 'folder', remote, locals: fileExplorer.folders });
-    } else {
-      const success = await updateFolderPlaceholder({ ctx, remote, folders: fileExplorer.folders });
-      if (success) {
-        await traverse({ ctx, database, fileExplorer, currentFolder: remote, isFirstExecution, limit });
+    if (item.requiresPlaceholderUpdate) {
+      if (item.folder.status === 'DELETED' || item.folder.status === 'TRASHED') {
+        await deleteItemPlaceholder({ ctx, type: 'folder', remote: item.folder, locals: fileExplorer.folders });
+        continue;
       }
+
+      const success = await updateFolderPlaceholder({ ctx, remote: item.folder, folders: fileExplorer.folders });
+      if (!success || ctx.abortController.signal.aborted) continue;
+    }
+
+    const { folder } = item;
+    const filesInThisFolder = database.files.filter((file) => file.parentUuid === folder.uuid);
+    const foldersInThisFolder = database.folders.filter((child) => child.parentUuid === folder.uuid);
+
+    await Promise.all(
+      filesInThisFolder.map((file) =>
+        limit(async () => {
+          const absolutePath = join(folder.absolutePath, file.name);
+          const remote = { ...file, absolutePath };
+
+          if (file.status === 'DELETED' || file.status === 'TRASHED') {
+            await deleteItemPlaceholder({ ctx, type: 'file', remote, locals: fileExplorer.files });
+          } else {
+            await updateFilePlaceholder({ ctx, remote, files: fileExplorer.files, isFirstExecution });
+          }
+        }),
+      ),
+    );
+
+    for (let index = foldersInThisFolder.length - 1; index >= 0; index -= 1) {
+      const child = foldersInThisFolder[index];
+      const absolutePath = join(folder.absolutePath, child.name);
+      stack.push({ folder: { ...child, absolutePath }, requiresPlaceholderUpdate: true });
     }
   }
 }

--- a/src/context/virtual-drive/items/application/Traverser.ts
+++ b/src/context/virtual-drive/items/application/Traverser.ts
@@ -22,7 +22,13 @@ type Props = {
 type StackItem =
   | { folder: Pick<ExtendedDriveFolder, 'absolutePath' | 'uuid'>; requiresPlaceholderUpdate: false }
   | { folder: ExtendedDriveFolder; requiresPlaceholderUpdate: true };
+type DatabaseChildrenIndex = {
+  filesByParentUuid: Map<string | undefined, SimpleDriveFile[]>;
+  foldersByParentUuid: Map<string | undefined, SimpleDriveFolder[]>;
+};
+
 export async function traverse({ ctx, database, fileExplorer, currentFolder, isFirstExecution, limit }: Props) {
+  const { filesByParentUuid, foldersByParentUuid } = indexDatabaseChildren(database);
   const stack: StackItem[] = [{ folder: currentFolder, requiresPlaceholderUpdate: false }];
 
   while (stack.length > 0) {
@@ -31,39 +37,122 @@ export async function traverse({ ctx, database, fileExplorer, currentFolder, isF
     const item = stack.pop();
     if (!item) return;
 
-    if (item.requiresPlaceholderUpdate) {
-      if (item.folder.status === 'DELETED' || item.folder.status === 'TRASHED') {
-        await deleteItemPlaceholder({ ctx, type: 'folder', remote: item.folder, locals: fileExplorer.folders });
-        continue;
-      }
-
-      const success = await updateFolderPlaceholder({ ctx, remote: item.folder, folders: fileExplorer.folders });
-      if (!success || ctx.abortController.signal.aborted) continue;
-    }
+    const canTraverseFolder = await processFolderPlaceHolder({ ctx, item, fileExplorer });
+    if (!canTraverseFolder) continue;
 
     const { folder } = item;
-    const filesInThisFolder = database.files.filter((file) => file.parentUuid === folder.uuid);
-    const foldersInThisFolder = database.folders.filter((child) => child.parentUuid === folder.uuid);
+    const filesInThisFolder = filesByParentUuid.get(folder.uuid);
+    const foldersInThisFolder = foldersByParentUuid.get(folder.uuid);
 
-    await Promise.all(
-      filesInThisFolder.map((file) =>
-        limit(async () => {
-          const absolutePath = join(folder.absolutePath, file.name);
-          const remote = { ...file, absolutePath };
-
-          if (file.status === 'DELETED' || file.status === 'TRASHED') {
-            await deleteItemPlaceholder({ ctx, type: 'file', remote, locals: fileExplorer.files });
-          } else {
-            await updateFilePlaceholder({ ctx, remote, files: fileExplorer.files, isFirstExecution });
-          }
-        }),
-      ),
-    );
-
-    for (let index = foldersInThisFolder.length - 1; index >= 0; index -= 1) {
-      const child = foldersInThisFolder[index];
-      const absolutePath = join(folder.absolutePath, child.name);
-      stack.push({ folder: { ...child, absolutePath }, requiresPlaceholderUpdate: true });
+    if (filesInThisFolder && filesInThisFolder.length > 0) {
+      await processFilesInFolder({ ctx, folder, files: filesInThisFolder, fileExplorer, isFirstExecution, limit });
+    }
+    if (foldersInThisFolder && foldersInThisFolder.length > 0) {
+      pushChildFoldersToStack({ stack, parentFolder: folder, folders: foldersInThisFolder });
     }
   }
+}
+
+function indexDatabaseChildren(database: Database): DatabaseChildrenIndex {
+  const filesByParentUuid = new Map<string | undefined, SimpleDriveFile[]>();
+  const foldersByParentUuid = new Map<string | undefined, SimpleDriveFolder[]>();
+
+  for (const file of database.files) {
+    const files = filesByParentUuid.get(file.parentUuid);
+    if (files) {
+      files.push(file);
+    } else {
+      filesByParentUuid.set(file.parentUuid, [file]);
+    }
+  }
+
+  for (const folder of database.folders) {
+    const folders = foldersByParentUuid.get(folder.parentUuid);
+    if (folders) {
+      folders.push(folder);
+    } else {
+      foldersByParentUuid.set(folder.parentUuid, [folder]);
+    }
+  }
+
+  return { filesByParentUuid, foldersByParentUuid };
+}
+
+async function processFolderPlaceHolder({ ctx, item, fileExplorer }: { ctx: SyncContext; item: StackItem; fileExplorer: FileExplorer }) {
+  if (!item.requiresPlaceholderUpdate) return true;
+
+  if (isDeletedOrTrashed(item.folder.status)) {
+    await deleteItemPlaceholder({ ctx, type: 'folder', remote: item.folder, locals: fileExplorer.folders });
+    return false;
+  }
+
+  const success = await updateFolderPlaceholder({ ctx, remote: item.folder, folders: fileExplorer.folders });
+  return success && !ctx.abortController.signal.aborted;
+}
+
+async function processFilesInFolder({
+  ctx,
+  folder,
+  files,
+  fileExplorer,
+  isFirstExecution,
+  limit,
+}: {
+  ctx: SyncContext;
+  folder: Pick<ExtendedDriveFolder, 'absolutePath' | 'uuid'>;
+  files: SimpleDriveFile[];
+  fileExplorer: FileExplorer;
+  isFirstExecution: boolean;
+  limit: LimitFunction;
+}) {
+  await Promise.all(
+    files.map((file) =>
+      limit(async () => {
+        await processFile({ ctx, folder, file, fileExplorer, isFirstExecution });
+      }),
+    ),
+  );
+}
+
+async function processFile({
+  ctx,
+  folder,
+  file,
+  fileExplorer,
+  isFirstExecution,
+}: {
+  ctx: SyncContext;
+  folder: Pick<ExtendedDriveFolder, 'absolutePath' | 'uuid'>;
+  file: SimpleDriveFile;
+  fileExplorer: FileExplorer;
+  isFirstExecution: boolean;
+}) {
+  const absolutePath = join(folder.absolutePath, file.name);
+  const remote = { ...file, absolutePath };
+
+  if (isDeletedOrTrashed(file.status)) {
+    await deleteItemPlaceholder({ ctx, type: 'file', remote, locals: fileExplorer.files });
+  } else {
+    await updateFilePlaceholder({ ctx, remote, files: fileExplorer.files, isFirstExecution });
+  }
+}
+
+function pushChildFoldersToStack({
+  stack,
+  parentFolder,
+  folders,
+}: {
+  stack: StackItem[];
+  parentFolder: Pick<ExtendedDriveFolder, 'absolutePath' | 'uuid'>;
+  folders: SimpleDriveFolder[];
+}) {
+  for (let index = folders.length - 1; index >= 0; index -= 1) {
+    const child = folders[index];
+    const absolutePath = join(parentFolder.absolutePath, child.name);
+    stack.push({ folder: { ...child, absolutePath }, requiresPlaceholderUpdate: true });
+  }
+}
+
+function isDeletedOrTrashed(status: SimpleDriveFile['status'] | SimpleDriveFolder['status']) {
+  return status === 'DELETED' || status === 'TRASHED';
 }


### PR DESCRIPTION
## What is Changed / Added
In this Pull request I improve the Traverser to avoid the app freezing when managing larges amount of items within the file tree.

Now, the remote files and folders are pre-processed once before traversal by `parentUuid`. This way we prevent the 2 original filters that retrieved those items within the current folder in the iteration, The child lookup changes from roughly  `O(folders * (files + folders))` to `O(files + folders)`

Also, the traverser was also changed from recursive to an iterative function. This avoids keeping one async call frame per nested folder level, which is especially beneficial for deep trees because traversal depth no longer grows the JavaScript call stack. The traversal state is now held in a single stack structure.

File placeholder work is now processed with a fixed number of workers, currently 20 from the existing `pLimit(20)`, instead of scheduling every file in the folder at once with one large `Promise.all`. This is especially beneficial for folders with many files, because we no longer keep one queued promise/closure per file in memory while only a limited number can run concurrently

---

## Why
Some users with larger trees have reported app crashing on startup or freezing for long periods.  While tracing the startup flow, we found that `refreshItemPlaceholders` runs during sync engine startup and traverses the full remote item tree to reconcile local virtual-drive placeholders.

The original traverser did not scale well for large trees. For every folder visited, it filtered the full `database.files` and `database.folders` arrays to find children. With tens of thousands of folders and hundreds of thousands of files, this becomes very expensive and can block the main process long enough for the app to feel frozen.

In local measurements, the original traversal became the dominant startup cost once the dataset grew:
```shell
  - `96,870` files / `20,828` folders
  - local placeholders: `67,486` files / `20,804` folders
  - placeholder traversal: `35.52s`
  - total placeholder refresh: `44.37s`
  - max event-loop delay during traversal: `~31.7s`
```
 After the traversal changes, the same startup path showed a large reduction in traversal time.
 Example optimized run:
```shell
  - `83,044` files / `20,827` folders
  - local placeholders: `63,672` files / `20,750` folders
  - placeholder traversal: `1.11s`
  - total placeholder refresh: `12.65s`
  - max event-loop delay during traversal: `~72ms`
```
### Next steps
As you can see in the "optimized run", traversal took around 1.1s out of a total of 12.6s. The remaining time mostly comes from `loadInMemoryPaths`, which took around 11s while scanning local placeholders. This indicates that the traverser is no longer the bottleneck. the next performance work should focus on reducing or avoiding the full local placeholder scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Performance Improvements**
  * Updated virtual drive folder traversal to use an iterative, stack-based approach (avoids deep recursion).
  * Improved efficiency by indexing items by parent and reducing repeated scans.
  * Added bounded concurrency for file processing to better handle large synchronizations.

* **Chores**
  * Documented a potential “too many files open” resource limit scenario when syncing extremely large local folders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->