### PR TITLE
fix: close the app gracefully before the installer kills it

### DIFF
--- a/assets/context-menu-installer.nsh
+++ b/assets/context-menu-installer.nsh
@@ -17,3 +17,17 @@
     ${EndIf}
   ${EndIf}
 !macroend
+
+!macro requestAppShutdown
+  DetailPrint "Asking Internxt Drive to close."
+  nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "$$filter='Name=''${APP_EXECUTABLE_FILENAME}'''; $$running=@(Get-CimInstance Win32_Process -Filter $$filter); if ($$running.Count -gt 0) { Start-Process -FilePath $$running[0].Path -ArgumentList '--quit'; $$deadline=(Get-Date).AddSeconds(30); while (@(Get-CimInstance Win32_Process -Filter $$filter).Count -gt 0 -and (Get-Date) -lt $$deadline) { Start-Sleep -Milliseconds 250 } }"`
+  Pop $0
+!macroend
+
+!macro customInit
+  !insertmacro requestAppShutdown
+!macroend
+
+!macro customUnInit
+  !insertmacro requestAppShutdown
+!macroend

--- a/src/apps/main/handle-second-instance.test.ts
+++ b/src/apps/main/handle-second-instance.test.ts
@@ -1,0 +1,58 @@
+import { BrowserWindow } from 'electron';
+import { call, partialSpyOn } from 'tests/vitest/utils.helper.test';
+import * as processDeeplinkModule from './electron/deeplink/process-deeplink';
+import { handleSecondInstance } from './handle-second-instance';
+import * as quit from './quit';
+import * as widget from './windows/widget';
+
+describe('handle-second-instance', () => {
+  const quitAppMock = partialSpyOn(quit, 'quitApp');
+  const processDeeplinkMock = partialSpyOn(processDeeplinkModule, 'processDeeplink');
+  const getWidgetMock = partialSpyOn(widget, 'getWidget');
+  const showFrontendMock = partialSpyOn(widget, 'showFrontend');
+
+  const exe = String.raw`C:\Users\user\AppData\Local\Programs\internxt-drive\Internxt.exe`;
+
+  it('should quit the app when the installer asks for it', () => {
+    // When
+    handleSecondInstance({ argv: [exe, '--quit'] });
+    // Then
+    expect(quitAppMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not process the deeplink when the app is asked to quit', () => {
+    // When
+    handleSecondInstance({ argv: [exe, '--quit'] });
+    // Then
+    expect(processDeeplinkMock).toHaveBeenCalledTimes(0);
+    expect(showFrontendMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('should process the deeplink when the app is not asked to quit', () => {
+    // Given
+    const argv = [exe, 'internxt://notification/https://internxt.com'];
+    // When
+    handleSecondInstance({ argv });
+    // Then
+    call(processDeeplinkMock).toStrictEqual({ argv });
+    expect(quitAppMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('should show the frontend when the widget already exists', () => {
+    // Given
+    getWidgetMock.mockReturnValue({});
+    // When
+    handleSecondInstance({ argv: [exe] });
+    // Then
+    expect(showFrontendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not show the frontend when there is no widget', () => {
+    // Given
+    getWidgetMock.mockReturnValue(undefined as unknown as BrowserWindow);
+    // When
+    handleSecondInstance({ argv: [exe] });
+    // Then
+    expect(showFrontendMock).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/apps/main/handle-second-instance.ts
+++ b/src/apps/main/handle-second-instance.ts
@@ -1,0 +1,18 @@
+import { logger } from '@/apps/shared/logger/logger';
+import { processDeeplink } from './electron/deeplink/process-deeplink';
+import { QUIT_FLAG, quitApp } from './quit';
+import { getWidget, showFrontend } from './windows/widget';
+
+type Props = { argv: string[] };
+
+export function handleSecondInstance({ argv }: Props) {
+  if (argv.includes(QUIT_FLAG)) {
+    logger.debug({ msg: 'Quit requested by another instance' });
+    void quitApp();
+    return;
+  }
+
+  processDeeplink({ argv });
+
+  if (getWidget()) showFrontend();
+}

--- a/src/apps/main/main.ts
+++ b/src/apps/main/main.ts
@@ -23,13 +23,13 @@ import { setupAutoLaunchHandlers } from './auto-launch/handlers';
 import { setUpBackups } from './background-processes/backups/setUpBackups';
 import { setupIssueHandlers } from './background-processes/issues';
 import { setupThemeListener } from './config/theme';
-import { processDeeplink } from './electron/deeplink/process-deeplink';
 import { startContextMenuPipe } from './electron/share/context-menu-pipe';
+import { handleSecondInstance } from './handle-second-instance';
 import { setupAntivirusIpc } from './ipcs/ipcMainAntivirus';
 import { setupPreloadIpc } from './preload/ipc-main';
 import { setupQuitHandlers } from './quit';
 import { setTrayStatus, setupTrayIcon } from './tray/tray';
-import { createWidget, getWidget, showFrontend } from './windows/widget';
+import { createWidget, showFrontend } from './windows/widget';
 
 app.setPath('crashDumps', join(PATHS.LOGS, 'crash'));
 crashReporter.start({ uploadToServer: false, compress: false });
@@ -55,11 +55,7 @@ const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
   app.exit(0);
 } else {
-  app.on('second-instance', (event, argv) => {
-    processDeeplink({ argv });
-
-    if (getWidget()) showFrontend();
-  });
+  app.on('second-instance', (event, argv) => handleSecondInstance({ argv }));
 }
 
 const tags = {

--- a/src/apps/main/quit.ts
+++ b/src/apps/main/quit.ts
@@ -2,6 +2,8 @@ import { logger } from '@internxt/drive-desktop-core/build/backend';
 import { app, ipcMain } from 'electron';
 import { cleanSyncEngineWorkers } from './background-processes/sync-engine/services/stop-sync-engine-worker';
 
+export const QUIT_FLAG = '--quit';
+
 export async function quitApp() {
   logger.debug({ msg: 'Quit app' });
   await cleanSyncEngineWorkers();

--- a/tests/vitest/setup.helper.test.ts
+++ b/tests/vitest/setup.helper.test.ts
@@ -118,6 +118,7 @@ vi.mock('@/apps/main/windows/widget.ts', () => {
         send: vi.fn(),
       },
     })),
+    showFrontend: vi.fn(),
   };
 });
 


### PR DESCRIPTION
Related to BR-2314. Stacked on top of #1486 — review that one first.

When the installer runs over a running app, electron-builder kills the process with `Stop-Process`. If that kill lands in the middle of a sync root registration, Windows keeps a half-written registration and a phantom Internxt folder is left behind in Explorer.

This PR removes that kill from the common path: the installer now asks the app to close on its own, and only falls back to killing it if the app does not exit in time.

## How it works

- A second instance launched with `--quit` is treated as a shutdown request instead of a deeplink. The running instance receives it through the existing single-instance channel and goes through the normal `before-quit` teardown, which is what unregisters its sync roots.
- `customInit` / `customUnInit` run before electron-builder's own `CHECK_APP_RUNNING`, so on a clean exit the kill never happens. If the app is not running, the macro is a no-op.
- The wait is capped at 30 s. Measured on a dev machine with the sync engine loaded, a full shutdown takes ~11.6 s end to end (~7.3 s of actual teardown). If the cap is ever hit, behaviour degrades to exactly what it is today.

## Notes for the reviewer

- `handle-second-instance.ts` exists so the handler can be tested without importing `main.ts`, which boots Sentry, the crash reporter and protocol registration on load. `main.ts` ends up shorter than before.
- The new macros live in `assets/context-menu-installer.nsh` because `nsis.include` accepts a single file. The name is now misleading; renaming it was left out of this PR on purpose.
- `tests/vitest/setup.helper.test.ts`: the global widget mock was missing `showFrontend`.

## Testing

- Unit tests for the second-instance handler: quit flag, deeplink, widget.
- Manual: packaged installer run over a running app. Logs show `Quit requested by another instance` followed by `App quitting, closing context-menu pipe` about 4 s into the install, and the registry is clean afterwards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Installations and uninstallations now request the app to close and wait for it to exit.
  - Launching a second instance with the quit option now closes the running app.
  - Deep links sent to an existing app instance continue to be processed, and the frontend is shown when a widget is available.

- **Tests**
  - Added coverage for second-instance commands, deep links, app closing, and frontend visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->