### PR TITLE
Fix/filesize modal on empty file

### DIFF
--- a/src/infra/drive-server-wip/defs.ts
+++ b/src/infra/drive-server-wip/defs.ts
@@ -4,6 +4,7 @@ export class DriveServerWipError extends Error {
     public readonly code: TDriveServerWipError,
     cause: unknown,
     public readonly response?: Response,
+    public readonly apiError?: unknown,
   ) {
     super(code, { cause });
   }

--- a/src/infra/drive-server-wip/in/error-wrapper.ts
+++ b/src/infra/drive-server-wip/in/error-wrapper.ts
@@ -31,6 +31,6 @@ export function errorWrapper({ loggerBody, error, response, retry }: TProps) {
     addGeneralIssue(serverErrorIssue);
     return new DriveServerWipError('SERVER', loggedError);
   } else {
-    return new DriveServerWipError('UNKNOWN', loggedError, response);
+    return new DriveServerWipError('UNKNOWN', loggedError, response, error);
   }
 }

--- a/src/infra/drive-server-wip/services/files.service.test.ts
+++ b/src/infra/drive-server-wip/services/files.service.test.ts
@@ -7,11 +7,8 @@ import { files } from './files.service';
 
 vi.mock(import('../in/client-wrapper.service'));
 
-function getError({ status, message, cause = new Error('cause') }: { status: number; message: string; cause?: unknown }) {
-  const error = new DriveServerWipError('UNKNOWN', cause, new Response(undefined, { status }));
-  error.message = message;
-
-  return error;
+function getError({ status, apiError, cause = new Error('cause') }: { status: number; apiError: unknown; cause?: unknown }) {
+  return new DriveServerWipError('UNKNOWN', cause, new Response(undefined, { status }), apiError);
 }
 
 describe('files service', () => {
@@ -35,7 +32,7 @@ describe('files service', () => {
   it('should map bad request empty files amount errors to EMPTY_FILES_EXCEEDED', async () => {
     // Given
     clientWrapperMock.mockResolvedValue({
-      error: getError({ status: 400, message: 'You can not have more empty files', cause }),
+      error: getError({ status: 400, apiError: { error: 'EMPTY_FILES_EXCEEDED' }, cause }),
     });
 
     // When
@@ -51,7 +48,7 @@ describe('files service', () => {
     clientWrapperMock.mockResolvedValue({
       error: getError({
         status: 402,
-        message: 'You can not have empty files, upgrade your plan to get more features',
+        apiError: { error: 'EMPTY_FILES_NOT_ALLOWED' },
         cause,
       }),
     });
@@ -67,7 +64,7 @@ describe('files service', () => {
   it('should map payment required upload size errors to FILE_UPLOAD_SIZE_EXCEEDED', async () => {
     // Given
     clientWrapperMock.mockResolvedValue({
-      error: getError({ status: 402, message: 'Storage limit exceeded', cause }),
+      error: getError({ status: 402, apiError: { message: 'Storage limit exceeded' }, cause }),
     });
 
     // When

--- a/src/infra/drive-server-wip/services/files.service.ts
+++ b/src/infra/drive-server-wip/services/files.service.ts
@@ -8,6 +8,7 @@ import { clientWrapper } from '../in/client-wrapper.service';
 import { getRequestKey } from '../in/get-in-flight-request';
 import { parseFileDto } from '../out/dto';
 import { checkExistence } from './files/check-existence';
+import { classifyFileWriteError } from './files/classify-file-write-error';
 import { createFile } from './files/create-file';
 import { move } from './files/move';
 
@@ -88,13 +89,18 @@ async function replaceFile({
 
   if (data) {
     return { data: parseFileDto({ fileDto: data }) };
-  } else if (error?.response?.status === 400 && error.message.includes('You can not have more empty files')) {
+  } else if (error && classifyFileWriteError({ error }) === 'EMPTY_FILES_EXCEEDED') {
     return { error: new DriveServerWipError('EMPTY_FILES_EXCEEDED', error.cause) };
-  } else if (error?.response?.status === 402) {
-    if (error.message.includes('You can not have empty files')) {
+  } else if (error) {
+    const fileWriteError = classifyFileWriteError({ error });
+
+    if (fileWriteError === 'EMPTY_FILES_NOT_ALLOWED') {
       return { error: new DriveServerWipError('EMPTY_FILES_NOT_ALLOWED', error.cause) };
     }
-    return { error: new DriveServerWipError('FILE_UPLOAD_SIZE_EXCEEDED', error.cause, error.response) };
+    if (fileWriteError === 'FILE_UPLOAD_SIZE_EXCEEDED') {
+      return { error: new DriveServerWipError('FILE_UPLOAD_SIZE_EXCEEDED', error.cause, error.response) };
+    }
+    return { error };
   } else {
     return { error };
   }

--- a/src/infra/drive-server-wip/services/files/classify-file-write-error.ts
+++ b/src/infra/drive-server-wip/services/files/classify-file-write-error.ts
@@ -1,0 +1,31 @@
+import { DriveServerWipError } from '../../defs';
+
+type FileWriteErrorCode = 'EMPTY_FILES_NOT_ALLOWED' | 'EMPTY_FILES_EXCEEDED' | 'FILE_UPLOAD_SIZE_EXCEEDED';
+
+function getApiErrorDetails({ apiError }: DriveServerWipError) {
+  if (!apiError || typeof apiError !== 'object') return {};
+
+  const { error, message } = apiError as { error?: unknown; message?: unknown };
+
+  return {
+    code: typeof error === 'string' ? error : undefined,
+    message: typeof message === 'string' ? message : undefined,
+  };
+}
+
+export function classifyFileWriteError({ error }: { error: DriveServerWipError }): FileWriteErrorCode | undefined {
+  const { code, message = '' } = getApiErrorDetails(error);
+  const status = error.response?.status;
+
+  if (status === 400 && (code === 'EMPTY_FILES_EXCEEDED' || message.includes('You can not have more empty files'))) {
+    return 'EMPTY_FILES_EXCEEDED';
+  }
+
+  if (status === 402) {
+    if (code === 'EMPTY_FILES_NOT_ALLOWED' || message.includes('You can not have empty files')) {
+      return 'EMPTY_FILES_NOT_ALLOWED';
+    }
+
+    return 'FILE_UPLOAD_SIZE_EXCEEDED';
+  }
+}

--- a/src/infra/drive-server-wip/services/files/parse-create-file-response.infra.test.ts
+++ b/src/infra/drive-server-wip/services/files/parse-create-file-response.infra.test.ts
@@ -27,18 +27,15 @@ function getFileDto(): FileDto {
 
 function getErrorResponse({
   status,
-  message = 'Request failed',
+  apiError = { message: 'Request failed' },
   cause = new Error('cause'),
 }: {
   status?: number;
-  message?: string;
+  apiError?: unknown;
   cause?: unknown;
 }): Awaited<TResponse<FileDto>> {
   const response = status ? new Response(undefined, { status }) : undefined;
-  const error = new DriveServerWipError('UNKNOWN', cause, response);
-  if (message) {
-    error.message = message;
-  }
+  const error = new DriveServerWipError('UNKNOWN', cause, response, apiError);
 
   return { error };
 }
@@ -59,15 +56,15 @@ describe('parseCreateFileResponse', () => {
   });
 
   it.each([
-    { status: 404, message: 'Parent folder does not exist', expectedCode: 'PARENT_NOT_FOUND' },
-    { status: 409, message: 'File already exists', expectedCode: 'FILE_ALREADY_EXISTS' },
-    { status: 402, message: 'You can not have empty files', expectedCode: 'EMPTY_FILES_NOT_ALLOWED' },
-    { status: 400, message: 'You can not have more empty files', expectedCode: 'EMPTY_FILES_EXCEEDED' },
-    { status: 402, message: 'Storage limit exceeded', expectedCode: 'FILE_UPLOAD_SIZE_EXCEEDED' },
-  ])('maps $status "$message" errors to $expectedCode', ({ status, message, expectedCode }) => {
+    { status: 404, apiError: { message: 'Parent folder does not exist' }, expectedCode: 'PARENT_NOT_FOUND' },
+    { status: 409, apiError: { message: 'File already exists' }, expectedCode: 'FILE_ALREADY_EXISTS' },
+    { status: 402, apiError: { error: 'EMPTY_FILES_NOT_ALLOWED' }, expectedCode: 'EMPTY_FILES_NOT_ALLOWED' },
+    { status: 400, apiError: { error: 'EMPTY_FILES_EXCEEDED' }, expectedCode: 'EMPTY_FILES_EXCEEDED' },
+    { status: 402, apiError: { message: 'Storage limit exceeded' }, expectedCode: 'FILE_UPLOAD_SIZE_EXCEEDED' },
+  ])('maps $status API errors to $expectedCode', ({ status, apiError, expectedCode }) => {
     const cause = new Error('cause');
 
-    const response = getErrorResponse({ status, message, cause });
+    const response = getErrorResponse({ status, apiError, cause });
     const result = parseCreateFileResponse(response);
 
     expect(result.error?.code).toBe(expectedCode);
@@ -93,7 +90,7 @@ describe('parseCreateFileResponse', () => {
 
   it('should properly return error when no message is provided', () => {
     const cause = new Error('cause');
-    const response = getErrorResponse({ status: 402, message: undefined, cause });
+    const response = getErrorResponse({ status: 402, apiError: null, cause });
 
     const result = parseCreateFileResponse(response);
 

--- a/src/infra/drive-server-wip/services/files/parse-create-file-response.ts
+++ b/src/infra/drive-server-wip/services/files/parse-create-file-response.ts
@@ -1,10 +1,11 @@
 import { TResponse } from '../../in/client-wrapper.service';
 import { FileDto, parseFileDto } from '../../out/dto';
+import { classifyFileWriteError } from './classify-file-write-error';
 import { CreateFileError } from './create-file-error';
 
 export function parseCreateFileResponse(res: Awaited<TResponse<FileDto>>) {
   if (res.error) {
-    const errorMessage = res.error.message ?? '';
+    const fileWriteError = classifyFileWriteError({ error: res.error });
 
     switch (res.error.response?.status) {
       case 404:
@@ -12,15 +13,12 @@ export function parseCreateFileResponse(res: Awaited<TResponse<FileDto>>) {
       case 409:
         return { error: new CreateFileError('FILE_ALREADY_EXISTS', res.error.cause, res.error.response) };
       case 400:
-        if (errorMessage.includes('You can not have more empty files')) {
-          return { error: new CreateFileError('EMPTY_FILES_EXCEEDED', res.error.cause, res.error.response) };
+        if (fileWriteError === 'EMPTY_FILES_EXCEEDED') {
+          return { error: new CreateFileError(fileWriteError, res.error.cause, res.error.response) };
         }
         return { error: res.error };
       case 402:
-        if (errorMessage.includes('You can not have empty files')) {
-          return { error: new CreateFileError('EMPTY_FILES_NOT_ALLOWED', res.error.cause, res.error.response) };
-        }
-        return { error: new CreateFileError('FILE_UPLOAD_SIZE_EXCEEDED', res.error.cause, res.error.response) };
+        return { error: new CreateFileError(fileWriteError ?? 'FILE_UPLOAD_SIZE_EXCEEDED', res.error.cause, res.error.response) };
       default:
         return { error: res.error };
     }


### PR DESCRIPTION
## What is Changed / Added
The Drive API error payload is now preserved when an HTTP request fails, instead of relying on the internal error message generated by the client wrapper. File creation and replacement now use the API error code to distinguish empty files, the empty-file limit, and file-size rejections. Backend message matching remains as a fallback for compatibility.
The related tests now reflect the real API error payload rather than manually changing the internal error message.

---

## Why
Empty-file upload errors were being converted into generic 402 errors before they reached the file error parser. As a result, they were treated as file-size rejections and displayed the file-size modal. Empty-file restrictions now create the corresponding issue, while actual file-size rejections continue to show the file-size modal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File and folder metadata now preserves separate creation and modification timestamps during local storage, remote synchronization, and folder creation.
  * Existing records are populated with creation and modification times where available.
* **Bug Fixes**
  * Improved file-write error classification for clearer handling of empty-file and upload-size limits.
  * Remote change detection now uses modification timestamps consistently.
* **Documentation**
  * Added explanatory documentation for synchronization, persistence, and error-handling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->