### PR TITLE
fix: bound createFiles concurrency to avoid unbounded Promise.all

### DIFF
--- a/src/apps/backups/process-files/create-files.ts
+++ b/src/apps/backups/process-files/create-files.ts
@@ -3,6 +3,7 @@ import { stat } from 'node:fs/promises';
 import { BackupsContext } from '@/apps/backups/BackupInfo';
 import { RemoteTree } from '@/apps/backups/remote-tree/traverser';
 import { Sync } from '@/backend/features/sync';
+import { getWorkerCount } from '@/core/utils/concurrency';
 import { dirname } from '@/context/local/localFile/infrastructure/AbsolutePath';
 import { StatItem } from '@/infra/file-system/services/stat-readdir';
 import { scheduleRequest } from '../schedule-request';
@@ -13,9 +14,15 @@ type Props = {
   added: StatItem[];
 };
 
+const CREATE_FILES_CONCURRENCY = 20;
+
 export async function createFiles({ ctx, remoteTree, added }: Props) {
-  await Promise.all(
-    added.map(async (local) => {
+  let nextIndex = 0;
+
+  async function processNext() {
+    while (nextIndex < added.length) {
+      const local = added[nextIndex];
+      nextIndex += 1;
       const path = local.path;
 
       try {
@@ -25,8 +32,11 @@ export async function createFiles({ ctx, remoteTree, added }: Props) {
 
         ctx.logger.sentryError({ msg: 'Error creating file', path, error }, { fileSize: fileStats?.size });
       }
-    }),
-  );
+    }
+  }
+
+  const workerCount = getWorkerCount({ concurrency: CREATE_FILES_CONCURRENCY, itemCount: added.length });
+  await Promise.all(Array.from({ length: workerCount }, processNext));
 }
 
 async function createFile(ctx: BackupsContext, path: AbsolutePath, remoteTree: RemoteTree) {

--- a/src/apps/backups/process-files/create-files.ts
+++ b/src/apps/backups/process-files/create-files.ts
@@ -3,8 +3,8 @@ import { stat } from 'node:fs/promises';
 import { BackupsContext } from '@/apps/backups/BackupInfo';
 import { RemoteTree } from '@/apps/backups/remote-tree/traverser';
 import { Sync } from '@/backend/features/sync';
-import { getWorkerCount } from '@/core/utils/concurrency';
 import { dirname } from '@/context/local/localFile/infrastructure/AbsolutePath';
+import { getWorkerCount } from '@/core/utils/concurrency';
 import { StatItem } from '@/infra/file-system/services/stat-readdir';
 import { scheduleRequest } from '../schedule-request';
 


### PR DESCRIPTION
## Summary
- `createFiles()` passed the entire `added` array straight into `Promise.all(added.map(...))`. On backup folders with millions of pending files this throws `RangeError: Too many elements passed to Promise.all` - confirmed in a customer's logs (19 occurrences since April).
- The `RangeError` is caught by `executeBackupWorker`, so it doesn't crash immediately - but by then `.map()` has already scheduled every item into the shared `backupsBottleneck`, leaving an orphaned backlog running in the background while the next backup folder starts its own scan. This is consistent with the OOM crashes reported for the affected customer.
- Bounds concurrency to a fixed worker pool via `getWorkerCount` (same pattern already used in `stat-readdir.ts` and applied to `Traverser.ts` in `20149eee`), so `Promise.all` never receives more than `CREATE_FILES_CONCURRENCY` (20) promises regardless of how large `added` is.

## Test plan
- [x] Existing unit tests in `create-files.test.ts` pass unchanged (3/3).
- [x] `tsc --noEmit` / lint clean.
- [x] Manually verified in the dev app: backup of a 2,000-file test folder completes with no `RangeError`, files processed out-of-order as expected from a 20-worker pool.
- [ ] Not yet tested at the customer's real scale (~2.2M files) - recommend validating with a large local dataset before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved backup file processing by handling multiple files concurrently.
  * Limited concurrent processing to maintain reliable performance and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->