### PR TITLE
feat: improve performance in calculateFoldersDiff

### DIFF
--- a/src/apps/backups/diff/calculate-folders-diff.ts
+++ b/src/apps/backups/diff/calculate-folders-diff.ts
@@ -19,6 +19,7 @@ export function calculateFoldersDiff({ local, remote }: TProps) {
   const added: FoldersDiff['added'] = [];
   const unmodified: FoldersDiff['unmodified'] = [];
   const deleted: FoldersDiff['deleted'] = [];
+  const localFolders = new Set(local.folders);
 
   for (const folder of local.folders) {
     if (remote.folders.has(folder)) {
@@ -29,7 +30,7 @@ export function calculateFoldersDiff({ local, remote }: TProps) {
   }
 
   for (const folder of remote.folders.values()) {
-    if (!local.folders.includes(folder.absolutePath)) {
+    if (!localFolders.has(folder.absolutePath)) {
       deleted.push(folder);
     }
   }


### PR DESCRIPTION
## What is Changed / Added
- Build a `Set` from local folder paths once in `calculateFoldersDiff`.
- Use `Set.has()` to determine whether each remote folder has been deleted locally.
- Preserve the existing diff result and behavior.

---

## Why
The previous implementation used `local.folders.includes(...)` for every remote folder. This makes deleted-folder detection O(local folders x remote folders) in the worst case.

The new implementation builds the local-folder set once and performs expected constant-time membership checks, reducing the overall diff operation to O(local folders + remote folders)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved backup folder comparison to more reliably detect folders that have been deleted remotely.
  - Folder synchronization checks are now more efficient, helping comparisons complete smoothly with larger folder sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->