### PR TITLE
fix: make upload retries actually work (BR-2306)

### DIFF
--- a/src/infra/inxt-js/file-uploader/constants.ts
+++ b/src/infra/inxt-js/file-uploader/constants.ts
@@ -1,3 +1,2 @@
-export const UPLOAD_MAX_RETRIES = 5;
 export const UPLOAD_INITIAL_SLEEP_MS = 5_000;
 export const UPLOAD_MAX_SLEEP_MS = 60_000;

--- a/src/infra/inxt-js/file-uploader/constants.ts
+++ b/src/infra/inxt-js/file-uploader/constants.ts
@@ -1,0 +1,3 @@
+export const UPLOAD_MAX_RETRIES = 5;
+export const UPLOAD_INITIAL_SLEEP_MS = 5_000;
+export const UPLOAD_MAX_SLEEP_MS = 60_000;

--- a/src/infra/inxt-js/file-uploader/environment-file-uploader.test.ts
+++ b/src/infra/inxt-js/file-uploader/environment-file-uploader.test.ts
@@ -1,25 +1,18 @@
-import { createReadStream, ReadStream } from 'node:fs';
 import { mockDeep } from 'vitest-mock-extended';
 import { LocalSync } from '@/backend/features';
 import { call, calls, mockProps, partialSpyOn } from '@/tests/vitest/utils.helper.test';
 import { environmentFileUpload } from './environment-file-uploader';
 import * as uploadFile from './upload-file';
 
