### PR TITLE
fix: remove orphan sync roots that Windows no longer resolves (BR-2314)

### DIFF
--- a/src/apps/main/background-processes/sync-engine/services/unregister-virtual-drives.test.ts
+++ b/src/apps/main/background-processes/sync-engine/services/unregister-virtual-drives.test.ts
@@ -1,15 +1,19 @@
-import { call, mockProps, partialSpyOn } from 'tests/vitest/utils.helper.test';
+import { call, calls, mockProps, partialSpyOn } from 'tests/vitest/utils.helper.test';
+import { WindowsRegistry } from '@/infra/windows-registry/windows-registry.module';
 import { Addon } from '@/node-win/addon-wrapper';
 import { unregisterVirtualDrives } from './unregister-virtual-drives';
 
 describe('unregister-virtual-drives', () => {
   const getRegisteredSyncRootsMock = partialSpyOn(Addon, 'getRegisteredSyncRoots');
   const unregisterSyncRootMock = partialSpyOn(Addon, 'unregisterSyncRoot');
+  const getSyncRootRegistrationsMock = partialSpyOn(WindowsRegistry, 'getSyncRootRegistrations');
+  const removeSyncRootRegistrationMock = partialSpyOn(WindowsRegistry, 'removeSyncRootRegistration');
 
   let props: Parameters<typeof unregisterVirtualDrives>[0];
 
   beforeEach(() => {
     getRegisteredSyncRootsMock.mockReturnValue([{ id: '{PROVIDER_ID}', displayName: 'Internxt' }]);
+    getSyncRootRegistrationsMock.mockResolvedValue([]);
     props = mockProps<typeof unregisterVirtualDrives>({ currentProviderIds: ['{PROVIDER_ID}'] });
   });
 
@@ -63,5 +67,72 @@ describe('unregister-virtual-drives', () => {
     await unregisterVirtualDrives(props);
     // Then
     expect(unregisterSyncRootMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('should remove a registration that the addon does not report', async () => {
+    // Given
+    const registration = { id: 'syncRootID', displayName: 'Internxt', namespaceClsid: '{CLSID}', hasUserSyncRoots: false };
+    getSyncRootRegistrationsMock.mockResolvedValue([registration]);
+    // When
+    await unregisterVirtualDrives(props);
+    // Then
+    call(removeSyncRootRegistrationMock).toStrictEqual({ registration });
+    expect(unregisterSyncRootMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not remove a registration that the addon still reports', async () => {
+    // Given
+    getSyncRootRegistrationsMock.mockResolvedValue([
+      { id: '{PROVIDER_ID}', displayName: 'Internxt', namespaceClsid: '{CLSID}', hasUserSyncRoots: false },
+    ]);
+    // When
+    await unregisterVirtualDrives(props);
+    // Then
+    calls(removeSyncRootRegistrationMock).toHaveLength(0);
+  });
+
+  it('should not remove a registration that is a current provider id', async () => {
+    // Given
+    getRegisteredSyncRootsMock.mockReturnValue([]);
+    getSyncRootRegistrationsMock.mockResolvedValue([
+      { id: '{PROVIDER_ID}', displayName: 'Internxt', namespaceClsid: '{CLSID}', hasUserSyncRoots: false },
+    ]);
+    // When
+    await unregisterVirtualDrives(props);
+    // Then
+    calls(removeSyncRootRegistrationMock).toHaveLength(0);
+  });
+
+  it('should not remove a registration from another provider', async () => {
+    // Given
+    getSyncRootRegistrationsMock.mockResolvedValue([
+      { id: 'OneDrive!S-1-5-21!Personal', displayName: 'OneDrive', namespaceClsid: '{CLSID}', hasUserSyncRoots: true },
+    ]);
+    // When
+    await unregisterVirtualDrives(props);
+    // Then
+    calls(removeSyncRootRegistrationMock).toHaveLength(0);
+  });
+
+  it('should not remove a registration that belongs to another windows user', async () => {
+    // Given
+    getSyncRootRegistrationsMock.mockResolvedValue([
+      { id: '{OTHER_WINDOWS_USER}', displayName: 'Internxt Drive', namespaceClsid: '{CLSID}', hasUserSyncRoots: true },
+    ]);
+    // When
+    await unregisterVirtualDrives(props);
+    // Then
+    calls(removeSyncRootRegistrationMock).toHaveLength(0);
+  });
+
+  it('should not remove a registration without a display name', async () => {
+    // Given
+    getSyncRootRegistrationsMock.mockResolvedValue([
+      { id: '9ba145d2-bd67-4f31-a221-bf820027862d', displayName: '', namespaceClsid: '', hasUserSyncRoots: false },
+    ]);
+    // When
+    await unregisterVirtualDrives(props);
+    // Then
+    calls(removeSyncRootRegistrationMock).toHaveLength(0);
   });
 });

--- a/src/apps/main/background-processes/sync-engine/services/unregister-virtual-drives.test.ts
+++ b/src/apps/main/background-processes/sync-engine/services/unregister-virtual-drives.test.ts
@@ -71,7 +71,13 @@ describe('unregister-virtual-drives', () => {
 
   it('should remove a registration that the addon does not report', async () => {
     // Given
-    const registration = { id: 'syncRootID', displayName: 'Internxt', namespaceClsid: '{CLSID}', hasUserSyncRoots: false };
+    const registration = {
+      id: 'syncRootID',
+      displayName: 'Internxt',
+      namespaceClsid: '{CLSID}',
+      targetFolderPath: '',
+      hasUserSyncRoots: false,
+    };
     getSyncRootRegistrationsMock.mockResolvedValue([registration]);
     // When
     await unregisterVirtualDrives(props);
@@ -83,7 +89,7 @@ describe('unregister-virtual-drives', () => {
   it('should not remove a registration that the addon still reports', async () => {
     // Given
     getSyncRootRegistrationsMock.mockResolvedValue([
-      { id: '{PROVIDER_ID}', displayName: 'Internxt', namespaceClsid: '{CLSID}', hasUserSyncRoots: false },
+      { id: '{PROVIDER_ID}', displayName: 'Internxt', namespaceClsid: '{CLSID}', targetFolderPath: '', hasUserSyncRoots: false },
     ]);
     // When
     await unregisterVirtualDrives(props);
@@ -95,7 +101,7 @@ describe('unregister-virtual-drives', () => {
     // Given
     getRegisteredSyncRootsMock.mockReturnValue([]);
     getSyncRootRegistrationsMock.mockResolvedValue([
-      { id: '{PROVIDER_ID}', displayName: 'Internxt', namespaceClsid: '{CLSID}', hasUserSyncRoots: false },
+      { id: '{PROVIDER_ID}', displayName: 'Internxt', namespaceClsid: '{CLSID}', targetFolderPath: '', hasUserSyncRoots: false },
     ]);
     // When
     await unregisterVirtualDrives(props);
@@ -106,7 +112,13 @@ describe('unregister-virtual-drives', () => {
   it('should not remove a registration from another provider', async () => {
     // Given
     getSyncRootRegistrationsMock.mockResolvedValue([
-      { id: 'OneDrive!S-1-5-21!Personal', displayName: 'OneDrive', namespaceClsid: '{CLSID}', hasUserSyncRoots: true },
+      {
+        id: 'OneDrive!S-1-5-21!Personal',
+        displayName: 'OneDrive',
+        namespaceClsid: '{CLSID}',
+        targetFolderPath: '',
+        hasUserSyncRoots: true,
+      },
     ]);
     // When
     await unregisterVirtualDrives(props);
@@ -117,7 +129,13 @@ describe('unregister-virtual-drives', () => {
   it('should not remove a registration that belongs to another windows user', async () => {
     // Given
     getSyncRootRegistrationsMock.mockResolvedValue([
-      { id: '{OTHER_WINDOWS_USER}', displayName: 'Internxt Drive', namespaceClsid: '{CLSID}', hasUserSyncRoots: true },
+      {
+        id: '{OTHER_WINDOWS_USER}',
+        displayName: 'Internxt Drive',
+        namespaceClsid: '{CLSID}',
+        targetFolderPath: '',
+        hasUserSyncRoots: true,
+      },
     ]);
     // When
     await unregisterVirtualDrives(props);
@@ -125,10 +143,43 @@ describe('unregister-virtual-drives', () => {
     calls(removeSyncRootRegistrationMock).toHaveLength(0);
   });
 
-  it('should not remove a registration without a display name', async () => {
+  it('should not remove a registration without a display name and without a target folder path', async () => {
     // Given
     getSyncRootRegistrationsMock.mockResolvedValue([
-      { id: '9ba145d2-bd67-4f31-a221-bf820027862d', displayName: '', namespaceClsid: '', hasUserSyncRoots: false },
+      { id: '9ba145d2-bd67-4f31-a221-bf820027862d', displayName: '', namespaceClsid: '', targetFolderPath: '', hasUserSyncRoots: false },
+    ]);
+    // When
+    await unregisterVirtualDrives(props);
+    // Then
+    calls(removeSyncRootRegistrationMock).toHaveLength(0);
+  });
+
+  it('should remove a registration without a display name if the target folder path is ours', async () => {
+    // Given
+    const registration = {
+      id: 'syncRootID',
+      displayName: '',
+      namespaceClsid: '{CLSID}',
+      targetFolderPath: String.raw`C:\Users\user\InternxtDrive - uuid`,
+      hasUserSyncRoots: false,
+    };
+    getSyncRootRegistrationsMock.mockResolvedValue([registration]);
+    // When
+    await unregisterVirtualDrives(props);
+    // Then
+    call(removeSyncRootRegistrationMock).toStrictEqual({ registration });
+  });
+
+  it('should not remove a registration without a display name if the target folder path is from another provider', async () => {
+    // Given
+    getSyncRootRegistrationsMock.mockResolvedValue([
+      {
+        id: 'syncRootID',
+        displayName: '',
+        namespaceClsid: '{CLSID}',
+        targetFolderPath: String.raw`C:\Users\user\OneDrive`,
+        hasUserSyncRoots: false,
+      },
     ]);
     // When
     await unregisterVirtualDrives(props);

--- a/src/apps/main/background-processes/sync-engine/services/unregister-virtual-drives.ts
+++ b/src/apps/main/background-processes/sync-engine/services/unregister-virtual-drives.ts
@@ -1,4 +1,5 @@
 import { logger } from '@/apps/shared/logger/logger';
+import { SyncRootRegistration } from '@/infra/windows-registry/services/get-sync-root-registrations';
 import { WindowsRegistry } from '@/infra/windows-registry/windows-registry.module';
 import { Addon } from '@/node-win/addon-wrapper';
 
@@ -45,13 +46,17 @@ export async function unregisterVirtualDrives({ currentProviderIds = [] }: TProp
   await removeOrphanRegistrations({ currentProviderIds });
 }
 
+function isFromInternxt({ registration }: { registration: SyncRootRegistration }) {
+  return registration.displayName.toLowerCase().includes('internxt') || registration.targetFolderPath.toLowerCase().includes('internxt');
+}
+
 async function removeOrphanRegistrations({ currentProviderIds }: { currentProviderIds: string[] }) {
   const registrations = await WindowsRegistry.getSyncRootRegistrations();
   const registeredIds = new Set(Addon.getRegisteredSyncRoots().map((syncRoot) => syncRoot.id));
 
   const orphans = registrations.filter(
     (registration) =>
-      registration.displayName.toLowerCase().includes('internxt') &&
+      isFromInternxt({ registration }) &&
       !registration.hasUserSyncRoots &&
       !currentProviderIds.includes(registration.id) &&
       !registeredIds.has(registration.id),

--- a/src/apps/main/background-processes/sync-engine/services/unregister-virtual-drives.ts
+++ b/src/apps/main/background-processes/sync-engine/services/unregister-virtual-drives.ts
@@ -1,4 +1,5 @@
 import { logger } from '@/apps/shared/logger/logger';
+import { WindowsRegistry } from '@/infra/windows-registry/windows-registry.module';
 import { Addon } from '@/node-win/addon-wrapper';
 
 type TProps = {
@@ -40,4 +41,25 @@ export async function unregisterVirtualDrives({ currentProviderIds = [] }: TProp
   });
 
   await Promise.all(promises);
+
+  await removeOrphanRegistrations({ currentProviderIds });
+}
+
+async function removeOrphanRegistrations({ currentProviderIds }: { currentProviderIds: string[] }) {
+  const registrations = await WindowsRegistry.getSyncRootRegistrations();
+  const registeredIds = Addon.getRegisteredSyncRoots().map((syncRoot) => syncRoot.id);
+
+  const orphans = registrations.filter(
+    (registration) =>
+      registration.displayName.toLowerCase().includes('internxt') &&
+      !registration.hasUserSyncRoots &&
+      !currentProviderIds.includes(registration.id) &&
+      !registeredIds.includes(registration.id),
+  );
+
+  logger.debug({ tag: 'SYNC-ENGINE', msg: 'Orphan sync root registrations', orphans });
+
+  for (const registration of orphans) {
+    await WindowsRegistry.removeSyncRootRegistration({ registration });
+  }
 }

--- a/src/apps/main/background-processes/sync-engine/services/unregister-virtual-drives.ts
+++ b/src/apps/main/background-processes/sync-engine/services/unregister-virtual-drives.ts
@@ -47,14 +47,14 @@ export async function unregisterVirtualDrives({ currentProviderIds = [] }: TProp
 
 async function removeOrphanRegistrations({ currentProviderIds }: { currentProviderIds: string[] }) {
   const registrations = await WindowsRegistry.getSyncRootRegistrations();
-  const registeredIds = Addon.getRegisteredSyncRoots().map((syncRoot) => syncRoot.id);
+  const registeredIds = new Set(Addon.getRegisteredSyncRoots().map((syncRoot) => syncRoot.id));
 
   const orphans = registrations.filter(
     (registration) =>
       registration.displayName.toLowerCase().includes('internxt') &&
       !registration.hasUserSyncRoots &&
       !currentProviderIds.includes(registration.id) &&
-      !registeredIds.includes(registration.id),
+      !registeredIds.has(registration.id),
   );
 
   logger.debug({ tag: 'SYNC-ENGINE', msg: 'Orphan sync root registrations', orphans });

--- a/src/apps/main/main.ts
+++ b/src/apps/main/main.ts
@@ -29,7 +29,7 @@ import { setupAntivirusIpc } from './ipcs/ipcMainAntivirus';
 import { setupPreloadIpc } from './preload/ipc-main';
 import { setupQuitHandlers } from './quit';
 import { setTrayStatus, setupTrayIcon } from './tray/tray';
-import { createWidget, showFrontend } from './windows/widget';
+import { createWidget, getWidget, showFrontend } from './windows/widget';
 
 app.setPath('crashDumps', join(PATHS.LOGS, 'crash'));
 crashReporter.start({ uploadToServer: false, compress: false });
@@ -57,6 +57,8 @@ if (!gotTheLock) {
 } else {
   app.on('second-instance', (event, argv) => {
     processDeeplink({ argv });
+
+    if (getWidget()) showFrontend();
   });
 }
 

--- a/src/infra/windows-registry/services/get-sync-root-registrations.infra.test.ts
+++ b/src/infra/windows-registry/services/get-sync-root-registrations.infra.test.ts
@@ -1,0 +1,28 @@
+import { Addon } from '@/node-win/addon-wrapper';
+import { getSyncRootRegistrations } from './get-sync-root-registrations';
+
+describe('get-sync-root-registrations', () => {
+  it('should read every registration that the addon reports', async () => {
+    // Given
+    const syncRoots = Addon.getRegisteredSyncRoots();
+    // When
+    const registrations = await getSyncRootRegistrations();
+    // Then
+    for (const syncRoot of syncRoots) {
+      const registration = registrations.find((item) => item.id === syncRoot.id);
+      expect(registration).toBeDefined();
+      expect(registration?.displayName).toBe(syncRoot.displayName);
+      expect(registration?.namespaceClsid).toMatch(/^\{[0-9A-F-]+\}$/i);
+      expect(registration?.hasUserSyncRoots).toBe(true);
+    }
+  });
+
+  it('should also read registrations that the addon does not report', async () => {
+    // Given
+    const registeredIds = Addon.getRegisteredSyncRoots().map((syncRoot) => syncRoot.id);
+    // When
+    const registrations = await getSyncRootRegistrations();
+    // Then
+    expect(registrations.length).toBeGreaterThanOrEqual(registeredIds.length);
+  });
+});

--- a/src/infra/windows-registry/services/get-sync-root-registrations.infra.test.ts
+++ b/src/infra/windows-registry/services/get-sync-root-registrations.infra.test.ts
@@ -13,6 +13,7 @@ describe('get-sync-root-registrations', () => {
       expect(registration).toBeDefined();
       expect(registration?.displayName).toBe(syncRoot.displayName);
       expect(registration?.namespaceClsid).toMatch(/^\{[0-9A-F-]+\}$/i);
+      expect(registration?.targetFolderPath.replace(/\\/g, '/')).toBe(syncRoot.path);
       expect(registration?.hasUserSyncRoots).toBe(true);
     }
   });

--- a/src/infra/windows-registry/services/get-sync-root-registrations.test.ts
+++ b/src/infra/windows-registry/services/get-sync-root-registrations.test.ts
@@ -1,0 +1,52 @@
+import { calls, partialSpyOn } from 'tests/vitest/utils.helper.test';
+import { getSyncRootRegistrations } from './get-sync-root-registrations';
+import * as registry from './registry';
+
+describe('get-sync-root-registrations', () => {
+  const queryKeyMock = partialSpyOn(registry, 'queryKey');
+
+  it('should map values and detect the user sync roots subkey', async () => {
+    // Given
+    queryKeyMock.mockResolvedValueOnce({ values: {}, subKeys: ['{PROVIDER_ID}'] });
+    queryKeyMock.mockResolvedValueOnce({
+      values: { DisplayNameResource: 'Internxt Drive', NamespaceCLSID: '{CLSID}' },
+      subKeys: ['UserSyncRoots'],
+    });
+    // When
+    const registrations = await getSyncRootRegistrations();
+    // Then
+    expect(registrations).toStrictEqual([
+      { id: '{PROVIDER_ID}', displayName: 'Internxt Drive', namespaceClsid: '{CLSID}', hasUserSyncRoots: true },
+    ]);
+  });
+
+  it('should mark a registration without the user sync roots subkey', async () => {
+    // Given
+    queryKeyMock.mockResolvedValueOnce({ values: {}, subKeys: ['syncRootID'] });
+    queryKeyMock.mockResolvedValueOnce({ values: { DisplayNameResource: 'Internxt' }, subKeys: [] });
+    // When
+    const registrations = await getSyncRootRegistrations();
+    // Then
+    expect(registrations).toStrictEqual([{ id: 'syncRootID', displayName: 'Internxt', namespaceClsid: '', hasUserSyncRoots: false }]);
+  });
+
+  it('should return nothing if the registry cannot be read', async () => {
+    // Given
+    queryKeyMock.mockRejectedValue(new Error('reg query failed'));
+    // When
+    const registrations = await getSyncRootRegistrations();
+    // Then
+    expect(registrations).toStrictEqual([]);
+  });
+
+  it('should return nothing if a single registration cannot be read', async () => {
+    // Given
+    queryKeyMock.mockResolvedValueOnce({ values: {}, subKeys: ['{PROVIDER_ID}'] });
+    queryKeyMock.mockRejectedValueOnce(new Error('reg query failed'));
+    // When
+    const registrations = await getSyncRootRegistrations();
+    // Then
+    expect(registrations).toStrictEqual([]);
+    calls(queryKeyMock).toHaveLength(2);
+  });
+});

--- a/src/infra/windows-registry/services/get-sync-root-registrations.test.ts
+++ b/src/infra/windows-registry/services/get-sync-root-registrations.test.ts
@@ -12,11 +12,18 @@ describe('get-sync-root-registrations', () => {
       values: { DisplayNameResource: 'Internxt Drive', NamespaceCLSID: '{CLSID}' },
       subKeys: ['UserSyncRoots'],
     });
+    queryKeyMock.mockResolvedValueOnce({ values: { TargetFolderPath: String.raw`C:\Users\user\InternxtDrive - uuid` }, subKeys: [] });
     // When
     const registrations = await getSyncRootRegistrations();
     // Then
     expect(registrations).toStrictEqual([
-      { id: '{PROVIDER_ID}', displayName: 'Internxt Drive', namespaceClsid: '{CLSID}', hasUserSyncRoots: true },
+      {
+        id: '{PROVIDER_ID}',
+        displayName: 'Internxt Drive',
+        namespaceClsid: '{CLSID}',
+        targetFolderPath: String.raw`C:\Users\user\InternxtDrive - uuid`,
+        hasUserSyncRoots: true,
+      },
     ]);
   });
 
@@ -27,7 +34,42 @@ describe('get-sync-root-registrations', () => {
     // When
     const registrations = await getSyncRootRegistrations();
     // Then
-    expect(registrations).toStrictEqual([{ id: 'syncRootID', displayName: 'Internxt', namespaceClsid: '', hasUserSyncRoots: false }]);
+    expect(registrations).toStrictEqual([
+      { id: 'syncRootID', displayName: 'Internxt', namespaceClsid: '', targetFolderPath: '', hasUserSyncRoots: false },
+    ]);
+    calls(queryKeyMock).toHaveLength(2);
+  });
+
+  it('should read the target folder path of a registration without a display name', async () => {
+    // Given
+    queryKeyMock.mockResolvedValueOnce({ values: {}, subKeys: ['syncRootID'] });
+    queryKeyMock.mockResolvedValueOnce({ values: { NamespaceCLSID: '{CLSID}' }, subKeys: [] });
+    queryKeyMock.mockResolvedValueOnce({ values: { TargetFolderPath: String.raw`C:\Users\user\InternxtDrive - uuid` }, subKeys: [] });
+    // When
+    const registrations = await getSyncRootRegistrations();
+    // Then
+    expect(registrations).toStrictEqual([
+      {
+        id: 'syncRootID',
+        displayName: '',
+        namespaceClsid: '{CLSID}',
+        targetFolderPath: String.raw`C:\Users\user\InternxtDrive - uuid`,
+        hasUserSyncRoots: false,
+      },
+    ]);
+  });
+
+  it('should keep the registration if the target folder path cannot be read', async () => {
+    // Given
+    queryKeyMock.mockResolvedValueOnce({ values: {}, subKeys: ['syncRootID'] });
+    queryKeyMock.mockResolvedValueOnce({ values: { DisplayNameResource: 'Internxt', NamespaceCLSID: '{CLSID}' }, subKeys: [] });
+    queryKeyMock.mockRejectedValueOnce(new Error('reg query failed'));
+    // When
+    const registrations = await getSyncRootRegistrations();
+    // Then
+    expect(registrations).toStrictEqual([
+      { id: 'syncRootID', displayName: 'Internxt', namespaceClsid: '{CLSID}', targetFolderPath: '', hasUserSyncRoots: false },
+    ]);
   });
 
   it('should return nothing if the registry cannot be read', async () => {

--- a/src/infra/windows-registry/services/get-sync-root-registrations.ts
+++ b/src/infra/windows-registry/services/get-sync-root-registrations.ts
@@ -1,5 +1,5 @@
 import { logger } from '@/apps/shared/logger/logger';
-import { queryKeys, queryValues, SYNC_ROOT_MANAGER_KEY, tryQueryValues } from './registry';
+import { queryKey, SYNC_ROOT_MANAGER_KEY } from './registry';
 
 export type SyncRootRegistration = {
   id: string;
@@ -10,19 +10,17 @@ export type SyncRootRegistration = {
 
 export async function getSyncRootRegistrations(): Promise<SyncRootRegistration[]> {
   try {
-    const ids = await queryKeys({ key: SYNC_ROOT_MANAGER_KEY });
+    const { subKeys: ids } = await queryKey({ key: SYNC_ROOT_MANAGER_KEY });
 
     const registrations = await Promise.all(
       ids.map(async (id) => {
-        const key = `${SYNC_ROOT_MANAGER_KEY}\\${id}`;
-        const values = await queryValues({ key });
-        const userSyncRoots = await tryQueryValues({ key: `${key}\\UserSyncRoots` });
+        const { values, subKeys } = await queryKey({ key: `${SYNC_ROOT_MANAGER_KEY}\\${id}` });
 
         return {
           id,
           displayName: values.DisplayNameResource ?? '',
           namespaceClsid: values.NamespaceCLSID ?? '',
-          hasUserSyncRoots: Object.keys(userSyncRoots).length > 0,
+          hasUserSyncRoots: subKeys.includes('UserSyncRoots'),
         };
       }),
     );

--- a/src/infra/windows-registry/services/get-sync-root-registrations.ts
+++ b/src/infra/windows-registry/services/get-sync-root-registrations.ts
@@ -1,0 +1,35 @@
+import { logger } from '@/apps/shared/logger/logger';
+import { queryKeys, queryValues, SYNC_ROOT_MANAGER_KEY, tryQueryValues } from './registry';
+
+export type SyncRootRegistration = {
+  id: string;
+  displayName: string;
+  namespaceClsid: string;
+  hasUserSyncRoots: boolean;
+};
+
+export async function getSyncRootRegistrations(): Promise<SyncRootRegistration[]> {
+  try {
+    const ids = await queryKeys({ key: SYNC_ROOT_MANAGER_KEY });
+
+    const registrations = await Promise.all(
+      ids.map(async (id) => {
+        const key = `${SYNC_ROOT_MANAGER_KEY}\\${id}`;
+        const values = await queryValues({ key });
+        const userSyncRoots = await tryQueryValues({ key: `${key}\\UserSyncRoots` });
+
+        return {
+          id,
+          displayName: values.DisplayNameResource ?? '',
+          namespaceClsid: values.NamespaceCLSID ?? '',
+          hasUserSyncRoots: Object.keys(userSyncRoots).length > 0,
+        };
+      }),
+    );
+
+    return registrations;
+  } catch (exc) {
+    logger.error({ tag: 'SYNC-ENGINE', msg: 'Error reading sync root registrations', exc });
+    return [];
+  }
+}

--- a/src/infra/windows-registry/services/get-sync-root-registrations.ts
+++ b/src/infra/windows-registry/services/get-sync-root-registrations.ts
@@ -1,12 +1,24 @@
 import { logger } from '@/apps/shared/logger/logger';
-import { queryKey, SYNC_ROOT_MANAGER_KEY } from './registry';
+import { CLSID_KEY, queryKey, SYNC_ROOT_MANAGER_KEY } from './registry';
 
 export type SyncRootRegistration = {
   id: string;
   displayName: string;
   namespaceClsid: string;
+  targetFolderPath: string;
   hasUserSyncRoots: boolean;
 };
+
+async function getTargetFolderPath({ namespaceClsid }: { namespaceClsid: string }) {
+  if (!namespaceClsid) return '';
+
+  try {
+    const { values } = await queryKey({ key: `${CLSID_KEY}\\${namespaceClsid}\\Instance\\InitPropertyBag` });
+    return values.TargetFolderPath ?? '';
+  } catch {
+    return '';
+  }
+}
 
 export async function getSyncRootRegistrations(): Promise<SyncRootRegistration[]> {
   try {
@@ -15,11 +27,13 @@ export async function getSyncRootRegistrations(): Promise<SyncRootRegistration[]
     const registrations = await Promise.all(
       ids.map(async (id) => {
         const { values, subKeys } = await queryKey({ key: `${SYNC_ROOT_MANAGER_KEY}\\${id}` });
+        const namespaceClsid = values.NamespaceCLSID ?? '';
 
         return {
           id,
           displayName: values.DisplayNameResource ?? '',
-          namespaceClsid: values.NamespaceCLSID ?? '',
+          namespaceClsid,
+          targetFolderPath: await getTargetFolderPath({ namespaceClsid }),
           hasUserSyncRoots: subKeys.includes('UserSyncRoots'),
         };
       }),

--- a/src/infra/windows-registry/services/registry.ts
+++ b/src/infra/windows-registry/services/registry.ts
@@ -9,35 +9,38 @@ export const CLSID_KEY = String.raw`HKCU\Software\Classes\CLSID`;
 
 const VALUE_REGEX = /^ {4}(.+?) {4}REG_\w+ {4}(.*)$/;
 
-export async function queryKeys({ key }: { key: string }) {
-  const { stdout } = await execFileAsync('reg', ['query', key]);
+const HIVES: Record<string, string> = {
+  HKLM: 'HKEY_LOCAL_MACHINE',
+  HKCU: 'HKEY_CURRENT_USER',
+};
 
-  return stdout
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.startsWith('HKEY_') && line.length > key.length)
-    .map((line) => line.slice(line.lastIndexOf('\\') + 1));
+function expandHive({ key }: { key: string }) {
+  const [hive, ...rest] = key.split('\\');
+  return [HIVES[hive] ?? hive, ...rest].join('\\');
 }
 
-export async function queryValues({ key }: { key: string }) {
+export async function queryKey({ key }: { key: string }) {
   const { stdout } = await execFileAsync('reg', ['query', key]);
 
+  const prefix = `${expandHive({ key })}\\`;
   const values: Record<string, string> = {};
+  const subKeys: string[] = [];
 
-  for (const line of stdout.split('\r\n')) {
-    const match = VALUE_REGEX.exec(line);
-    if (match) values[match[1]] = match[2];
+  for (const raw of stdout.split('\n')) {
+    const line = raw.replace(/\r$/, '');
+
+    const value = VALUE_REGEX.exec(line);
+    if (value) {
+      values[value[1]] = value[2];
+      continue;
+    }
+
+    if (line.startsWith(prefix)) {
+      subKeys.push(line.slice(prefix.length));
+    }
   }
 
-  return values;
-}
-
-export async function tryQueryValues({ key }: { key: string }) {
-  try {
-    return await queryValues({ key });
-  } catch {
-    return {};
-  }
+  return { values, subKeys };
 }
 
 export async function deleteKey({ key }: { key: string }) {

--- a/src/infra/windows-registry/services/registry.ts
+++ b/src/infra/windows-registry/services/registry.ts
@@ -1,0 +1,45 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export const SYNC_ROOT_MANAGER_KEY = String.raw`HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\SyncRootManager`;
+export const NAMESPACE_KEY = String.raw`HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace`;
+export const CLSID_KEY = String.raw`HKCU\Software\Classes\CLSID`;
+
+const VALUE_REGEX = /^ {4}(.+?) {4}REG_\w+ {4}(.*)$/;
+
+export async function queryKeys({ key }: { key: string }) {
+  const { stdout } = await execFileAsync('reg', ['query', key]);
+
+  return stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('HKEY_') && line.length > key.length)
+    .map((line) => line.slice(line.lastIndexOf('\\') + 1));
+}
+
+export async function queryValues({ key }: { key: string }) {
+  const { stdout } = await execFileAsync('reg', ['query', key]);
+
+  const values: Record<string, string> = {};
+
+  for (const line of stdout.split('\r\n')) {
+    const match = VALUE_REGEX.exec(line);
+    if (match) values[match[1]] = match[2];
+  }
+
+  return values;
+}
+
+export async function tryQueryValues({ key }: { key: string }) {
+  try {
+    return await queryValues({ key });
+  } catch {
+    return {};
+  }
+}
+
+export async function deleteKey({ key }: { key: string }) {
+  await execFileAsync('reg', ['delete', key, '/f']);
+}

--- a/src/infra/windows-registry/services/remove-sync-root-registration.test.ts
+++ b/src/infra/windows-registry/services/remove-sync-root-registration.test.ts
@@ -7,7 +7,13 @@ describe('remove-sync-root-registration', () => {
 
   it('should remove the explorer entry before the provider record', async () => {
     // Given
-    const registration = { id: 'syncRootID', displayName: 'Internxt', namespaceClsid: '{CLSID}', hasUserSyncRoots: false };
+    const registration = {
+      id: 'syncRootID',
+      displayName: 'Internxt',
+      namespaceClsid: '{CLSID}',
+      targetFolderPath: '',
+      hasUserSyncRoots: false,
+    };
     // When
     await removeSyncRootRegistration({ registration });
     // Then
@@ -20,7 +26,7 @@ describe('remove-sync-root-registration', () => {
 
   it('should only remove the provider record if there is no namespace clsid', async () => {
     // Given
-    const registration = { id: 'syncRootID', displayName: 'Internxt', namespaceClsid: '', hasUserSyncRoots: false };
+    const registration = { id: 'syncRootID', displayName: 'Internxt', namespaceClsid: '', targetFolderPath: '', hasUserSyncRoots: false };
     // When
     await removeSyncRootRegistration({ registration });
     // Then
@@ -29,7 +35,13 @@ describe('remove-sync-root-registration', () => {
 
   it('should keep removing the remaining keys if one of them fails', async () => {
     // Given
-    const registration = { id: 'syncRootID', displayName: 'Internxt', namespaceClsid: '{CLSID}', hasUserSyncRoots: false };
+    const registration = {
+      id: 'syncRootID',
+      displayName: 'Internxt',
+      namespaceClsid: '{CLSID}',
+      targetFolderPath: '',
+      hasUserSyncRoots: false,
+    };
     deleteKeyMock.mockRejectedValueOnce(new Error('access denied'));
     // When
     await removeSyncRootRegistration({ registration });

--- a/src/infra/windows-registry/services/remove-sync-root-registration.test.ts
+++ b/src/infra/windows-registry/services/remove-sync-root-registration.test.ts
@@ -1,0 +1,39 @@
+import { calls, partialSpyOn } from 'tests/vitest/utils.helper.test';
+import * as registry from './registry';
+import { removeSyncRootRegistration } from './remove-sync-root-registration';
+
+describe('remove-sync-root-registration', () => {
+  const deleteKeyMock = partialSpyOn(registry, 'deleteKey');
+
+  it('should remove the explorer entry before the provider record', async () => {
+    // Given
+    const registration = { id: 'syncRootID', displayName: 'Internxt', namespaceClsid: '{CLSID}', hasUserSyncRoots: false };
+    // When
+    await removeSyncRootRegistration({ registration });
+    // Then
+    calls(deleteKeyMock).toStrictEqual([
+      { key: `${registry.NAMESPACE_KEY}\\{CLSID}` },
+      { key: `${registry.CLSID_KEY}\\{CLSID}` },
+      { key: `${registry.SYNC_ROOT_MANAGER_KEY}\\syncRootID` },
+    ]);
+  });
+
+  it('should only remove the provider record if there is no namespace clsid', async () => {
+    // Given
+    const registration = { id: 'syncRootID', displayName: 'Internxt', namespaceClsid: '', hasUserSyncRoots: false };
+    // When
+    await removeSyncRootRegistration({ registration });
+    // Then
+    calls(deleteKeyMock).toStrictEqual([{ key: `${registry.SYNC_ROOT_MANAGER_KEY}\\syncRootID` }]);
+  });
+
+  it('should keep removing the remaining keys if one of them fails', async () => {
+    // Given
+    const registration = { id: 'syncRootID', displayName: 'Internxt', namespaceClsid: '{CLSID}', hasUserSyncRoots: false };
+    deleteKeyMock.mockRejectedValueOnce(new Error('access denied'));
+    // When
+    await removeSyncRootRegistration({ registration });
+    // Then
+    calls(deleteKeyMock).toHaveLength(3);
+  });
+});

--- a/src/infra/windows-registry/services/remove-sync-root-registration.ts
+++ b/src/infra/windows-registry/services/remove-sync-root-registration.ts
@@ -1,0 +1,21 @@
+import { logger } from '@/apps/shared/logger/logger';
+import { SyncRootRegistration } from './get-sync-root-registrations';
+import { CLSID_KEY, deleteKey, NAMESPACE_KEY, SYNC_ROOT_MANAGER_KEY } from './registry';
+
+export async function removeSyncRootRegistration({ registration }: { registration: SyncRootRegistration }) {
+  const { id, namespaceClsid } = registration;
+
+  logger.debug({ tag: 'SYNC-ENGINE', msg: 'Removing orphan sync root registration', registration });
+
+  const keys = namespaceClsid
+    ? [`${NAMESPACE_KEY}\\${namespaceClsid}`, `${CLSID_KEY}\\${namespaceClsid}`, `${SYNC_ROOT_MANAGER_KEY}\\${id}`]
+    : [`${SYNC_ROOT_MANAGER_KEY}\\${id}`];
+
+  for (const key of keys) {
+    try {
+      await deleteKey({ key });
+    } catch (exc) {
+      logger.error({ tag: 'SYNC-ENGINE', msg: 'Error removing orphan sync root key', key, exc });
+    }
+  }
+}

--- a/src/infra/windows-registry/windows-registry.module.ts
+++ b/src/infra/windows-registry/windows-registry.module.ts
@@ -1,0 +1,7 @@
+import { getSyncRootRegistrations } from './services/get-sync-root-registrations';
+import { removeSyncRootRegistration } from './services/remove-sync-root-registration';
+
+export const WindowsRegistry = {
+  getSyncRootRegistrations,
+  removeSyncRootRegistration,
+};


### PR DESCRIPTION
## What is Changed / Added

`unregisterVirtualDrives` gets a second pass that reads `SyncRootManager` straight from the registry and removes the entries Windows will not resolve. New `src/infra/windows-registry` module, no new dependencies.

## Why

Registering a virtual drive writes **two linked halves**:

```
HKLM\...\Explorer\SyncRootManager\{providerId}
    NamespaceCLSID, DisplayNameResource, IconResource, Flags, RecycleBinUrl
    UserSyncRoots[<user SID>] = <root path>

HKCU\...\Explorer\Desktop\NameSpace\{NamespaceCLSID}     ← what Explorer draws
HKCU\Software\Classes\CLSID\{NamespaceCLSID}
```

If the process dies mid-registration, the shell half is complete but the provider half is not — it stops at `NamespaceCLSID` + `DisplayNameResource`, with no `UserSyncRoots`. The result is unreachable from the Cloud Files API in **both** directions:

| | result |
|---|---|
| `GetCurrentSyncRoots()` | does not return it — no `Path()`, no `Version()` to build the object from |
| `Unregister(id)` | throws `0x80070490 ERROR_NOT_FOUND` on a key that is plainly there |
| Explorer | renders it, pinned, with `SFGAO_CANDELETE` **off** — hence no Delete in the context menu |

So `unregisterVirtualDrives` could never see it, and the user could never delete it. Deleting the folder from disk does not help either: the three registry keys survive and the entry stays, now pointing at nothing.

Only direct registry deletion clears it, which is what this PR does — and only for entries that pass four filters:

```ts
registration.displayName.toLowerCase().includes('internxt') &&
!registration.hasUserSyncRoots &&
!currentProviderIds.includes(registration.id) &&
!registeredIds.includes(registration.id),
```

`hasUserSyncRoots` separates the two reasons the API may skip an entry: **broken** (no `UserSyncRoots` at all) vs **belonging to another Windows user** (`UserSyncRoots` present, under a different SID). Without it, a shared machine with two Windows accounts using Internxt would have one account delete the other's registration.

`currentProviderIds` guards a real race: `spawnDrive` does not await `spawnSyncEngineWorker`, so our own registration may still be in flight when this runs — indistinguishable from a phantom at that moment.

No filesystem and no database access: the v2.5.1 rule about never deleting the folder is preserved.

## Verification

Reproduced deterministically on a real machine and driven through the real app, three scenarios:

| scenario | result |
|---|---|
| Phantom with its folder present | detected and removed |
| Phantom whose folder was deleted by hand | detected and removed |
| No phantom | `orphans: []`, nothing touched |

Plus a real account switch: the active drive was unregistered through the normal API pass and never appeared as an orphan.

```
Orphan sync root registrations  orphans: [ { id: 'syncRootID', displayName: 'Internxt',
  namespaceClsid: '{995BF3C7-...}', hasUserSyncRoots: false } ]
Removing orphan sync root registration
```

Files were verified untouched across the cleanup, including a file that only existed locally.

12 unit tests on `unregisterVirtualDrives` (5 of them pinning the filter boundaries) and 2 `.infra` tests reading the machine's real registry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically removes stale Windows sync-root registrations no longer associated with active folders.
  * Preserves valid registrations belonging to the current provider, other providers, or other users.
  * Opening a second app instance now correctly displays the existing widget when available.

* **Reliability**
  * Improved Windows registry access and cleanup so individual failures do not interrupt remaining operations.
  * More accurately identifies registrations using their associated folder paths.

* **Tests**
  * Added coverage for detecting, preserving, and removing Windows sync-root registrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->