### PR TITLE
fix: build context-menu against any installed Windows SDK

### DIFF
--- a/packages/context-menu/InternxtContextMenu.vcxproj
+++ b/packages/context-menu/InternxtContextMenu.vcxproj
@@ -11,13 +11,14 @@
     <ProjectGuid>{40A1542B-B5AB-4C4A-81F9-A824B29D129B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>InternxtContextMenu</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset Condition="'$(PlatformToolset)' == ''">$(DefaultPlatformToolset)</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/packages/context-menu/InternxtContextMenuHost.vcxproj
+++ b/packages/context-menu/InternxtContextMenuHost.vcxproj
@@ -11,13 +11,14 @@
     <ProjectGuid>{D65C60CC-37EE-4B50-AC63-C71B735C771B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>InternxtContextMenuHost</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset Condition="'$(PlatformToolset)' == ''">$(DefaultPlatformToolset)</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/packages/context-menu/build.ps1
+++ b/packages/context-menu/build.ps1
@@ -1,12 +1,11 @@
 $ErrorActionPreference = "Stop"
 
-$sdkVersion = "10.0.22621.0"
 $projectPath = Join-Path $PSScriptRoot "InternxtContextMenu.vcxproj"
 $hostProjectPath = Join-Path $PSScriptRoot "InternxtContextMenuHost.vcxproj"
 $dllOutputPath = Join-Path $PSScriptRoot "dist\internxt_context_menu.dll"
 $hostOutputPath = Join-Path $PSScriptRoot "dist\internxt_context_menu_host.exe"
 $vswherePath = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
-$sdkIncludePath = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\Include\$sdkVersion"
+$windowsKitsIncludePath = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\Include"
 
 if (-not (Test-Path -LiteralPath $vswherePath)) {
   throw "Visual Studio Installer was not found. Install Visual Studio Build Tools with the C++ workload."
@@ -42,8 +41,13 @@ if (-not $platformToolset) {
   throw "The installed Visual Studio C++ platform toolset could not be determined."
 }
 
-if (-not (Test-Path -LiteralPath $sdkIncludePath)) {
-  throw "Windows SDK $sdkVersion was not found."
+$sdkVersion = Get-ChildItem -Path $windowsKitsIncludePath -Directory -ErrorAction SilentlyContinue |
+  Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
+  Sort-Object { [version]$_.Name } -Descending |
+  Select-Object -First 1 -ExpandProperty Name
+
+if (-not $sdkVersion) {
+  throw "No installed Windows SDK was found under $windowsKitsIncludePath."
 }
 
 foreach ($nativeProjectPath in @($projectPath, $hostProjectPath)) {
@@ -53,6 +57,7 @@ foreach ($nativeProjectPath in @($projectPath, $hostProjectPath)) {
     /p:Configuration=Release `
     /p:Platform=x64 `
     /p:PlatformToolset=$platformToolset `
+    /p:WindowsTargetPlatformVersion=$sdkVersion `
     /m
 
   if ($LASTEXITCODE -ne 0) {

--- a/packages/context-menu/package-development.ps1
+++ b/packages/context-menu/package-development.ps1
@@ -3,16 +3,21 @@ $ErrorActionPreference = "Stop"
 $certificateSubject = "CN=Internxt Development"
 $certificateFriendlyName = "Internxt Context Menu Development"
 $certificateStore = "Cert:\CurrentUser\My"
-$sdkVersion = "10.0.22621.0"
-$signToolPath = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\bin\$sdkVersion\x64\SignTool.exe"
 $dllPath = Join-Path $PSScriptRoot "dist\internxt_context_menu.dll"
 $hostPath = Join-Path $PSScriptRoot "dist\internxt_context_menu_host.exe"
 $msixPath = Join-Path $PSScriptRoot "dist\InternxtContextMenu.msix"
 $certificateExportPath = Join-Path $PSScriptRoot "dist\InternxtDevelopment.cer"
 $certificateExportDirectory = Split-Path $certificateExportPath
 
-if (-not (Test-Path -LiteralPath $signToolPath)) {
-  throw "SignTool.exe from Windows SDK $sdkVersion was not found."
+$signToolPath = Get-ChildItem -Path (Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\bin") -Directory -ErrorAction SilentlyContinue |
+  Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
+  Sort-Object { [version]$_.Name } -Descending |
+  ForEach-Object { Join-Path $_.FullName "x64\SignTool.exe" } |
+  Where-Object { Test-Path -LiteralPath $_ } |
+  Select-Object -First 1
+
+if (-not $signToolPath) {
+  throw "SignTool.exe was not found under any installed Windows SDK."
 }
 
 # Reuse the newest valid development certificate when possible. The private

--- a/packages/context-menu/package.ps1
+++ b/packages/context-menu/package.ps1
@@ -1,6 +1,5 @@
 $ErrorActionPreference = "Stop"
 
-$sdkVersion = "10.0.22621.0"
 $rootPath = Resolve-Path (Join-Path $PSScriptRoot "..\..")
 $rootPackageJsonPath = Join-Path $rootPath "package.json"
 $manifestTemplatePath = Join-Path $PSScriptRoot "AppxManifest.template.xml"
@@ -8,15 +7,21 @@ $stagingPath = Join-Path $PSScriptRoot "build\package"
 $assetsPath = Join-Path $stagingPath "Assets"
 $outputPath = Join-Path $PSScriptRoot "dist\InternxtContextMenu.msix"
 $iconPath = Join-Path $rootPath "assets\icon.ico"
-$makeAppxPath = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\bin\$sdkVersion\x64\MakeAppx.exe"
 $publisher = if ($env:WINDOWS_PACKAGE_PUBLISHER) {
   $env:WINDOWS_PACKAGE_PUBLISHER
 } else {
   "CN=Internxt Development"
 }
 
-if (-not (Test-Path -LiteralPath $makeAppxPath)) {
-  throw "MakeAppx.exe from Windows SDK $sdkVersion was not found."
+$makeAppxPath = Get-ChildItem -Path (Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\bin") -Directory -ErrorAction SilentlyContinue |
+  Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
+  Sort-Object { [version]$_.Name } -Descending |
+  ForEach-Object { Join-Path $_.FullName "x64\MakeAppx.exe" } |
+  Where-Object { Test-Path -LiteralPath $_ } |
+  Select-Object -First 1
+
+if (-not $makeAppxPath) {
+  throw "MakeAppx.exe was not found under any installed Windows SDK."
 }
 
 if (-not (Test-Path -LiteralPath $iconPath)) {

--- a/packages/context-menu/prepare-test.ps1
+++ b/packages/context-menu/prepare-test.ps1
@@ -4,8 +4,6 @@ $certificateSubject = "CN=Internxt Development"
 $certificateFriendlyName = "Internxt Context Menu Development"
 $certificateStore = "Cert:\CurrentUser\My"
 $rootPath = Resolve-Path (Join-Path $PSScriptRoot "..\..")
-$sdkVersion = "10.0.22621.0"
-$signToolPath = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\bin\$sdkVersion\x64\SignTool.exe"
 $dllPath = Join-Path $PSScriptRoot "dist\internxt_context_menu.dll"
 $hostPath = Join-Path $PSScriptRoot "dist\internxt_context_menu_host.exe"
 $msixPath = Join-Path $PSScriptRoot "dist\InternxtContextMenu.msix"
@@ -14,8 +12,15 @@ $testContextMenuPath = Join-Path $testInstallPath "context-menu"
 $testDllPath = Join-Path $testContextMenuPath "internxt_context_menu.dll"
 $testHostPath = Join-Path $testContextMenuPath "internxt_context_menu_host.exe"
 
-if (-not (Test-Path -LiteralPath $signToolPath)) {
-  throw "SignTool.exe from Windows SDK $sdkVersion was not found."
+$signToolPath = Get-ChildItem -Path (Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\bin") -Directory -ErrorAction SilentlyContinue |
+  Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
+  Sort-Object { [version]$_.Name } -Descending |
+  ForEach-Object { Join-Path $_.FullName "x64\SignTool.exe" } |
+  Where-Object { Test-Path -LiteralPath $_ } |
+  Select-Object -First 1
+
+if (-not $signToolPath) {
+  throw "SignTool.exe was not found under any installed Windows SDK."
 }
 
 $certificate = Get-ChildItem $certificateStore |

--- a/packages/context-menu/trust-test-certificate.ps1
+++ b/packages/context-menu/trust-test-certificate.ps1
@@ -1,8 +1,6 @@
 $ErrorActionPreference = "Stop"
 
-$sdkVersion = "10.0.22621.0"
 $certificatePath = Join-Path $PSScriptRoot "build\InternxtDevelopment.cer"
-$signToolPath = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\bin\$sdkVersion\x64\SignTool.exe"
 $artifactPaths = @(
   (Join-Path $PSScriptRoot "dist\internxt_context_menu.dll"),
   (Join-Path $PSScriptRoot "dist\internxt_context_menu_host.exe"),
@@ -13,8 +11,15 @@ if (-not (Test-Path -LiteralPath $certificatePath)) {
   throw "Development certificate not found. Run npm run prepare:test:context-menu first."
 }
 
-if (-not (Test-Path -LiteralPath $signToolPath)) {
-  throw "SignTool.exe from Windows SDK $sdkVersion was not found."
+$signToolPath = Get-ChildItem -Path (Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\bin") -Directory -ErrorAction SilentlyContinue |
+  Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
+  Sort-Object { [version]$_.Name } -Descending |
+  ForEach-Object { Join-Path $_.FullName "x64\SignTool.exe" } |
+  Where-Object { Test-Path -LiteralPath $_ } |
+  Select-Object -First 1
+
+if (-not $signToolPath) {
+  throw "SignTool.exe was not found under any installed Windows SDK."
 }
 
 $isAdministrator = (


### PR DESCRIPTION
## What is Changed / Added

The five context-menu PowerShell scripts no longer hardcode Windows SDK
10.0.22621.0. They now pick the newest SDK installed under `Windows Kits\10`:
`build.ps1` scans `Include` and passes it to MSBuild, and the packaging and
signing scripts scan `bin` for the newest version that actually contains
`MakeAppx.exe` / `SignTool.exe`.

Both `.vcxproj` files get the same treatment, so they build outside
`build.ps1` too: `WindowsTargetPlatformVersion` is now `10.0` (MSBuild maps
it to the newest installed SDK) and `PlatformToolset` falls back to
`$(DefaultPlatformToolset)`. Both are guarded on being empty, so the `/p:`
overrides from `build.ps1` still win.

---

## Why

SDK 10.0.22621.0 is not installed on current machines, so every script hit
its `throw` and the context-menu build was dead. Building the project
directly then failed a second time on `MSB8020`, since no toolset was
declared and MSBuild fell back to VS2010's v100.

Verified on a machine with SDKs 10.0.26100.0 / 10.0.28000.0: MSBuild
resolves to 10.0.28000.0 with toolset v145, and both the direct build and
the full `build.ps1` run produce the DLL and EXE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHVnpSPt8acVMk7JMUnvSi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Windows context-menu builds now automatically detect the newest compatible Windows SDK installed on the system.
  * Build, packaging, signing, and test preparation scripts dynamically locate required Windows tools instead of relying on a fixed SDK version.
  * Project configuration now respects existing Windows SDK and compiler toolset settings, improving compatibility across development environments.
  * Clearer errors are provided when required Windows SDK tools cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->