-vi.mock(import('node:fs'));
-
 describe('environment-file-upload', () => {
-  const createReadStreamMock = vi.mocked(createReadStream);
   const uploadFileMock = partialSpyOn(uploadFile, 'uploadFile');
   const addItemMock = partialSpyOn(LocalSync.SyncState, 'addItem');
 
-  const readable = mockDeep<ReadStream>();
   const abortController = mockDeep<AbortController>();
 
   let props: Parameters<typeof environmentFileUpload>[0];
 
   beforeEach(() => {
-    createReadStreamMock.mockReturnValue(readable);
-
     props = mockProps<typeof environmentFileUpload>({
       ctx: { abortController },
     });
@@ -29,10 +22,18 @@ describe('environment-file-upload', () => {
     // When
     await environmentFileUpload(props);
     // Then
-    calls(readable.close).toHaveLength(1);
     calls(uploadFileMock).toHaveLength(1);
     call(addItemMock).toMatchObject({ action: 'UPLOADING', progress: 0 });
     call(abortController.signal.addEventListener).toStrictEqual(['abort', expect.any(Function)]);
+    call(abortController.signal.removeEventListener).toStrictEqual(['abort', expect.any(Function)]);
+  });
+
+  it('should remove abort listener even if the upload throws', async () => {
+    // Given
+    uploadFileMock.mockRejectedValue(new Error('boom'));
+    // When
+    await expect(environmentFileUpload(props)).rejects.toThrow('boom');
+    // Then
     call(abortController.signal.removeEventListener).toStrictEqual(['abort', expect.any(Function)]);
   });
 });

--- a/src/infra/inxt-js/file-uploader/environment-file-uploader.ts
+++ b/src/infra/inxt-js/file-uploader/environment-file-uploader.ts
@@ -1,4 +1,3 @@
-import { createReadStream } from 'node:fs';
 import { CommonContext } from '@/apps/sync-engine/config';
 import { LocalSync } from '@/backend/features';
 import { AbsolutePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
@@ -22,11 +21,9 @@ export async function environmentFileUpload({ ctx, path, size }: TProps) {
 
   LocalSync.SyncState.addItem({ action: 'UPLOADING', path, progress: 0 });
 
-  const readable = createReadStream(path);
-  const contentsId = await uploadFile({ ctx, readable, size, path, abortController });
-
-  readable.close();
-  ctx.abortController.signal.removeEventListener('abort', onAbort);
-
-  return contentsId;
+  try {
+    return await uploadFile({ ctx, size, path, abortController });
+  } finally {
+    ctx.abortController.signal.removeEventListener('abort', onAbort);
+  }
 }

--- a/src/infra/inxt-js/file-uploader/process-error.test.ts
+++ b/src/infra/inxt-js/file-uploader/process-error.test.ts
@@ -36,15 +36,29 @@ describe('process-error', () => {
     call(addGeneralIssueMock).toMatchObject({ error: 'NOT_ENOUGH_SPACE' });
   });
 
-  it('should retry in case of server unavailable', async () => {
+  it.each([
+    'read ECONNRESET',
+    'Request failed with status code 409',
+    'Request failed with status code 500',
+    'Request failed with status code 502',
+  ])('should retry in case of server unavailable', async (message) => {
     // Given
-    props.error = new Error('Request failed with status code 409');
+    props.error = new Error(message);
     // When
     await processError(props);
     // Then
     call(addGeneralIssueMock).toMatchObject({ error: 'NETWORK_CONNECTIVITY_ERROR' });
     call(sleepMock).toStrictEqual(sleepMs);
     calls(retryFn).toHaveLength(1);
+  });
+
+  it('should not retry an error that is not retryable', async () => {
+    // Given
+    props.error = new Error('Request failed with status code 404');
+    // When
+    await processError(props);
+    // Then
+    calls(retryFn).toHaveLength(0);
   });
 
   it('should handle unknown error', async () => {

--- a/src/infra/inxt-js/file-uploader/process-error.test.ts
+++ b/src/infra/inxt-js/file-uploader/process-error.test.ts
@@ -3,7 +3,6 @@ import * as sleep from '@/apps/main/util';
 import { LocalSync } from '@/backend/features';
 import { loggerMock } from '@/tests/vitest/mocks.helper.test';
 import { call, calls, mockProps, partialSpyOn } from '@/tests/vitest/utils.helper.test';
-import { UPLOAD_MAX_RETRIES } from './constants';
 import { processError } from './process-error';
 
 describe('process-error', () => {
@@ -16,7 +15,7 @@ describe('process-error', () => {
   let props: Parameters<typeof processError>[0];
 
   beforeEach(() => {
-    props = mockProps<typeof processError>({ retryFn, sleepMs, retry: 1 });
+    props = mockProps<typeof processError>({ retryFn, sleepMs });
   });
 
   it('should not do anything if aborted', async () => {
@@ -46,19 +45,6 @@ describe('process-error', () => {
     call(addGeneralIssueMock).toMatchObject({ error: 'NETWORK_CONNECTIVITY_ERROR' });
     call(sleepMock).toStrictEqual(sleepMs);
     calls(retryFn).toHaveLength(1);
-  });
-
-  it('should stop retrying once max retries is reached', async () => {
-    // Given
-    props.error = new Error('Request failed with status code 500');
-    props.retry = UPLOAD_MAX_RETRIES;
-    // When
-    await processError(props);
-    // Then
-    call(addGeneralIssueMock).toMatchObject({ error: 'NETWORK_CONNECTIVITY_ERROR' });
-    calls(sleepMock).toHaveLength(0);
-    calls(retryFn).toHaveLength(0);
-    call(loggerMock.warn).toMatchObject({ msg: 'Giving up uploading file to the bucket after max retries' });
   });
 
   it('should handle unknown error', async () => {

--- a/src/infra/inxt-js/file-uploader/process-error.test.ts
+++ b/src/infra/inxt-js/file-uploader/process-error.test.ts
@@ -3,6 +3,7 @@ import * as sleep from '@/apps/main/util';
 import { LocalSync } from '@/backend/features';
 import { loggerMock } from '@/tests/vitest/mocks.helper.test';
 import { call, calls, mockProps, partialSpyOn } from '@/tests/vitest/utils.helper.test';
+import { UPLOAD_MAX_RETRIES } from './constants';
 import { processError } from './process-error';
 
 describe('process-error', () => {
@@ -15,7 +16,7 @@ describe('process-error', () => {
   let props: Parameters<typeof processError>[0];
 
   beforeEach(() => {
-    props = mockProps<typeof processError>({ retryFn, sleepMs });
+    props = mockProps<typeof processError>({ retryFn, sleepMs, retry: 1 });
   });
 
   it('should not do anything if aborted', async () => {
@@ -45,6 +46,19 @@ describe('process-error', () => {
     call(addGeneralIssueMock).toMatchObject({ error: 'NETWORK_CONNECTIVITY_ERROR' });
     call(sleepMock).toStrictEqual(sleepMs);
     calls(retryFn).toHaveLength(1);
+  });
+
+  it('should stop retrying once max retries is reached', async () => {
+    // Given
+    props.error = new Error('Request failed with status code 500');
+    props.retry = UPLOAD_MAX_RETRIES;
+    // When
+    await processError(props);
+    // Then
+    call(addGeneralIssueMock).toMatchObject({ error: 'NETWORK_CONNECTIVITY_ERROR' });
+    calls(sleepMock).toHaveLength(0);
+    calls(retryFn).toHaveLength(0);
+    call(loggerMock.warn).toMatchObject({ msg: 'Giving up uploading file to the bucket after max retries' });
   });
 
   it('should handle unknown error', async () => {

--- a/src/infra/inxt-js/file-uploader/process-error.ts
+++ b/src/infra/inxt-js/file-uploader/process-error.ts
@@ -5,17 +5,21 @@ import { sleep } from '@/apps/main/util';
 import { CommonContext } from '@/apps/sync-engine/config';
 import { LocalSync } from '@/backend/features';
 import { isAbortError } from '@/infra/drive-server-wip/in/helpers/error-helpers';
+import { UPLOAD_MAX_RETRIES } from './constants';
+
+const RETRYABLE_MESSAGES = ['read ECONNRESET', 'Request failed with status code 409', 'Request failed with status code 500'];
 
 type TProps = {
   ctx: CommonContext;
   path: AbsolutePath;
   size: number;
   error: unknown;
+  retry: number;
   sleepMs: number;
   retryFn: () => Promise<ContentsId | undefined>;
 };
 
-export async function processError({ ctx, path, error, sleepMs, size, retryFn }: TProps) {
+export async function processError({ ctx, path, error, retry, sleepMs, size, retryFn }: TProps) {
   if (isAbortError({ error })) return;
 
   ctx.logger.sentryError({ msg: 'Failed to upload file to the bucket', path, error }, { size });
@@ -23,12 +27,14 @@ export async function processError({ ctx, path, error, sleepMs, size, retryFn }:
 
   if (!(error instanceof Error)) return;
 
-  if (
-    error.message === 'read ECONNRESET' ||
-    error.message === 'Request failed with status code 409' ||
-    error.message === 'Request failed with status code 500'
-  ) {
+  if (RETRYABLE_MESSAGES.includes(error.message)) {
     addGeneralIssue({ error: 'NETWORK_CONNECTIVITY_ERROR', name: path });
+
+    if (retry >= UPLOAD_MAX_RETRIES) {
+      ctx.logger.warn({ msg: 'Giving up uploading file to the bucket after max retries', path, retry });
+      return;
+    }
+
     await sleep(sleepMs);
     return retryFn();
   }

--- a/src/infra/inxt-js/file-uploader/process-error.ts
+++ b/src/infra/inxt-js/file-uploader/process-error.ts
@@ -5,7 +5,6 @@ import { sleep } from '@/apps/main/util';
 import { CommonContext } from '@/apps/sync-engine/config';
 import { LocalSync } from '@/backend/features';
 import { isAbortError } from '@/infra/drive-server-wip/in/helpers/error-helpers';
-import { UPLOAD_MAX_RETRIES } from './constants';
 
 const RETRYABLE_MESSAGES = ['read ECONNRESET', 'Request failed with status code 409', 'Request failed with status code 500'];
 
@@ -14,12 +13,11 @@ type TProps = {
   path: AbsolutePath;
   size: number;
   error: unknown;
-  retry: number;
   sleepMs: number;
   retryFn: () => Promise<ContentsId | undefined>;
 };
 
-export async function processError({ ctx, path, error, retry, sleepMs, size, retryFn }: TProps) {
+export async function processError({ ctx, path, error, sleepMs, size, retryFn }: TProps) {
   if (isAbortError({ error })) return;
 
   ctx.logger.sentryError({ msg: 'Failed to upload file to the bucket', path, error }, { size });
@@ -29,11 +27,6 @@ export async function processError({ ctx, path, error, retry, sleepMs, size, ret
 
   if (RETRYABLE_MESSAGES.includes(error.message)) {
     addGeneralIssue({ error: 'NETWORK_CONNECTIVITY_ERROR', name: path });
-
-    if (retry >= UPLOAD_MAX_RETRIES) {
-      ctx.logger.warn({ msg: 'Giving up uploading file to the bucket after max retries', path, retry });
-      return;
-    }
 
     await sleep(sleepMs);
     return retryFn();

--- a/src/infra/inxt-js/file-uploader/process-error.ts
+++ b/src/infra/inxt-js/file-uploader/process-error.ts
@@ -6,7 +6,12 @@ import { CommonContext } from '@/apps/sync-engine/config';
 import { LocalSync } from '@/backend/features';
 import { isAbortError } from '@/infra/drive-server-wip/in/helpers/error-helpers';
 
-const RETRYABLE_MESSAGES = ['read ECONNRESET', 'Request failed with status code 409', 'Request failed with status code 500'];
+const RETRYABLE_MESSAGES = new Set([
+  'read ECONNRESET',
+  'Request failed with status code 409',
+  'Request failed with status code 500',
+  'Request failed with status code 502',
+]);
 
 type TProps = {
   ctx: CommonContext;
@@ -25,7 +30,7 @@ export async function processError({ ctx, path, error, sleepMs, size, retryFn }:
 
   if (!(error instanceof Error)) return;
 
-  if (RETRYABLE_MESSAGES.includes(error.message)) {
+  if (RETRYABLE_MESSAGES.has(error.message)) {
     addGeneralIssue({ error: 'NETWORK_CONNECTIVITY_ERROR', name: path });
 
     await sleep(sleepMs);

--- a/src/infra/inxt-js/file-uploader/upload-file.test.ts
+++ b/src/infra/inxt-js/file-uploader/upload-file.test.ts
@@ -1,5 +1,5 @@
 import { Environment } from '@internxt/inxt-js';
-import { ReadStream } from 'node:fs';
+import { createReadStream, ReadStream } from 'node:fs';
 import { mockDeep } from 'vitest-mock-extended';
 import { LocalSync } from '@/backend/features';
 import { fileSystem } from '@/infra/file-system/file-system.module';
@@ -8,7 +8,10 @@ import { call, calls, mockProps, partialSpyOn } from '@/tests/vitest/utils.helpe
 import * as processError from './process-error';
 import { uploadFile } from './upload-file';
 
+vi.mock(import('node:fs'));
+
 describe('upload-file', () => {
+  const createReadStreamMock = vi.mocked(createReadStream);
   const processErrorMock = partialSpyOn(processError, 'processError');
   const addItemMock = partialSpyOn(LocalSync.SyncState, 'addItem');
   const statMock = partialSpyOn(fileSystem, 'stat');
@@ -21,12 +24,12 @@ describe('upload-file', () => {
 
   beforeEach(() => {
     statMock.mockResolvedValue({ data: { size: 10 } });
+    createReadStreamMock.mockReturnValue(readable);
 
     abortController = new AbortController();
     props = mockProps<typeof uploadFile>({
       ctx: { environment },
       abortController,
-      readable,
       size: 10,
     });
   });
@@ -63,7 +66,7 @@ describe('upload-file', () => {
     const res = await uploadFile(props);
     // Then
     expect(res).toBeUndefined();
-    call(processErrorMock).toMatchObject({ sleepMs: 5000 });
+    call(processErrorMock).toMatchObject({ retry: 1, sleepMs: 5000 });
     calls(addItemMock).toHaveLength(0);
   });
 
@@ -80,5 +83,52 @@ describe('upload-file', () => {
     expect(res).toBeUndefined();
     calls(addItemMock).toHaveLength(0);
     calls(loggerMock.debug).toMatchObject([{ msg: 'Uploading file to the bucket' }, { msg: 'File size changed during upload' }]);
+  });
+
+  it('should open and close a stream on every attempt', async () => {
+    // Given
+    environment.upload.mockResolvedValue('contentsId');
+    // When
+    await uploadFile(props);
+    // Then
+    calls(createReadStreamMock).toHaveLength(1);
+    calls(readable.close).toHaveLength(1);
+  });
+
+  it('should close the stream when the upload fails', async () => {
+    // Given
+    environment.upload.mockRejectedValue(new Error());
+    // When
+    await uploadFile(props);
+    // Then
+    calls(readable.close).toHaveLength(1);
+  });
+
+  it('should give the retry a fresh stream and a doubled sleep', async () => {
+    // Given
+    environment.upload.mockRejectedValue(new Error());
+    processErrorMock.mockImplementationOnce(async ({ retryFn }) => await retryFn());
+    // When
+    await uploadFile({ ...props, retry: 1, sleepMs: 5000 });
+    // Then
+    calls(createReadStreamMock).toHaveLength(2);
+    calls(readable.close).toHaveLength(2);
+    calls(processErrorMock).toMatchObject([
+      { retry: 1, sleepMs: 5000 },
+      { retry: 2, sleepMs: 10000 },
+    ]);
+  });
+
+  it('should cap the sleep between retries', async () => {
+    // Given
+    environment.upload.mockRejectedValue(new Error());
+    processErrorMock.mockImplementationOnce(async ({ retryFn }) => await retryFn());
+    // When
+    await uploadFile({ ...props, retry: 1, sleepMs: 40000 });
+    // Then
+    calls(processErrorMock).toMatchObject([
+      { retry: 1, sleepMs: 40000 },
+      { retry: 2, sleepMs: 60000 },
+    ]);
   });
 });

--- a/src/infra/inxt-js/file-uploader/upload-file.test.ts
+++ b/src/infra/inxt-js/file-uploader/upload-file.test.ts
@@ -104,6 +104,20 @@ describe('upload-file', () => {
     calls(readable.close).toHaveLength(1);
   });
 
+  it('should close the failed stream before starting the retry', async () => {
+    // Given
+    environment.upload.mockRejectedValue(new Error());
+    let closedWhenRetryStarted = 0;
+    processErrorMock.mockImplementationOnce(async ({ retryFn }) => {
+      closedWhenRetryStarted = readable.close.mock.calls.length;
+      return await retryFn();
+    });
+    // When
+    await uploadFile({ ...props, retry: 1, sleepMs: 5000 });
+    // Then
+    expect(closedWhenRetryStarted).toBe(1);
+  });
+
   it('should give the retry a fresh stream and a doubled sleep', async () => {
     // Given
     environment.upload.mockRejectedValue(new Error());

--- a/src/infra/inxt-js/file-uploader/upload-file.test.ts
+++ b/src/infra/inxt-js/file-uploader/upload-file.test.ts
@@ -66,7 +66,7 @@ describe('upload-file', () => {
     const res = await uploadFile(props);
     // Then
     expect(res).toBeUndefined();
-    call(processErrorMock).toMatchObject({ retry: 1, sleepMs: 5000 });
+    call(processErrorMock).toMatchObject({ sleepMs: 5000 });
     calls(addItemMock).toHaveLength(0);
   });
 
@@ -127,10 +127,7 @@ describe('upload-file', () => {
     // Then
     calls(createReadStreamMock).toHaveLength(2);
     calls(readable.close).toHaveLength(2);
-    calls(processErrorMock).toMatchObject([
-      { retry: 1, sleepMs: 5000 },
-      { retry: 2, sleepMs: 10000 },
-    ]);
+    calls(processErrorMock).toMatchObject([{ sleepMs: 5000 }, { sleepMs: 10000 }]);
   });
 
   it('should cap the sleep between retries', async () => {
@@ -140,9 +137,6 @@ describe('upload-file', () => {
     // When
     await uploadFile({ ...props, retry: 1, sleepMs: 40000 });
     // Then
-    calls(processErrorMock).toMatchObject([
-      { retry: 1, sleepMs: 40000 },
-      { retry: 2, sleepMs: 60000 },
-    ]);
+    calls(processErrorMock).toMatchObject([{ sleepMs: 40000 }, { sleepMs: 60000 }]);
   });
 });

--- a/src/infra/inxt-js/file-uploader/upload-file.ts
+++ b/src/infra/inxt-js/file-uploader/upload-file.ts
@@ -1,14 +1,14 @@
-import { ReadStream } from 'node:fs';
+import { createReadStream } from 'node:fs';
 import { ContentsId } from '@/apps/main/database/entities/DriveFile';
 import { CommonContext } from '@/apps/sync-engine/config';
 import { LocalSync } from '@/backend/features';
 import { AbsolutePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
 import { fileSystem } from '@/infra/file-system/file-system.module';
+import { UPLOAD_INITIAL_SLEEP_MS, UPLOAD_MAX_SLEEP_MS } from './constants';
 import { processError } from './process-error';
 
 type Props = {
   ctx: CommonContext;
-  readable: ReadStream;
   size: number;
   path: AbsolutePath;
   abortController: AbortController;
@@ -16,7 +16,14 @@ type Props = {
   sleepMs?: number;
 };
 
-export async function uploadFile({ ctx, readable, size, path, abortController, retry = 1, sleepMs = 5000 }: Props) {
+export async function uploadFile({
+  ctx,
+  size,
+  path,
+  abortController,
+  retry = 1,
+  sleepMs = UPLOAD_INITIAL_SLEEP_MS,
+}: Props): Promise<ContentsId | undefined> {
   ctx.logger.debug({
     msg: 'Uploading file to the bucket',
     path,
@@ -37,6 +44,12 @@ export async function uploadFile({ ctx, readable, size, path, abortController, r
     LocalSync.SyncState.addItem({ action: 'UPLOADING', path, progress });
   }
 
+  /**
+   * A stream that a failed attempt already consumed cannot be replayed, so every
+   * attempt opens its own and closes it before returning.
+   */
+  const readable = createReadStream(path);
+
   try {
     const contentsId = await ctx.environment.upload(ctx.bucket, {
       source: readable,
@@ -50,14 +63,15 @@ export async function uploadFile({ ctx, readable, size, path, abortController, r
     const retryFn = () =>
       uploadFile({
         ctx,
-        readable,
         size,
         path,
         abortController,
         retry: retry + 1,
-        sleepMs: sleepMs * 2,
+        sleepMs: Math.min(sleepMs * 2, UPLOAD_MAX_SLEEP_MS),
       });
 
-    return processError({ ctx, path, size, error, sleepMs, retryFn });
+    return processError({ ctx, path, size, error, retry, sleepMs, retryFn });
+  } finally {
+    readable.close();
   }
 }

--- a/src/infra/inxt-js/file-uploader/upload-file.ts
+++ b/src/infra/inxt-js/file-uploader/upload-file.ts
@@ -44,10 +44,6 @@ export async function uploadFile({
     LocalSync.SyncState.addItem({ action: 'UPLOADING', path, progress });
   }
 
-  /**
-   * A stream that a failed attempt already consumed cannot be replayed, so every
-   * attempt opens its own and closes it before returning.
-   */
   const readable = createReadStream(path);
   let uploadError: unknown;
 
@@ -66,11 +62,6 @@ export async function uploadFile({
     readable.close();
   }
 
-  /**
-   * processError awaits the whole retry chain, so it has to run outside the try
-   * block: otherwise this attempt's stream would stay open for every later
-   * attempt and its backoff, holding one descriptor per nested retry.
-   */
   const retryFn = () =>
     uploadFile({
       ctx,
@@ -81,5 +72,5 @@ export async function uploadFile({
       sleepMs: Math.min(sleepMs * 2, UPLOAD_MAX_SLEEP_MS),
     });
 
-  return processError({ ctx, path, size, error: uploadError, retry, sleepMs, retryFn });
+  return processError({ ctx, path, size, error: uploadError, sleepMs, retryFn });
 }

--- a/src/infra/inxt-js/file-uploader/upload-file.ts
+++ b/src/infra/inxt-js/file-uploader/upload-file.ts
@@ -49,6 +49,7 @@ export async function uploadFile({
    * attempt opens its own and closes it before returning.
    */
   const readable = createReadStream(path);
+  let uploadError: unknown;
 
   try {
     const contentsId = await ctx.environment.upload(ctx.bucket, {
@@ -60,18 +61,25 @@ export async function uploadFile({
 
     return contentsId as ContentsId;
   } catch (error) {
-    const retryFn = () =>
-      uploadFile({
-        ctx,
-        size,
-        path,
-        abortController,
-        retry: retry + 1,
-        sleepMs: Math.min(sleepMs * 2, UPLOAD_MAX_SLEEP_MS),
-      });
-
-    return processError({ ctx, path, size, error, retry, sleepMs, retryFn });
+    uploadError = error;
   } finally {
     readable.close();
   }
+
+  /**
+   * processError awaits the whole retry chain, so it has to run outside the try
+   * block: otherwise this attempt's stream would stay open for every later
+   * attempt and its backoff, holding one descriptor per nested retry.
+   */
+  const retryFn = () =>
+    uploadFile({
+      ctx,
+      size,
+      path,
+      abortController,
+      retry: retry + 1,
+      sleepMs: Math.min(sleepMs * 2, UPLOAD_MAX_SLEEP_MS),
+    });
+
+  return processError({ ctx, path, size, error: uploadError, retry, sleepMs, retryFn });
 }


### PR DESCRIPTION
## What is Changed / Added

- Each upload attempt opens its own `ReadStream` and closes it in a `finally` (this also fixes the descriptor leaking on the error path)
- `readable` removed from `uploadFile`'s props, so a stream can no longer be reused from outside
- `processError` runs outside the `try`, so the failed attempt's stream is closed before the retry starts instead of staying open for every nested attempt and its backoff
- Backoff is capped at 60s (`constants.ts`), so a long outage settles into one attempt per minute instead of growing without bound

Retries themselves stay unbounded, as agreed: these errors are transient on the bridge side, and the file should keep being retried until the upload goes through rather than being dropped.

---

## Why

An upload failing with a retryable error (`500`, `409`, `ECONNRESET`) permanently stalled the entire upload scan. Reproduced on `main`: **531 of 326,431 files uploaded, then nothing**, with the app idle and reporting `SYNCED`.

The root cause is that **the retry could never succeed**. `environmentFileUpload` created the `ReadStream` once and passed it down, so every retry inside `uploadFile` reused a stream the failed attempt had already drained. This has been the case since retries were introduced in #1303 (March), so the retry has never worked.

Because it always failed, it always escalated: `sleepMs` doubled with nothing stopping it. Measured escalation in the repro: 5s → 10s → 20s → 40s → … → **21 minutes**, still climbing.

And since `createPendingFiles` awaits every file in a folder before `traverseDepthFirst` advances, a promise that never settles halts the whole traversal. The remaining ~328,000 files were never attempted.

With the stream fixed, a transient failure now resolves on the next attempt and the traversal keeps moving.

## Verification

Beyond unit tests, this was verified against the customer's actual tree from BR-2306 (156,523 folders / 329,156 files, rebuilt from the `file-explorer.csv` attached to the ticket):

- **Real `ECONNRESET` against production**: failed, retried after 5s, **uploaded**. No escalation. Under the previous code that retry could not have succeeded.
- **Stub forcing a 500 on every `/files/finish`**: 396 consecutive files, retries escalating 5s → 10s → 20s → 40s with the stream correctly closed between attempts and no descriptor accumulation.

## Not in scope

The retryable list itself is unchanged and remains too narrow. In the customer's logs only **0.7% of upload failures** are retried today:

| Error | Occurrences | Retried |
|---|---|---|
| `ENOTFOUND` | 74,796 | no |
| `UND_ERR_CONNECT_TIMEOUT` | 8,828 | no |
| `ETIMEDOUT` | 7,462 | no |
| `ECONNRESET` | 538 | yes |
| `socket hang up` | 26 | no |
| HTTP 502 | 72 | no |
| HTTP 500 | 60 | yes |

Note that `socket hang up` is the same underlying `ECONNRESET` we already retry — it only escapes because the message text differs. Transport errors cannot be added to a message list at all: their text embeds the resolved host and IPs, so it is never constant. Matching would have to move to `error.code`.

`ENOTFOUND` (81% of the customer's failures) means the machine could not resolve our host at all, and probably warrants pausing sync rather than a per-file retry.

**BR-2306 is not fully resolved by this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file upload reliability by creating a fresh upload stream for each attempt and ensuring resources are cleaned up.
  * Abort handling is now reliably removed after both successful and failed uploads.
  * Upload retries now cover common connection and server errors, while non-retryable errors such as 404 responses fail immediately.
  * Retry delays increase between attempts and are capped at 60 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->