### PR TITLE
docs: record the decision not to sanitize windows names (BR-2245)

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/adr

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ assets.d.ts
 packages
 preload.js
 CLAUDE.md
+.adr-dir

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2026-09-10
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/docs/adr/0002-do-not-sanitize-windows-names-for-unaddressable-items.md
+++ b/docs/adr/0002-do-not-sanitize-windows-names-for-unaddressable-items.md
@@ -1,0 +1,51 @@
+# 2. Do not sanitize windows names for unaddressable items
+
+Date: 2026-09-10
+
+## Status
+
+Accepted
+
+## Context
+
+Some names our server accepts cannot be addressed on Windows. We create placeholders through `\\?\` device paths, which skip win32 name parsing, so a name ending in a space or a dot is stored verbatim. Explorer does parse, looks for the trimmed name, and reports that the item does not exist. That is BR-1796: a folder the user can see and cannot open or delete.
+
+It is not only the item itself. A folder we refuse to create takes its whole subtree with it, so files the user never named badly stop arriving too. That is the data loss reported in BR-2245.
+
+Two ways out were considered.
+
+**Skip the item** and surface it as a sync issue, leaving the user to rename it in the web. This is what internxt/drive-desktop#1493 does, after measuring on Windows which names are actually unreachable: a trailing space or dot is, a leading space is not, so names that were being rejected for no reason now arrive.
+
+**Sanitize the name locally**, so the item comes down under a name Windows can address — `Press U.S.` as `Press U.S`, with a numbered suffix when the cleaned name collides with a sibling. Nothing would be skipped and no subtree would be lost.
+
+Sanitizing was implemented and then set aside, for three reasons. Two of them are about the product and would hold even if the implementation were perfect.
+
+No other Internxt client renames anything. Web, mobile and the other desktop platforms all show the name as stored. A name we cleaned up would exist only on Windows, so the same item would appear under one name in the app and another everywhere else, and a path copied from one would not resolve in the other.
+
+The user did not choose that name and would have no way to tell where it came from. A file they uploaded as `Press U.S.` appearing on their machine as `Press U.S`, or as `Press U.S(1)` when a sibling collides, reads as the app corrupting their data rather than working around a limitation of Windows. We would rather tell them the name cannot be used than change it behind their back.
+
+The third reason is what the numbering costs.
+
+The local name and the remote name stop being the same string, so every operation that starts from a local path has to work out which remote item it means. Deletion is the dangerous one: the watcher reports a path after the fact, the placeholder metadata is gone with the item, and the uuid along with it. Recovering the uuid means recomputing the whole sibling assignment and seeing which name is missing.
+
+That assignment is positional. Given `Teaser`, `Teaser(1)`, `Teaser(2)`, `Teaser(3)`, deleting `Teaser(2)` leaves the remaining siblings to be renumbered on the next full traversal. Until that traversal runs, the database holds one set of siblings and the disk still shows the old numbering. A second deletion in that window recomputes to a shifted assignment and trashes the wrong item in the cloud. It fails silently, and it fails towards data loss.
+
+## Decision
+
+We do not sanitize names. The local name always equals the remote name, on every platform.
+
+An item whose name does not meet the criteria we consider valid on Windows is not brought down to the desktop at all: no placeholder is created for it, and its subtree is not walked. Instead it is recorded as a sync issue against its full path, which the app groups by cause and lists in the issues panel. The item stays in the cloud, reachable from every other client, and the user resolves it by renaming it there.
+
+The criteria are ours, and they are deliberately narrower than the list Windows documents as invalid. We reject the reserved characters and the control characters, which fail on creation, and names ending in a space or a dot, which win32 trims when looking them up. We accept everything else, including reserved device names like `CON` and `LPT1` and names beginning with a space, because measuring on Windows shows they are reachable once created.
+
+Being narrow is the point. A name we reject costs the user its whole subtree, so rejecting one that actually works loses folders for nothing. The criteria are measured rather than taken from documentation for that reason, and the measurement is kept as a test so they cannot drift back.
+
+## Consequences
+
+Every local path maps back to exactly one remote item by name, so deletions and moves resolve without reconstructing anything. There is no window in which the disk and the database disagree about which sibling is which.
+
+The cost is that unaddressable items still do not arrive, and neither does anything under them. The user is told through the issues panel, but the fix is theirs: rename the item in the web. The message shown there was corrected in internxt/drive-desktop-core#61, which had been describing a rule we no longer apply.
+
+The third reason is the only one we know how to remove. If the local name stopped being how we identify items — storing the assigned name in sqlite, or taking the uuid from the Cloud Files delete notification (`CF_CALLBACK_TYPE_NOTIFY_DELETE` carries `FileIdentity`, which is where we write it) — the renumbering would no longer be able to resolve to the wrong item.
+
+That is worth doing on its own merits, but it would not reopen this decision by itself. The two product reasons would still stand, and they are not ours to settle alone: showing a different name on Windows than everywhere else is a question for the whole product, not for the desktop client.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,25 @@
+# Architecture Decision Records
+
+Each file here records one decision: what we were facing, what we chose, and what that costs us. They exist so that a year from now the reasoning is still available to whoever has to revisit the choice — including the arguments against what we picked.
+
+## Reading them
+
+They are plain markdown, numbered in the order they were taken. Nothing is needed to read them.
+
+**They are never edited once accepted.** If a decision is replaced, the new record supersedes the old one and both are updated to link to each other; the old one stays where it is, marked as superseded. The history is the point.
+
+## Writing one
+
+Copy the most recent record, give it the next number, and keep the four headings: Status, Context, Decision, Consequences. Write the context so it makes sense to someone who was not in the room.
+
+Optionally, [adr-tools](https://github.com/npryce/adr-tools) automates the numbering and the superseding links:
+
+    adr new Title of the decision      # creates the next record
+    adr new -s 2 Title                 # creates it, superseding record 2
+    adr list
+
+It is a set of bash scripts, so it is not installed through `package.json`. On Windows it runs under git bash — see the project's [INSTALL.md](https://github.com/npryce/adr-tools/blob/master/INSTALL.md#windows-10), and set `PAGER=less` or `adr help` will fail looking for `more`.
+
+The tool is a convenience. What matters is what ends up in this directory, and that is the same either way.
+
+The `.adr-dir` file at the repository root is what points the tool at this directory.


### PR DESCRIPTION
Records why we skip names Windows cannot address instead of renaming them locally, so the
reasoning survives the next time someone asks why a folder does not come down.

Sanitizing was implemented and then set aside for three reasons, and the record keeps all
three: no other Internxt client renames anything, so a cleaned name would exist only on
Windows; the user did not choose that name and would read it as us corrupting their data; and
the numbering that makes collisions work has to be recomputed on every deletion, which can
resolve to the wrong sibling and trash the wrong item in the cloud.

It also writes down the acceptance criteria and why they are deliberately narrower than the
list Windows documents as invalid — a name we reject costs the user its whole subtree, so
rejecting one that actually works loses folders for nothing.

Adds `docs/adr/README.md` explaining the convention for whoever writes the next one. The
records are plain markdown and need no tooling to read or write;
[adr-tools](https://github.com/npryce/adr-tools) is mentioned as an optional convenience, along
with the `.adr-dir` file that points it at this directory.

Based on the BR-2245 branch rather than master, since it documents the behaviour that branch
introduces. Documentation only — no code changes.
