### PR TITLE
fix: stop propagating deletions from folders we could not sync (BR-2245)

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/adr

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ assets.d.ts
 packages
 preload.js
 CLAUDE.md
+.adr-dir

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2026-09-10
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/docs/adr/0002-do-not-sanitize-windows-names-for-unaddressable-items.md
+++ b/docs/adr/0002-do-not-sanitize-windows-names-for-unaddressable-items.md
@@ -1,0 +1,51 @@
+# 2. Do not sanitize windows names for unaddressable items
+
+Date: 2026-09-10
+
+## Status
+
+Accepted
+
+## Context
+
+Some names our server accepts cannot be addressed on Windows. We create placeholders through `\\?\` device paths, which skip win32 name parsing, so a name ending in a space or a dot is stored verbatim. Explorer does parse, looks for the trimmed name, and reports that the item does not exist. That is BR-1796: a folder the user can see and cannot open or delete.
+
+It is not only the item itself. A folder we refuse to create takes its whole subtree with it, so files the user never named badly stop arriving too. That is the data loss reported in BR-2245.
+
+Two ways out were considered.
+
+**Skip the item** and surface it as a sync issue, leaving the user to rename it in the web. This is what internxt/drive-desktop#1493 does, after measuring on Windows which names are actually unreachable: a trailing space or dot is, a leading space is not, so names that were being rejected for no reason now arrive.
+
+**Sanitize the name locally**, so the item comes down under a name Windows can address — `Press U.S.` as `Press U.S`, with a numbered suffix when the cleaned name collides with a sibling. Nothing would be skipped and no subtree would be lost.
+
+Sanitizing was implemented and then set aside, for three reasons. Two of them are about the product and would hold even if the implementation were perfect.
+
+No other Internxt client renames anything. Web, mobile and the other desktop platforms all show the name as stored. A name we cleaned up would exist only on Windows, so the same item would appear under one name in the app and another everywhere else, and a path copied from one would not resolve in the other.
+
+The user did not choose that name and would have no way to tell where it came from. A file they uploaded as `Press U.S.` appearing on their machine as `Press U.S`, or as `Press U.S(1)` when a sibling collides, reads as the app corrupting their data rather than working around a limitation of Windows. We would rather tell them the name cannot be used than change it behind their back.
+
+The third reason is what the numbering costs.
+
+The local name and the remote name stop being the same string, so every operation that starts from a local path has to work out which remote item it means. Deletion is the dangerous one: the watcher reports a path after the fact, the placeholder metadata is gone with the item, and the uuid along with it. Recovering the uuid means recomputing the whole sibling assignment and seeing which name is missing.
+
+That assignment is positional. Given `Teaser`, `Teaser(1)`, `Teaser(2)`, `Teaser(3)`, deleting `Teaser(2)` leaves the remaining siblings to be renumbered on the next full traversal. Until that traversal runs, the database holds one set of siblings and the disk still shows the old numbering. A second deletion in that window recomputes to a shifted assignment and trashes the wrong item in the cloud. It fails silently, and it fails towards data loss.
+
+## Decision
+
+We do not sanitize names. The local name always equals the remote name, on every platform.
+
+An item whose name does not meet the criteria we consider valid on Windows is not brought down to the desktop at all: no placeholder is created for it, and its subtree is not walked. Instead it is recorded as a sync issue against its full path, which the app groups by cause and lists in the issues panel. The item stays in the cloud, reachable from every other client, and the user resolves it by renaming it there.
+
+The criteria are ours, and they are deliberately narrower than the list Windows documents as invalid. We reject the reserved characters and the control characters, which fail on creation, and names ending in a space or a dot, which win32 trims when looking them up. We accept everything else, including reserved device names like `CON` and `LPT1` and names beginning with a space, because measuring on Windows shows they are reachable once created.
+
+Being narrow is the point. A name we reject costs the user its whole subtree, so rejecting one that actually works loses folders for nothing. The criteria are measured rather than taken from documentation for that reason, and the measurement is kept as a test so they cannot drift back.
+
+## Consequences
+
+Every local path maps back to exactly one remote item by name, so deletions and moves resolve without reconstructing anything. There is no window in which the disk and the database disagree about which sibling is which.
+
+The cost is that unaddressable items still do not arrive, and neither does anything under them. The user is told through the issues panel, but the fix is theirs: rename the item in the web. The message shown there was corrected in internxt/drive-desktop-core#61, which had been describing a rule we no longer apply.
+
+The third reason is the only one we know how to remove. If the local name stopped being how we identify items — storing the assigned name in sqlite, or taking the uuid from the Cloud Files delete notification (`CF_CALLBACK_TYPE_NOTIFY_DELETE` carries `FileIdentity`, which is where we write it) — the renumbering would no longer be able to resolve to the wrong item.
+
+That is worth doing on its own merits, but it would not reopen this decision by itself. The two product reasons would still stand, and they are not ours to settle alone: showing a different name on Windows than everywhere else is a question for the whole product, not for the desktop client.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,25 @@
+# Architecture Decision Records
+
+Each file here records one decision: what we were facing, what we chose, and what that costs us. They exist so that a year from now the reasoning is still available to whoever has to revisit the choice — including the arguments against what we picked.
+
+## Reading them
+
+They are plain markdown, numbered in the order they were taken. Nothing is needed to read them.
+
+**They are never edited once accepted.** If a decision is replaced, the new record supersedes the old one and both are updated to link to each other; the old one stays where it is, marked as superseded. The history is the point.
+
+## Writing one
+
+Copy the most recent record, give it the next number, and keep the four headings: Status, Context, Decision, Consequences. Write the context so it makes sense to someone who was not in the room.
+
+Optionally, [adr-tools](https://github.com/npryce/adr-tools) automates the numbering and the superseding links:
+
+    adr new Title of the decision      # creates the next record
+    adr new -s 2 Title                 # creates it, superseding record 2
+    adr list
+
+It is a set of bash scripts, so it is not installed through `package.json`. On Windows it runs under git bash — see the project's [INSTALL.md](https://github.com/npryce/adr-tools/blob/master/INSTALL.md#windows-10), and set `PAGER=less` or `adr help` will fail looking for `more`.
+
+The tool is a convenience. What matters is what ends up in this directory, and that is the same either way.
+
+The `.adr-dir` file at the repository root is what points the tool at this directory.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@headlessui/react": "^1.4.2",
         "@iconscout/react-unicons": "^2.2.5",
-        "@internxt/drive-desktop-core": "file:packages/core/internxt-drive-desktop-core-1.0.0.tgz",
+        "@internxt/drive-desktop-core": "file:packages/core/internxt-drive-desktop-core-1.0.1.tgz",
         "@internxt/inxt-js": "3.2.2",
         "@internxt/lib": "1.5.2",
         "@internxt/scan": "1.0.7",
@@ -3346,9 +3346,9 @@
       }
     },
     "node_modules/@internxt/drive-desktop-core": {
-      "version": "1.0.0",
-      "resolved": "file:packages/core/internxt-drive-desktop-core-1.0.0.tgz",
-      "integrity": "sha512-ePo0nmr8GUoj0jIT7vvktVYFLf16JmtoSYhTjgpvacHCjWAJbK/NCkLQnT0ZWB8tlco3nww7EXRk1XrlhIYHwg==",
+      "version": "1.0.1",
+      "resolved": "file:packages/core/internxt-drive-desktop-core-1.0.1.tgz",
+      "integrity": "sha512-5HpdhXjGBV7zCSpBh1iCO1kf/sDojF99VUME9AEif9MfQnmvCNA+siJgZlA9N9dcrVxXkEseZZ6hJJYhSeMeOg==",
       "license": "MIT",
       "dependencies": {
         "@internxt/sdk": "^1.16.2",
@@ -14421,16 +14421,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/ip-address": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
-      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
   "dependencies": {
     "@headlessui/react": "^1.4.2",
     "@iconscout/react-unicons": "^2.2.5",
-    "@internxt/drive-desktop-core": "file:packages/core/internxt-drive-desktop-core-1.0.0.tgz",
+    "@internxt/drive-desktop-core": "file:packages/core/internxt-drive-desktop-core-1.0.1.tgz",
     "@internxt/inxt-js": "3.2.2",
     "@internxt/lib": "1.5.2",
     "@internxt/scan": "1.0.7",

--- a/src/apps/main/auth/logout.ts
+++ b/src/apps/main/auth/logout.ts
@@ -3,6 +3,7 @@ import { AuthContext } from '@/apps/sync-engine/config';
 import { LocalSync } from '@/backend/features';
 import { resetConfig } from '@/backend/features/auth/services/utils/reset-config';
 import { saveConfig } from '@/backend/features/auth/services/utils/save-config';
+import { onLogout as clearUnreconciledFolders } from '@/backend/features/remote-sync/unreconciled-folders';
 import { DriveServerWipModule } from '@/infra/drive-server-wip/drive-server-wip.module';
 import { clearAntivirus } from '../antivirus/utils/initializeAntivirus';
 import { clearIssues } from '../background-processes/issues';
@@ -35,6 +36,7 @@ export function logout({ ctx }: Props) {
 
     stopRemoteNotifications();
     LocalSync.SyncState.onLogout();
+    clearUnreconciledFolders();
     clearAntivirus();
     clearIssues();
 

--- a/src/backend/features/local-sync/watcher/events/unlink/on-unlink.test.ts
+++ b/src/backend/features/local-sync/watcher/events/unlink/on-unlink.test.ts
@@ -1,5 +1,6 @@
 import { FileUuid } from '@/apps/main/database/entities/DriveFile';
 import { FolderUuid } from '@/apps/main/database/entities/DriveFolder';
+import { addUnreconciledFolder, removeUnreconciledFolder } from '@/backend/features/remote-sync/unreconciled-folders';
 import { abs } from '@/context/local/localFile/infrastructure/AbsolutePath';
 import * as ipcMain from '@/infra/drive-server-wip/out/ipc-main';
 import { NodeWin } from '@/infra/node-win/node-win.module';
@@ -72,6 +73,36 @@ describe('on-unlink', () => {
       call(getFolderByNameMock).toStrictEqual({ plainName: 'folder', parentUuid: 'parentUuid' });
       call(getFolderInfoMock).toMatchObject({ path: '/parent' });
       call(deleteFolderByUuidMock).toMatchObject({ path: '/parent/folder', uuid: 'uuid' });
+    });
+  });
+
+  describe('when the item is inside a folder that we could not reconcile', () => {
+    const folderUuid = 'unreconciledUuid' as FolderUuid;
+
+    beforeEach(() => {
+      getFileByNameMock.mockResolvedValue({ data: { uuid: 'uuid' as FileUuid } });
+      addUnreconciledFolder({ uuid: folderUuid, path: abs('/parent') });
+    });
+
+    afterEach(() => {
+      removeUnreconciledFolder({ uuid: folderUuid });
+    });
+
+    it('should not propagate the deletion to the server', async () => {
+      // When
+      await onUnlink(props as any);
+      // Then
+      calls(deleteFileByUuidMock).toHaveLength(0);
+      calls(getFolderInfoMock).toHaveLength(0);
+    });
+
+    it('should propagate the deletion once the folder is reconciled again', async () => {
+      // Given
+      removeUnreconciledFolder({ uuid: folderUuid });
+      // When
+      await onUnlink(props as any);
+      // Then
+      calls(deleteFileByUuidMock).toHaveLength(1);
     });
   });
 });

--- a/src/backend/features/local-sync/watcher/events/unlink/on-unlink.ts
+++ b/src/backend/features/local-sync/watcher/events/unlink/on-unlink.ts
@@ -1,5 +1,6 @@
 import { basename } from 'node:path';
 import { SyncContext } from '@/apps/sync-engine/config';
+import { isInsideUnreconciledFolder } from '@/backend/features/remote-sync/unreconciled-folders';
 import { AbsolutePath, dirname } from '@/context/local/localFile/infrastructure/AbsolutePath';
 import { deleteFileByUuid, deleteFolderByUuid } from '@/infra/drive-server-wip/out/ipc-main';
 import { NodeWin } from '@/infra/node-win/node-win.module';
@@ -12,6 +13,18 @@ type Props = {
 };
 
 export async function onUnlink({ ctx, path, type }: Props) {
+  /**
+   * BR-2245
+   * Inside a folder that we could not reconcile we never materialized the whole subtree, so
+   * a local deletion there does not tell us that the user deleted the remote items: it can
+   * also be us failing to keep the placeholders in sync. Propagating it would trash in the
+   * server items that never existed locally, so we wait until the folder syncs again.
+   */
+  if (isInsideUnreconciledFolder({ path })) {
+    ctx.logger.warn({ msg: 'Skip unlink inside unreconciled folder', path, type });
+    return;
+  }
+
   // Get parent placeholderId from the file explorer.
   const parentPath = dirname(path);
   const { data: parentInfo } = await NodeWin.getFolderInfo({ ctx, path: parentPath });

--- a/src/backend/features/remote-sync/file-explorer/check-if-moved.test.ts
+++ b/src/backend/features/remote-sync/file-explorer/check-if-moved.test.ts
@@ -1,8 +1,10 @@
 import { AbsolutePath } from '@internxt/drive-desktop-core/build/backend';
 import { rename } from 'node:fs/promises';
+import { FolderUuid } from '@/apps/main/database/entities/DriveFolder';
 import { Addon } from '@/node-win/addon-wrapper';
 import { loggerFn, loggerMock } from '@/tests/vitest/mocks.helper.test';
 import { call, calls, deepMocked, partialSpyOn, TestProps } from '@/tests/vitest/utils.helper.test';
+import { clearMoveAttempts, MAX_MOVE_ATTEMPTS } from '../unreconciled-folders';
 import { checkIfMoved } from './check-if-moved';
 import * as needsToBeMoved from './needs-to-be-moved';
 
@@ -16,15 +18,20 @@ describe('check-if-moved', () => {
   const props: TestProps<typeof checkIfMoved> = {
     ctx: { logger: loggerMock },
     local: { path: 'localPath' as AbsolutePath },
-    remote: { absolutePath: 'remotePath' as AbsolutePath },
+    remote: { absolutePath: 'remotePath' as AbsolutePath, uuid: 'uuid' as FolderUuid },
   };
+
+  beforeEach(() => {
+    clearMoveAttempts({ uuid: 'uuid' });
+  });
 
   it('should not rename if does not need to be moved', async () => {
     // Given
     needsToBeMovedMock.mockReturnValue(false);
     // When
-    await checkIfMoved(props as any);
+    const res = await checkIfMoved(props as any);
     // Then
+    expect(res).toBe(true);
     calls(loggerFn).toHaveLength(0);
   });
 
@@ -32,10 +39,54 @@ describe('check-if-moved', () => {
     // Given
     needsToBeMovedMock.mockReturnValue(true);
     // When
-    await checkIfMoved(props as any);
+    const res = await checkIfMoved(props as any);
     // Then
+    expect(res).toBe(true);
     call(loggerFn).toMatchObject({ msg: 'Moving placeholder' });
     call(renameMock).toStrictEqual(['localPath', 'remotePath']);
     call(updateSyncStatusMock).toStrictEqual({ path: 'remotePath' });
+  });
+
+  it('should give up on the move once it does not converge', async () => {
+    // Given
+    needsToBeMovedMock.mockReturnValue(true);
+    for (let attempt = 0; attempt < MAX_MOVE_ATTEMPTS; attempt += 1) {
+      await checkIfMoved(props as any);
+    }
+    // When
+    const res = await checkIfMoved(props as any);
+    // Then
+    expect(res).toBe(false);
+    calls(renameMock).toHaveLength(MAX_MOVE_ATTEMPTS);
+    expect(loggerFn).toHaveBeenLastCalledWith(expect.objectContaining({ msg: 'Placeholder move does not converge' }));
+  });
+
+  it('should keep retrying when the requested move changes', async () => {
+    // Given
+    needsToBeMovedMock.mockReturnValue(true);
+    for (let attempt = 0; attempt < MAX_MOVE_ATTEMPTS; attempt += 1) {
+      await checkIfMoved(props as any);
+    }
+    // When
+    const res = await checkIfMoved({ ...props, remote: { ...props.remote, absolutePath: 'otherPath' } } as any);
+    // Then
+    expect(res).toBe(true);
+    calls(renameMock).toHaveLength(MAX_MOVE_ATTEMPTS + 1);
+  });
+
+  it('should start over once the move converges', async () => {
+    // Given
+    needsToBeMovedMock.mockReturnValue(true);
+    for (let attempt = 0; attempt < MAX_MOVE_ATTEMPTS; attempt += 1) {
+      await checkIfMoved(props as any);
+    }
+    needsToBeMovedMock.mockReturnValue(false);
+    await checkIfMoved(props as any);
+    // When
+    needsToBeMovedMock.mockReturnValue(true);
+    const res = await checkIfMoved(props as any);
+    // Then
+    expect(res).toBe(true);
+    calls(renameMock).toHaveLength(MAX_MOVE_ATTEMPTS + 1);
   });
 });

--- a/src/backend/features/remote-sync/file-explorer/check-if-moved.ts
+++ b/src/backend/features/remote-sync/file-explorer/check-if-moved.ts
@@ -4,6 +4,7 @@ import { ExtendedDriveFolder } from '@/apps/main/database/entities/DriveFolder';
 import { SyncContext } from '@/apps/sync-engine/config';
 import { Addon } from '@/node-win/addon-wrapper';
 import { FileExplorerItem } from '../sync-items-by-checkpoint/load-in-memory-paths';
+import { clearMoveAttempts, MAX_MOVE_ATTEMPTS, trackMoveAttempt } from '../unreconciled-folders';
 import { needsToBeMoved } from './needs-to-be-moved';
 
 type Props = {
@@ -16,12 +17,30 @@ type Props = {
 export async function checkIfMoved({ ctx, type, remote, local }: Props) {
   const isMoved = needsToBeMoved({ remote, local });
 
-  if (isMoved) {
-    const remotePath = remote.absolutePath;
-    const localPath = local.path;
-
-    ctx.logger.debug({ msg: 'Moving placeholder', type, localPath, remotePath });
-    await rename(localPath, remotePath);
-    await Addon.updateSyncStatus({ path: remotePath });
+  if (!isMoved) {
+    clearMoveAttempts({ uuid: remote.uuid });
+    return true;
   }
+
+  const remotePath = remote.absolutePath;
+  const localPath = local.path;
+
+  /**
+   * BR-2245
+   * `rename` can return without throwing and still leave the item where it was, so the only way
+   * to know that the previous move worked is that this one is no longer requested. Asking for the
+   * same origin and destination again means it did not, and retrying forever burns the CPU while
+   * leaving the local tree silently out of sync with the remote one.
+   */
+  const { attempts } = trackMoveAttempt({ uuid: remote.uuid, from: localPath, to: remotePath });
+
+  if (attempts > MAX_MOVE_ATTEMPTS) {
+    ctx.logger.warn({ msg: 'Placeholder move does not converge', type, localPath, remotePath, attempts });
+    return false;
+  }
+
+  ctx.logger.debug({ msg: 'Moving placeholder', type, localPath, remotePath });
+  await rename(localPath, remotePath);
+  await Addon.updateSyncStatus({ path: remotePath });
+  return true;
 }

--- a/src/backend/features/remote-sync/file-explorer/update-folder-placeholder.test.ts
+++ b/src/backend/features/remote-sync/file-explorer/update-folder-placeholder.test.ts
@@ -19,6 +19,7 @@ describe('update-folder-placeholder', () => {
 
   beforeEach(() => {
     validateWindowsNameMock.mockReturnValue({ isValid: true });
+    checkIfMovedMock.mockResolvedValue(true);
 
     props = {
       ctx: { logger: loggerMock },

--- a/src/backend/features/remote-sync/file-explorer/update-folder-placeholder.test.ts
+++ b/src/backend/features/remote-sync/file-explorer/update-folder-placeholder.test.ts
@@ -1,9 +1,10 @@
 import { FolderUuid } from '@/apps/main/database/entities/DriveFolder';
-import { AbsolutePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
+import { abs, AbsolutePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
 import * as validateWindowsName from '@/context/virtual-drive/items/validate-windows-name';
 import { Addon } from '@/node-win/addon-wrapper';
 import { loggerFn, loggerMock } from '@/tests/vitest/mocks.helper.test';
 import { call, calls, partialSpyOn, TestProps } from '@/tests/vitest/utils.helper.test';
+import { isInsideUnreconciledFolder, removeUnreconciledFolder } from '../unreconciled-folders';
 import * as checkIfMoved from './check-if-moved';
 import { updateFolderPlaceholder } from './update-folder-placeholder';
 
@@ -77,5 +78,44 @@ describe('update-folder-placeholder', () => {
     expect(res).toBe(false);
     expect(checkIfMovedMock).toBeCalledTimes(0);
     call(loggerFn).toMatchObject([{ msg: 'Error updating folder placeholder' }, { uuid: 'uuid' }]);
+  });
+
+  describe('tracking of folders that we could not reconcile', () => {
+    afterEach(() => {
+      removeUnreconciledFolder({ uuid: 'uuid' as FolderUuid });
+    });
+
+    it('should track the local path when the reconciliation fails', async () => {
+      // Given
+      validateWindowsNameMock.mockReturnValue({ isValid: false });
+      props.folders = new Map([['uuid' as FolderUuid, { path: abs('/local/folder') }]]);
+      // When
+      await updateFolderPlaceholder(props as any);
+      // Then
+      expect(isInsideUnreconciledFolder({ path: abs('/local/folder/file.txt') })).toBe(true);
+    });
+
+    it('should track the remote path when the placeholder does not exist locally', async () => {
+      // Given
+      validateWindowsNameMock.mockReturnValue({ isValid: false });
+      props.folders = new Map();
+      props.remote = { ...props.remote, absolutePath: abs('/remote/folder') };
+      // When
+      await updateFolderPlaceholder(props as any);
+      // Then
+      expect(isInsideUnreconciledFolder({ path: abs('/remote/folder/file.txt') })).toBe(true);
+    });
+
+    it('should stop tracking it once the reconciliation succeeds', async () => {
+      // Given
+      validateWindowsNameMock.mockReturnValue({ isValid: false });
+      props.folders = new Map([['uuid' as FolderUuid, { path: abs('/local/folder') }]]);
+      await updateFolderPlaceholder(props as any);
+      // When
+      validateWindowsNameMock.mockReturnValue({ isValid: true });
+      await updateFolderPlaceholder(props as any);
+      // Then
+      expect(isInsideUnreconciledFolder({ path: abs('/local/folder/file.txt') })).toBe(false);
+    });
   });
 });

--- a/src/backend/features/remote-sync/file-explorer/update-folder-placeholder.ts
+++ b/src/backend/features/remote-sync/file-explorer/update-folder-placeholder.ts
@@ -51,8 +51,7 @@ async function update({ ctx, remote, local }: Omit<Props, 'folders'> & { local: 
       return true;
     }
 
-    await checkIfMoved({ ctx, type: 'folder', remote, local });
-    return true;
+    return await checkIfMoved({ ctx, type: 'folder', remote, local });
   } catch (error) {
     ctx.logger.sentryError({ msg: 'Error updating folder placeholder', path, error }, { uuid: remote.uuid });
     return false;

--- a/src/backend/features/remote-sync/file-explorer/update-folder-placeholder.ts
+++ b/src/backend/features/remote-sync/file-explorer/update-folder-placeholder.ts
@@ -2,7 +2,8 @@ import { ExtendedDriveFolder } from '@/apps/main/database/entities/DriveFolder';
 import { SyncContext } from '@/apps/sync-engine/config';
 import { validateWindowsName } from '@/context/virtual-drive/items/validate-windows-name';
 import { Addon } from '@/node-win/addon-wrapper';
-import { FileExplorerFolders } from '../sync-items-by-checkpoint/load-in-memory-paths';
+import { FileExplorerFolders, FileExplorerItem } from '../sync-items-by-checkpoint/load-in-memory-paths';
+import { addUnreconciledFolder, removeUnreconciledFolder } from '../unreconciled-folders';
 import { checkIfMoved } from './check-if-moved';
 
 type Props = {
@@ -12,13 +13,32 @@ type Props = {
 };
 
 export async function updateFolderPlaceholder({ ctx, remote, folders }: Props) {
+  const local = folders.get(remote.uuid);
+  const success = await update({ ctx, remote, local });
+
+  /**
+   * BR-2245
+   * When we fail to reconcile a folder placeholder we skip its whole subtree, so from that
+   * moment the local tree no longer represents the remote one. We keep track of it so that
+   * we never propagate to the server a local deletion that happens inside that subtree.
+   * We store the local path when we know it because that is the one the watcher reports,
+   * and it can differ from the remote one, which is precisely why we failed to reconcile.
+   */
+  if (success) {
+    removeUnreconciledFolder({ uuid: remote.uuid });
+  } else {
+    addUnreconciledFolder({ uuid: remote.uuid, path: local?.path ?? remote.absolutePath });
+  }
+
+  return success;
+}
+
+async function update({ ctx, remote, local }: Omit<Props, 'folders'> & { local: FileExplorerItem | undefined }) {
   const path = remote.absolutePath;
 
   try {
     const { isValid } = validateWindowsName({ path, name: remote.name });
     if (!isValid) return false;
-
-    const local = folders.get(remote.uuid);
 
     if (!local) {
       await Addon.createFolderPlaceholder({

--- a/src/backend/features/remote-sync/unreconciled-folders/defs.ts
+++ b/src/backend/features/remote-sync/unreconciled-folders/defs.ts
@@ -1,0 +1,8 @@
+/**
+ * BR-2245
+ * A placeholder move that keeps being requested with the same origin and destination has not
+ * converged: if the previous one had worked, the origin would already be the destination. We
+ * allow a generous amount of attempts because a move can also fail for transient reasons, like
+ * the user holding a file open inside the folder.
+ */
+export const MAX_MOVE_ATTEMPTS = 10;

--- a/src/backend/features/remote-sync/unreconciled-folders/index.ts
+++ b/src/backend/features/remote-sync/unreconciled-folders/index.ts
@@ -1,0 +1,9 @@
+import { clearStore } from './store';
+
+export { addUnreconciledFolder } from './services/add-unreconciled-folder';
+export { isInsideUnreconciledFolder } from './services/is-inside-unreconciled-folder';
+export { removeUnreconciledFolder } from './services/remove-unreconciled-folder';
+
+export function onLogout() {
+  clearStore();
+}

--- a/src/backend/features/remote-sync/unreconciled-folders/index.ts
+++ b/src/backend/features/remote-sync/unreconciled-folders/index.ts
@@ -1,8 +1,11 @@
 import { clearStore } from './store';
 
+export { MAX_MOVE_ATTEMPTS } from './defs';
 export { addUnreconciledFolder } from './services/add-unreconciled-folder';
+export { clearMoveAttempts } from './services/clear-move-attempts';
 export { isInsideUnreconciledFolder } from './services/is-inside-unreconciled-folder';
 export { removeUnreconciledFolder } from './services/remove-unreconciled-folder';
+export { trackMoveAttempt } from './services/track-move-attempt';
 
 export function onLogout() {
   clearStore();

--- a/src/backend/features/remote-sync/unreconciled-folders/services/add-unreconciled-folder.ts
+++ b/src/backend/features/remote-sync/unreconciled-folders/services/add-unreconciled-folder.ts
@@ -1,0 +1,12 @@
+import { FolderUuid } from '@/apps/main/database/entities/DriveFolder';
+import { AbsolutePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
+import { store } from '../store';
+
+type Props = {
+  uuid: FolderUuid;
+  path: AbsolutePath;
+};
+
+export function addUnreconciledFolder({ uuid, path }: Props) {
+  store.folders.set(uuid, path);
+}

--- a/src/backend/features/remote-sync/unreconciled-folders/services/clear-move-attempts.ts
+++ b/src/backend/features/remote-sync/unreconciled-folders/services/clear-move-attempts.ts
@@ -1,0 +1,5 @@
+import { store } from '../store';
+
+export function clearMoveAttempts({ uuid }: { uuid: string }) {
+  store.moves.delete(uuid);
+}

--- a/src/backend/features/remote-sync/unreconciled-folders/services/is-inside-unreconciled-folder.test.ts
+++ b/src/backend/features/remote-sync/unreconciled-folders/services/is-inside-unreconciled-folder.test.ts
@@ -1,0 +1,66 @@
+import { FolderUuid } from '@/apps/main/database/entities/DriveFolder';
+import { abs } from '@/context/local/localFile/infrastructure/AbsolutePath';
+import { addUnreconciledFolder } from './add-unreconciled-folder';
+import { isInsideUnreconciledFolder } from './is-inside-unreconciled-folder';
+import { removeUnreconciledFolder } from './remove-unreconciled-folder';
+
+describe('is-inside-unreconciled-folder', () => {
+  const uuid = 'uuid' as FolderUuid;
+
+  beforeEach(() => {
+    removeUnreconciledFolder({ uuid });
+  });
+
+  it('should return false if there are no unreconciled folders', () => {
+    // When
+    const res = isInsideUnreconciledFolder({ path: abs('/root/folder/file.txt') });
+    // Then
+    expect(res).toBe(false);
+  });
+
+  it('should return true for the unreconciled folder itself', () => {
+    // Given
+    addUnreconciledFolder({ uuid, path: abs('/root/folder') });
+    // When
+    const res = isInsideUnreconciledFolder({ path: abs('/root/folder') });
+    // Then
+    expect(res).toBe(true);
+  });
+
+  it('should return true for an item inside the unreconciled folder', () => {
+    // Given
+    addUnreconciledFolder({ uuid, path: abs('/root/folder') });
+    // When
+    const res = isInsideUnreconciledFolder({ path: abs('/root/folder/nested/file.txt') });
+    // Then
+    expect(res).toBe(true);
+  });
+
+  it('should ignore case because windows paths are case insensitive', () => {
+    // Given
+    addUnreconciledFolder({ uuid, path: abs('/root/Folder') });
+    // When
+    const res = isInsideUnreconciledFolder({ path: abs('/root/FOLDER/file.txt') });
+    // Then
+    expect(res).toBe(true);
+  });
+
+  it('should not match a sibling that shares the prefix', () => {
+    // Given
+    addUnreconciledFolder({ uuid, path: abs('/root/folder') });
+    // When
+    const res = isInsideUnreconciledFolder({ path: abs('/root/folder2/file.txt') });
+    // Then
+    expect(res).toBe(false);
+  });
+
+  it('should return false once the folder is reconciled again', () => {
+    // Given
+    addUnreconciledFolder({ uuid, path: abs('/root/folder') });
+    removeUnreconciledFolder({ uuid });
+    // When
+    const res = isInsideUnreconciledFolder({ path: abs('/root/folder/file.txt') });
+    // Then
+    expect(res).toBe(false);
+  });
+});

--- a/src/backend/features/remote-sync/unreconciled-folders/services/is-inside-unreconciled-folder.ts
+++ b/src/backend/features/remote-sync/unreconciled-folders/services/is-inside-unreconciled-folder.ts
@@ -1,0 +1,18 @@
+import { AbsolutePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
+import { store } from '../store';
+
+/**
+ * BR-2245
+ * Windows paths are case insensitive, so the path reported by the watcher and the one
+ * stored while traversing can differ in case and still be the same folder.
+ */
+export function isInsideUnreconciledFolder({ path }: { path: AbsolutePath }) {
+  const item = path.toLowerCase();
+
+  for (const folder of store.folders.values()) {
+    const root = folder.toLowerCase();
+    if (item === root || item.startsWith(`${root}/`)) return true;
+  }
+
+  return false;
+}

--- a/src/backend/features/remote-sync/unreconciled-folders/services/remove-unreconciled-folder.ts
+++ b/src/backend/features/remote-sync/unreconciled-folders/services/remove-unreconciled-folder.ts
@@ -1,0 +1,6 @@
+import { FolderUuid } from '@/apps/main/database/entities/DriveFolder';
+import { store } from '../store';
+
+export function removeUnreconciledFolder({ uuid }: { uuid: FolderUuid }) {
+  store.folders.delete(uuid);
+}

--- a/src/backend/features/remote-sync/unreconciled-folders/services/track-move-attempt.test.ts
+++ b/src/backend/features/remote-sync/unreconciled-folders/services/track-move-attempt.test.ts
@@ -1,0 +1,48 @@
+import { abs } from '@/context/local/localFile/infrastructure/AbsolutePath';
+import { clearMoveAttempts } from './clear-move-attempts';
+import { trackMoveAttempt } from './track-move-attempt';
+
+describe('track-move-attempt', () => {
+  const uuid = 'uuid';
+
+  beforeEach(() => {
+    clearMoveAttempts({ uuid });
+  });
+
+  it('should count consecutive attempts of the same move', () => {
+    // Given
+    const move = { uuid, from: abs('/root/folder'), to: abs('/root/renamed') };
+    // When
+    const attempts = [trackMoveAttempt(move), trackMoveAttempt(move), trackMoveAttempt(move)];
+    // Then
+    expect(attempts).toStrictEqual([{ attempts: 1 }, { attempts: 2 }, { attempts: 3 }]);
+  });
+
+  it('should start over when the destination changes because it is a new move', () => {
+    // Given
+    trackMoveAttempt({ uuid, from: abs('/root/folder'), to: abs('/root/renamed') });
+    // When
+    const { attempts } = trackMoveAttempt({ uuid, from: abs('/root/folder'), to: abs('/root/other') });
+    // Then
+    expect(attempts).toBe(1);
+  });
+
+  it('should start over when the origin changes because the previous move worked', () => {
+    // Given
+    trackMoveAttempt({ uuid, from: abs('/root/folder'), to: abs('/root/renamed') });
+    // When
+    const { attempts } = trackMoveAttempt({ uuid, from: abs('/root/renamed'), to: abs('/root/renamed again') });
+    // Then
+    expect(attempts).toBe(1);
+  });
+
+  it('should track each item separately', () => {
+    // Given
+    trackMoveAttempt({ uuid, from: abs('/root/folder'), to: abs('/root/renamed') });
+    // When
+    const { attempts } = trackMoveAttempt({ uuid: 'other', from: abs('/root/folder'), to: abs('/root/renamed') });
+    // Then
+    expect(attempts).toBe(1);
+    clearMoveAttempts({ uuid: 'other' });
+  });
+});

--- a/src/backend/features/remote-sync/unreconciled-folders/services/track-move-attempt.ts
+++ b/src/backend/features/remote-sync/unreconciled-folders/services/track-move-attempt.ts
@@ -1,0 +1,18 @@
+import { AbsolutePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
+import { store } from '../store';
+
+type Props = {
+  uuid: string;
+  from: AbsolutePath;
+  to: AbsolutePath;
+};
+
+export function trackMoveAttempt({ uuid, from, to }: Props) {
+  const move = `${from} -> ${to}`;
+  const previous = store.moves.get(uuid);
+  const attempts = previous?.move === move ? previous.attempts + 1 : 1;
+
+  store.moves.set(uuid, { move, attempts });
+
+  return { attempts };
+}

--- a/src/backend/features/remote-sync/unreconciled-folders/store.ts
+++ b/src/backend/features/remote-sync/unreconciled-folders/store.ts
@@ -1,0 +1,14 @@
+import { FolderUuid } from '@/apps/main/database/entities/DriveFolder';
+import { AbsolutePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
+
+type Store = {
+  folders: Map<FolderUuid, AbsolutePath>;
+};
+
+export const store: Store = {
+  folders: new Map(),
+};
+
+export function clearStore() {
+  store.folders.clear();
+}

--- a/src/backend/features/remote-sync/unreconciled-folders/store.ts
+++ b/src/backend/features/remote-sync/unreconciled-folders/store.ts
@@ -1,14 +1,22 @@
 import { FolderUuid } from '@/apps/main/database/entities/DriveFolder';
 import { AbsolutePath } from '@/context/local/localFile/infrastructure/AbsolutePath';
 
+type MoveAttempt = {
+  move: string;
+  attempts: number;
+};
+
 type Store = {
   folders: Map<FolderUuid, AbsolutePath>;
+  moves: Map<string, MoveAttempt>;
 };
 
 export const store: Store = {
   folders: new Map(),
+  moves: new Map(),
 };
 
 export function clearStore() {
   store.folders.clear();
+  store.moves.clear();
 }

--- a/src/context/virtual-drive/items/validate-windows-name.infra.test.ts
+++ b/src/context/virtual-drive/items/validate-windows-name.infra.test.ts
@@ -28,12 +28,22 @@ describe('validate-windows-name.infra', () => {
 
   function isAddressableByWindows(name: string) {
     const win32Path = `${rootPath}/${name}`.replaceAll('/', '\\').replaceAll("'", "''");
+    const devicePath = `\\\\?\\${win32Path}`;
+    /**
+     * `GetFileAttributesW` is asked instead of `Directory.Exists` because .net trims more trailing
+     * whitespace than win32 does, and win32 is the layer explorer and every other program go
+     * through, so it is win32 that decides whether the user can still reach the item.
+     */
     const script = [
-      `try { [System.IO.Directory]::CreateDirectory('\\\\?\\\\${win32Path}') | Out-Null } catch { Write-Output 'NO'; exit }`,
-      `if ([System.IO.Directory]::Exists('${win32Path}')) { Write-Output 'YES' } else { Write-Output 'NO' }`,
+      `$ProgressPreference = 'SilentlyContinue'`,
+      `$signature = '[DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)] public static extern uint GetFileAttributesW(string path);'`,
+      `$win32 = Add-Type -MemberDefinition $signature -Name 'Win32' -Namespace 'Infra' -PassThru`,
+      `try { [System.IO.Directory]::CreateDirectory('${devicePath}') | Out-Null } catch { Write-Output 'NO'; exit }`,
+      `if ($win32::GetFileAttributesW('${win32Path}') -ne [uint32]::MaxValue) { Write-Output 'YES' } else { Write-Output 'NO' }`,
     ].join('; ');
 
-    const stdout = execFileSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], { encoding: 'utf8' });
+    const encoded = Buffer.from(script, 'utf16le').toString('base64');
+    const stdout = execFileSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-EncodedCommand', encoded], { encoding: 'utf8' });
     return stdout.trim() === 'YES';
   }
 
@@ -48,6 +58,7 @@ describe('validate-windows-name.infra', () => {
     'Streamit 3.0 | Tema',
     'Nota: importante',
     'Todo*',
+    'Reporte\u00a0',
   ];
 
   it.each(names)('should only accept %j if windows can reach it afterwards', (name) => {

--- a/src/context/virtual-drive/items/validate-windows-name.infra.test.ts
+++ b/src/context/virtual-drive/items/validate-windows-name.infra.test.ts
@@ -1,0 +1,61 @@
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { mkdir } from 'node:fs/promises';
+import { TEST_FILES } from 'tests/vitest/mocks.helper.test';
+import * as issues from '@/apps/main/background-processes/issues';
+import { AbsolutePath, join } from '@/context/local/localFile/infrastructure/AbsolutePath';
+import { mockProps, partialSpyOn } from '@/tests/vitest/utils.helper.test';
+import { validateWindowsName } from './validate-windows-name';
+
+/**
+ * BR-2245
+ * We create placeholders through `\\?\` paths, which skip the win32 name parsing, so what we
+ * can create is not what the rest of windows can reach: explorer parses the path, trims the
+ * name and reports that the item does not exist, which is the folder the user sees and cannot
+ * delete in BR-1796. This measures that difference instead of trusting the documentation, so
+ * the rule set cannot drift back into rejecting names that work or accepting names that trap
+ * the user. Powershell is used on purpose because node always goes through the device path.
+ */
+describe('validate-windows-name.infra', () => {
+  partialSpyOn(issues, 'addSyncIssue');
+
+  let rootPath: AbsolutePath;
+
+  beforeEach(async () => {
+    rootPath = join(TEST_FILES, randomUUID());
+    await mkdir(rootPath);
+  });
+
+  function isAddressableByWindows(name: string) {
+    const win32Path = `${rootPath}/${name}`.replaceAll('/', '\\').replaceAll("'", "''");
+    const script = [
+      `try { [System.IO.Directory]::CreateDirectory('\\\\?\\\\${win32Path}') | Out-Null } catch { Write-Output 'NO'; exit }`,
+      `if ([System.IO.Directory]::Exists('${win32Path}')) { Write-Output 'YES' } else { Write-Output 'NO' }`,
+    ].join('; ');
+
+    const stdout = execFileSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], { encoding: 'utf8' });
+    return stdout.trim() === 'YES';
+  }
+
+  const names = [
+    'Facturas',
+    ' Invoice',
+    'CON',
+    'LPT1',
+    'Testi ',
+    'Press U.S.',
+    'Doc..',
+    'Streamit 3.0 | Tema',
+    'Nota: importante',
+    'Todo*',
+  ];
+
+  it.each(names)('should only accept %j if windows can reach it afterwards', (name) => {
+    // Given
+    const addressable = isAddressableByWindows(name);
+    // When
+    const { isValid } = validateWindowsName(mockProps<typeof validateWindowsName>({ name, path: name }));
+    // Then
+    expect(isValid).toBe(addressable);
+  });
+});

--- a/src/context/virtual-drive/items/validate-windows-name.infra.test.ts
+++ b/src/context/virtual-drive/items/validate-windows-name.infra.test.ts
@@ -19,39 +19,6 @@ import { validateWindowsName } from './validate-windows-name';
 describe('validate-windows-name.infra', () => {
   partialSpyOn(issues, 'addSyncIssue');
 
-  let rootPath: AbsolutePath;
-
-  beforeEach(async () => {
-    rootPath = join(TEST_FILES, randomUUID());
-    await mkdir(rootPath);
-  });
-
-  afterEach(async () => {
-    // Node deletes through the device path, so it reaches the names win32 cannot.
-    await rm(rootPath, { recursive: true, force: true });
-  });
-
-  function isAddressableByWindows(name: string) {
-    const win32Path = `${rootPath}/${name}`.replaceAll('/', '\\').replaceAll("'", "''");
-    const devicePath = `\\\\?\\${win32Path}`;
-    /**
-     * `GetFileAttributesW` is asked instead of `Directory.Exists` because .net trims more trailing
-     * whitespace than win32 does, and win32 is the layer explorer and every other program go
-     * through, so it is win32 that decides whether the user can still reach the item.
-     */
-    const script = [
-      `$ProgressPreference = 'SilentlyContinue'`,
-      `$signature = '[DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)] public static extern uint GetFileAttributesW(string path);'`,
-      `$win32 = Add-Type -MemberDefinition $signature -Name 'Win32' -Namespace 'Infra' -PassThru`,
-      `try { [System.IO.Directory]::CreateDirectory('${devicePath}') | Out-Null } catch { Write-Output 'NO'; exit }`,
-      `if ($win32::GetFileAttributesW('${win32Path}') -ne [uint32]::MaxValue) { Write-Output 'YES' } else { Write-Output 'NO' }`,
-    ].join('; ');
-
-    const encoded = Buffer.from(script, 'utf16le').toString('base64');
-    const stdout = execFileSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-EncodedCommand', encoded], { encoding: 'utf8' });
-    return stdout.trim() === 'YES';
-  }
-
   const names = [
     'Facturas',
     ' Invoice',
@@ -66,12 +33,61 @@ describe('validate-windows-name.infra', () => {
     'Reporte\u00a0',
   ];
 
+  let rootPath: AbsolutePath;
+  let addressable: Map<string, boolean>;
+
+  /**
+   * The whole list is measured in one powershell process because `Add-Type` compiles the c# shim at
+   * runtime: the first compilation on a cold machine costs tens of seconds and every one after it
+   * costs nothing, so paying it once per file instead of once per name is what keeps this under the
+   * timeout on a clean runner. The generous budget here is that compilation, not the measuring.
+   */
+  beforeAll(async () => {
+    rootPath = join(TEST_FILES, randomUUID());
+    await mkdir(rootPath);
+    addressable = askWindows();
+  }, 120_000);
+
+  afterAll(async () => {
+    // Node deletes through the device path, so it reaches the names win32 cannot.
+    await rm(rootPath, { recursive: true, force: true });
+  });
+
+  function askWindows() {
+    /**
+     * `GetFileAttributesW` is asked instead of `Directory.Exists` because .net trims more trailing
+     * whitespace than win32 does, and win32 is the layer explorer and every other program go
+     * through, so it is win32 that decides whether the user can still reach the item.
+     */
+    const script = [
+      `$ProgressPreference = 'SilentlyContinue'`,
+      `$signature = '[DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)] public static extern uint GetFileAttributesW(string path);'`,
+      `$win32 = Add-Type -MemberDefinition $signature -Name 'Win32' -Namespace 'Infra' -PassThru`,
+      ...names.map((name) => {
+        const win32Path = `${rootPath}/${name}`.replaceAll('/', '\\').replaceAll("'", "''");
+        const devicePath = `\\\\?\\${win32Path}`;
+        const probe = `if ($win32::GetFileAttributesW('${win32Path}') -ne [uint32]::MaxValue) { Write-Output 'YES' } else { Write-Output 'NO' }`;
+        // A name win32 refuses outright never reaches the probe, so the catch answers for it.
+        return `try { [System.IO.Directory]::CreateDirectory('${devicePath}') | Out-Null; ${probe} } catch { Write-Output 'NO' }`;
+      }),
+    ].join('; ');
+
+    const encoded = Buffer.from(script, 'utf16le').toString('base64');
+    const stdout = execFileSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-EncodedCommand', encoded], { encoding: 'utf8' });
+    const answers = stdout.trim().split(/\r?\n/);
+
+    // One answer missing would shift every other name onto the wrong result without saying so.
+    expect(answers).toHaveLength(names.length);
+
+    return new Map(names.map((name, index) => [name, answers[index] === 'YES']));
+  }
+
   it.each(names)('should only accept %j if windows can reach it afterwards', (name) => {
     // Given
-    const addressable = isAddressableByWindows(name);
+    const reachable = addressable.get(name);
     // When
     const { isValid } = validateWindowsName(mockProps<typeof validateWindowsName>({ name, path: name }));
     // Then
-    expect(isValid).toBe(addressable);
+    expect(isValid).toBe(reachable);
   });
 });

--- a/src/context/virtual-drive/items/validate-windows-name.infra.test.ts
+++ b/src/context/virtual-drive/items/validate-windows-name.infra.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { mkdir } from 'node:fs/promises';
+import { mkdir, rm } from 'node:fs/promises';
 import { TEST_FILES } from 'tests/vitest/mocks.helper.test';
 import * as issues from '@/apps/main/background-processes/issues';
 import { AbsolutePath, join } from '@/context/local/localFile/infrastructure/AbsolutePath';
@@ -24,6 +24,11 @@ describe('validate-windows-name.infra', () => {
   beforeEach(async () => {
     rootPath = join(TEST_FILES, randomUUID());
     await mkdir(rootPath);
+  });
+
+  afterEach(async () => {
+    // Node deletes through the device path, so it reaches the names win32 cannot.
+    await rm(rootPath, { recursive: true, force: true });
   });
 
   function isAddressableByWindows(name: string) {

--- a/src/context/virtual-drive/items/validate-windows-name.test.ts
+++ b/src/context/virtual-drive/items/validate-windows-name.test.ts
@@ -94,6 +94,16 @@ describe('validate-windows-name', () => {
     expect(result.isValid).toBe(true);
   });
 
+  /**
+   * BR-2245
+   * Win32 only trims the ascii space, so a name ending in any other unicode space is still
+   * reachable and rejecting it would skip the folder and everything below it.
+   */
+  it('should return true when the name ends with a non breaking space', () => {
+    const result = validateWindowsName(getProps({ name: 'Reporte\u00a0' }));
+    expect(result.isValid).toBe(true);
+  });
+
   it('should return true for a reserved device name', () => {
     const result = validateWindowsName(getProps({ name: 'CON' }));
     expect(result.isValid).toBe(true);

--- a/src/context/virtual-drive/items/validate-windows-name.test.ts
+++ b/src/context/virtual-drive/items/validate-windows-name.test.ts
@@ -15,7 +15,7 @@ describe('validate-windows-name', () => {
   });
 
   it('should return false when the name includes \\', () => {
-    const result = validateWindowsName(getProps({ name: '\\test' }));
+    const result = validateWindowsName(getProps({ name: String.raw`\test` }));
     expect(result.isValid).toBe(false);
   });
 
@@ -59,13 +59,43 @@ describe('validate-windows-name', () => {
     expect(result.isValid).toBe(false);
   });
 
-  it('should return false when the name starts with empty space', () => {
-    const result = validateWindowsName(getProps({ name: ' test' }));
+  it('should return false when the name includes a tab', () => {
+    const result = validateWindowsName(getProps({ name: 'Screams\tby A SOUND EFFECT' }));
+    expect(result.isValid).toBe(false);
+  });
+
+  it('should return false when the name includes a line break', () => {
+    const result = validateWindowsName(getProps({ name: 'Doc\numento' }));
     expect(result.isValid).toBe(false);
   });
 
   it('should return false when the name ends with empty space', () => {
     const result = validateWindowsName(getProps({ name: 'test ' }));
     expect(result.isValid).toBe(false);
+  });
+
+  /**
+   * BR-2245
+   * Win32 trims trailing dots the same way it trims trailing spaces, so the item ends up
+   * unreachable for explorer even though we could create it.
+   */
+  it('should return false when the name ends with a dot', () => {
+    const result = validateWindowsName(getProps({ name: 'Press U.S.' }));
+    expect(result.isValid).toBe(false);
+  });
+
+  /**
+   * BR-2245
+   * A leading space survives win32 parsing, so rejecting it was skipping the folder and every
+   * item below it for nothing.
+   */
+  it('should return true when the name starts with empty space', () => {
+    const result = validateWindowsName(getProps({ name: ' test' }));
+    expect(result.isValid).toBe(true);
+  });
+
+  it('should return true for a reserved device name', () => {
+    const result = validateWindowsName(getProps({ name: 'CON' }));
+    expect(result.isValid).toBe(true);
   });
 });

--- a/src/context/virtual-drive/items/validate-windows-name.ts
+++ b/src/context/virtual-drive/items/validate-windows-name.ts
@@ -6,13 +6,28 @@ type TProps = {
   name: string;
 };
 
+/**
+ * v2.5.3 Daniel Jiménez
+ * These characters are invalid in windows paths.
+ *
+ * v2.6.6 Daniel Jiménez
+ * Names that start or end with a space are rejected too (BR-1796).
+ *
+ * BR-2245
+ * The rule is not whether we can create the item, but whether the rest of windows can address
+ * it afterwards. We create placeholders through `\\?\` paths, which skip the win32 name
+ * parsing, so a trailing space or dot is stored verbatim and then explorer, which does parse,
+ * looks for the trimmed name and reports that the folder does not exist. That is exactly
+ * BR-1796: a folder the user can see and cannot delete. Measured, of the names we were unsure
+ * about, only the trailing ones become unaddressable, and control characters fail on creation
+ * with EINVAL. A leading space survives win32 parsing, so it no longer makes the name invalid.
+ */
+// eslint-disable-next-line no-control-regex -- matching control characters is the point: windows refuses them with EINVAL
+const forbiddenCharacters = /[<>:"/\\|?*\x00-\x1f]/;
+const unaddressableEnding = /[\s.]$/;
+
 export function validateWindowsName({ path, name }: TProps) {
-  /**
-   * v2.5.3 Daniel Jiménez
-   * These characters are invalid in windows paths.
-   */
-  const forbiddenPattern = /[<>:"/\\|?*]|^\s|\s$/;
-  const isValid = !forbiddenPattern.test(name);
+  const isValid = !forbiddenCharacters.test(name) && !unaddressableEnding.test(name);
 
   if (!isValid) {
     logger.debug({

--- a/src/context/virtual-drive/items/validate-windows-name.ts
+++ b/src/context/virtual-drive/items/validate-windows-name.ts
@@ -21,10 +21,12 @@ type TProps = {
  * BR-1796: a folder the user can see and cannot delete. Measured, of the names we were unsure
  * about, only the trailing ones become unaddressable, and control characters fail on creation
  * with EINVAL. A leading space survives win32 parsing, so it no longer makes the name invalid.
+ * Win32 only trims the ascii space and the dot: every other unicode space is kept and stays
+ * reachable, so this cannot be the \s class or we would skip whole subtrees for a name that works.
  */
 // eslint-disable-next-line no-control-regex -- matching control characters is the point: windows refuses them with EINVAL
 const forbiddenCharacters = /[<>:"/\\|?*\x00-\x1f]/;
-const unaddressableEnding = /[\s.]$/;
+const unaddressableEnding = /[ .]$/;
 
 export function validateWindowsName({ path, name }: TProps) {
   const isValid = !forbiddenCharacters.test(name) && !unaddressableEnding.test(name);

--- a/src/node-win/watcher/tests/watcher-on-unlink-unreconciled.test.ts
+++ b/src/node-win/watcher/tests/watcher-on-unlink-unreconciled.test.ts
@@ -42,8 +42,10 @@ describe('watcher-on-unlink-unreconciled', () => {
     getFileByNameMock.mockResolvedValue({ data: { uuid: 'remoteFileUuid' as FileUuid } });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     removeUnreconciledFolder({ uuid });
+    // The native watcher is unsubscribed after this hook, so it can still hold the root open.
+    await rm(rootPath, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
   });
 
   it('should propagate the deletion when the folder is in sync', async () => {

--- a/src/node-win/watcher/tests/watcher-on-unlink-unreconciled.test.ts
+++ b/src/node-win/watcher/tests/watcher-on-unlink-unreconciled.test.ts
@@ -1,0 +1,105 @@
+import { AbsolutePath } from '@internxt/drive-desktop-core/build/backend';
+import { randomUUID } from 'node:crypto';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { TEST_FILES } from 'tests/vitest/mocks.helper.test';
+import { FileUuid } from '@/apps/main/database/entities/DriveFile';
+import { FolderUuid } from '@/apps/main/database/entities/DriveFolder';
+import { sleep } from '@/apps/main/util';
+import { updateFolderPlaceholder } from '@/backend/features/remote-sync/file-explorer/update-folder-placeholder';
+import { addUnreconciledFolder, removeUnreconciledFolder } from '@/backend/features/remote-sync/unreconciled-folders';
+import { join } from '@/context/local/localFile/infrastructure/AbsolutePath';
+import * as ipcMain from '@/infra/drive-server-wip/out/ipc-main';
+import { NodeWin } from '@/infra/node-win/node-win.module';
+import { SqliteModule } from '@/infra/sqlite/sqlite.module';
+import { loggerMock } from '@/tests/vitest/mocks.helper.test';
+import { calls, partialSpyOn } from '@/tests/vitest/utils.helper.test';
+import { setupWatcher } from './watcher.helper.test';
+
+describe('watcher-on-unlink-unreconciled', () => {
+  const getFolderInfoMock = partialSpyOn(NodeWin, 'getFolderInfo');
+  const getFolderByNameMock = partialSpyOn(SqliteModule.FolderModule, 'getByName');
+  const getFileByNameMock = partialSpyOn(SqliteModule.FileModule, 'getByName');
+  const deleteFolderByUuidMock = partialSpyOn(ipcMain, 'deleteFolderByUuid');
+  const deleteFileByUuidMock = partialSpyOn(ipcMain, 'deleteFileByUuid');
+
+  const uuid = 'unreconciledUuid' as FolderUuid;
+  const date = '2000-01-01T00:00:00.000Z';
+
+  let rootPath: AbsolutePath;
+  let parent: AbsolutePath;
+
+  beforeEach(async () => {
+    rootPath = join(TEST_FILES, randomUUID());
+    parent = join(rootPath, 'parent');
+
+    await mkdir(rootPath);
+    await mkdir(parent);
+    await mkdir(join(parent, 'child'));
+    await writeFile(join(parent, 'child', 'file.txt'), 'content');
+
+    getFolderInfoMock.mockResolvedValue({ data: { uuid: 'parentUuid' as FolderUuid } });
+    getFolderByNameMock.mockResolvedValue({ data: { uuid: 'remoteFolderUuid' as FolderUuid } });
+    getFileByNameMock.mockResolvedValue({ data: { uuid: 'remoteFileUuid' as FileUuid } });
+  });
+
+  afterEach(() => {
+    removeUnreconciledFolder({ uuid });
+  });
+
+  it('should propagate the deletion when the folder is in sync', async () => {
+    // Given
+    await setupWatcher(rootPath);
+    // When
+    await rm(parent, { recursive: true, force: true });
+    await sleep(100);
+    // Then
+    calls(deleteFolderByUuidMock).toHaveLength(1);
+  });
+
+  it('should not propagate the deletion when we could not reconcile the folder', async () => {
+    // Given
+    addUnreconciledFolder({ uuid, path: parent });
+    await setupWatcher(rootPath);
+    // When
+    await rm(parent, { recursive: true, force: true });
+    await sleep(100);
+    // Then
+    calls(deleteFolderByUuidMock).toHaveLength(0);
+    calls(deleteFileByUuidMock).toHaveLength(0);
+  });
+
+  it('should not propagate the deletion of a folder whose move keeps failing, like BR-2245', async () => {
+    // Given
+    // The remote name is already taken on disk, so windows refuses to move the placeholder and
+    // the reconciliation of that folder never succeeds.
+    const remotePath = join(rootPath, 'R.B. Cinema');
+    await mkdir(remotePath);
+
+    const reconciled = await updateFolderPlaceholder({
+      ctx: { logger: loggerMock },
+      remote: { absolutePath: remotePath, uuid, name: 'R.B. Cinema', createdAt: date, updatedAt: date },
+      folders: new Map([[uuid, { path: parent }]]),
+    } as any);
+
+    expect(reconciled).toBe(false);
+    await setupWatcher(rootPath);
+    // When
+    await rm(parent, { recursive: true, force: true });
+    await sleep(100);
+    // Then
+    calls(deleteFolderByUuidMock).toHaveLength(0);
+    calls(deleteFileByUuidMock).toHaveLength(0);
+  });
+
+  it('should not propagate the deletion of an item inside the folder we could not reconcile', async () => {
+    // Given
+    addUnreconciledFolder({ uuid, path: parent });
+    await setupWatcher(rootPath);
+    // When
+    await rm(join(parent, 'child'), { recursive: true, force: true });
+    await sleep(100);
+    // Then
+    calls(deleteFolderByUuidMock).toHaveLength(0);
+    calls(deleteFileByUuidMock).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Problem

A folder whose name cannot be reconciled enters a rename loop that never converges.
`updateFolderPlaceholder` returns `false` and the traversal abandons the entire subtree,
silently, so a large share of the account never makes it to disk. When that content later
disappears from disk, the watcher reads it as a user deletion and replicates it to the
server 1:1, with no checks at all — thousands of deletion events within seconds, and the
same number of items sent to the cloud trash.

## What this PR does

1. **Validate windows names by what windows can address.** The rule is now whether windows can
   *reach* the name, not whether it can create it. We create placeholders through `\\?\` paths,
   which skip win32 name parsing, so a trailing space or dot is stored verbatim and explorer
   then cannot find it — that is BR-1796, a folder the user can see and cannot delete. Adds
   trailing dots and control characters; stops rejecting a leading space, which is addressable.

2. **Track folders we could not reconcile.** When a folder's reconciliation fails we store its
   local path, which is the one the watcher reports and can differ from the remote one — that
   difference is usually why it failed in the first place.

3. **Convergence counter.** Today `checkIfMoved` treats the reconciliation as done if `rename`
   does not throw. That is not true: it can return without an error and leave the folder where
   it was. When that happens `needsToBeMoved` asks for the same move again on the next pass,
   and again after that — over a thousand times on a single folder in the logs we analysed,
   without a single error logged.

   The only reliable signal that a move worked is that it **stops being requested**: if the
   rename at 13:30 had taken effect, there would be nothing left to move at 13:41.

   ```
   13:30:56  Moving placeholder  ~/<origin>  ->  ~/<destination>
   13:41:08  Moving placeholder  ~/<origin>  ->  ~/<destination>
   13:51:31  Moving placeholder  ~/<origin>  ->  ~/<destination>
   ```

   So we count consecutive attempts of the same **origin to destination pair**. The pair, rather
   than the folder, is what separates a retry from new work: if the move succeeded, the origin
   on the next pass is already a different path, because the folder has a different name. A
   user renaming a folder five times from the web produces five different pairs and resets the
   counter each time; a move that never takes effect repeats the same pair and adds up.

   After 10 attempts we stop trying and mark the folder, so the guard in point 4 covers its
   subtree. The limit is deliberately generous, because a move can also fail for transient
   reasons — a file held open inside the folder, for instance — and those resolve on their own
   and reset the count.

4. **Guard on deletion propagation.** A local deletion inside a folder we could not reconcile
   is not sent to the server.

## What it fixes

- The data loss in the main incident: the folder was still looping when it happened, so the
  counter would have marked it and the guard would have stopped every propagated deletion.
- A `CfCreatePlaceholders` loop caused by a trailing dot, which ran for over a thousand
  iterations and was never detected.
- Names containing a tab, which threw inside the addon instead of being reported.
- Names with a leading space, whose subtrees were being pruned for no reason.

## What it does NOT fix

- **The contents of folders with invalid names still do not sync.** They are detected and
  reported, but the subtree is still pruned. The fix is name sanitising, which will go in a
  branch on top of this one: create the placeholder with the name win32 can actually reach
  (`Report.` -> `Report`) so the subtree syncs. The link to
  the cloud does not break, because reconciliation goes by uuid, but it does require
  `needs-to-be-moved` and `on-unlink` to compare the sanitised name.
- **A mass deletion with no broken folder above it.** That needs a volume brake, already
  measured and pending: normal use never exceeded 6 propagated deletions per minute, while the
  four incidents were 15, 33, 53 and 58. It was left out of this PR because notifying the user
  relies on an Electron notification carrying a `TODO: Notification is not working` since
  v2.5.3, and we need to settle where the warning surfaces first.
- Backups, WebSocket and the context menu from the ticket.

## Pending outside this repo

The `INVALID_WINDOWS_NAME` strings in `packages/core` (en/es/fr) say "start/end with spaces";
they should now say "end with a space or a dot". Needs a PR against the submodule.

## Tests

699 unit tests and 33 infra tests. The infra one creates the folder and checks against real
windows whether it is addressable, so the rule set cannot drift back towards the documentation.
`watcher-on-unlink-unreconciled` reproduces the whole chain with the native watcher: a rename
that genuinely fails, the folder being marked, a real deletion on disk, and the assertion that
nothing reaches the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented deletions from syncing to the server when items are inside folders that failed reconciliation.
  - Restored deletion syncing after folders are reconciled.
  - Added safeguards to stop repeatedly retrying moves that cannot converge.
  - Improved handling of unreconciled folders during sync and logout.
  - Updated Windows filename validation to better match actual Windows behavior, including leading spaces and Unicode whitespace.

- **Tests**
  - Expanded coverage for unreconciled folders, move retries, deletion handling, and Windows-compatible names.

- **Documentation**
  - Added architecture decision records and guidance for documenting future architectural decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
